### PR TITLE
Correct Mood=Imp to Aspect=Imp for imperfect verbs

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -140,7 +140,7 @@
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	cailín	cailín	NOUN	Noun	Gender=Masc|Number=Sing	11	appos	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
-16	bhíodh	bí	VERB	VI	Form=Len|Mood=Imp|Tense=Past	14	acl:relcl	_	_
+16	bhíodh	bí	VERB	VI	Aspect=Imp|Form=Len|Tense=Past	14	acl:relcl	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
 18	amhranaí	amhránaí	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
@@ -868,7 +868,7 @@
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
 30	áit	áit	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	28	obl	_	_
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	obl	_	_
-32	mbíodh	bí	VERB	PastImp	Form=Ecl|Mood=Imp|Tense=Past	30	acl:relcl	_	_
+32	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	30	acl:relcl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
 34	cúldoras	doras	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	obj	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	1	punct	_	_
@@ -1087,7 +1087,7 @@
 
 # sent_id = 502
 # text = Bhíodh íota air an bráithreachas briste idir daoine, agus idir an duine agus a imshaol nádúrtha, a dheisiú.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	íota	íota	NOUN	Noun	Gender=Fem|Number=Sing	1	nsubj	_	_
 3	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
@@ -1670,7 +1670,7 @@
 
 # sent_id = 521
 # text = Bhíodh sé go fóill ag súgradh leo, agus ag ithe leo, agus tráthnóna, shuíodh sé amuigh i gcearnóg a bhaile ag canadh ceoil ina gcuideachta.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	go	go	PART	Ad	PartType=Ad	4	mark:prt	_	_
 4	fóill	fóill	ADJ	Adj	Degree=Pos	1	advmod	_	_
@@ -1686,7 +1686,7 @@
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	tráthnóna	tráthnóna	NOUN	Noun	Gender=Masc|Number=Sing	17	obl:tmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	15	punct	_	_
-17	shuíodh	suigh	VERB	VTI	Form=Len|Mood=Imp|Tense=Past	1	conj	_	_
+17	shuíodh	suigh	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	1	conj	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
 19	amuigh	amuigh	ADV	Dir	_	17	advmod	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
@@ -1702,7 +1702,7 @@
 
 # sent_id = 522
 # text = Bhíodh colún rialta ag Máire dar theideal 'An Fáinne' ar an Irish Independent sna blianta 1927 agus 1928.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	colún	colún	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
 3	rialta	rialta	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
@@ -3189,7 +3189,7 @@
 2	dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	mura	mura	SCONJ	Subord	_	5	mark	_	_
-5	dtigeadh	tuig	VERB	VTI	Form=Ecl|Mood=Imp|Tense=Past	2	advcl	_	_
+5	dtigeadh	tuig	VERB	VTI	Form=Ecl|Mood=Cnd	2	advcl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	fhuil	fuil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	obj	_	_
 8	go	go	PART	Vb	PartType=Cmpl	9	mark:prt	_	_
@@ -3332,7 +3332,7 @@
 1	)	)	PUNCT	Punct	_	4	punct	_	_
 2	Toisc	toisc	SCONJ	Subord	_	4	mark	_	_
 3	go	go	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
-4	mbíodh	bí	VERB	PastImp	Form=Ecl|Mood=Imp|Tense=Past	9	advcl	_	_
+4	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	9	advcl	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	vótáil	vótáil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	oscailte	oscailte	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	_
@@ -5202,7 +5202,7 @@
 
 # sent_id = 657
 # text = Bhíodh sé ag brionglóidigh san oíche go raibh sé ar bord loinge agus í ag síobadh mara dá bord.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	brionglóidigh	each	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	xcomp	_	_
@@ -5699,7 +5699,7 @@
 10	aer	aer	NOUN	Noun	Gender=Masc|Number=Sing	5	obl	_	_
 11	mar	mar	ADP	Simp	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
-13	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	5	advcl	_	_
+13	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	5	advcl	_	_
 14	sna	i	ADP	Art	Number=Plur|PronType=Art	15	case	_	_
 15	blianta	bliain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	13	obl:tmod	_	_
 16	fada	fada	ADJ	Adj	Gender=Fem|Number=Plur	15	amod	_	_
@@ -5770,7 +5770,7 @@
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	nuair	nuair	SCONJ	Subord	_	16	mark	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
-16	bhíos	bí	VERB	PastImp	Form=Len|Mood=Imp|PronType=Rel|Tense=Past	9	conj	_	_
+16	bhíos	bí	VERB	PresImp	Form=Len|PronType=Rel	9	conj	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	ghaoth	gaoth	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	nsubj	_	_
 19	ar	ar	ADP	Simp	_	21	case	_	_
@@ -6746,7 +6746,7 @@
 
 # sent_id = 721
 # text = Bhíodh bríste fada ann chomh maith le bríste glúnach.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	bríste	bríste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	fada	fada	ADJ	Adj	Degree=Pos	2	amod	_	_
 4	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	xcomp:pred	_	_
@@ -7550,7 +7550,7 @@
 # sent_id = 757
 # text = Ní bhíodh aon bhailiúchán ann agus ceapann sé nach mbíodh bailiúchán ar siúl i dtithe eile Chillín Chaoimhín ach oiread.
 1	Ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	2	advmod	_	_
-2	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+2	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 3	aon	aon	DET	Det	PronType=Ind	4	det	_	_
 4	bhailiúchán	bailiúchán	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|NounType=Weak|Number=Plur	2	nsubj	_	_
 5	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	xcomp:pred	_	_
@@ -8008,7 +8008,7 @@
 12	mhinic	minic	ADJ	Adj	Degree=Pos|Form=Len	2	parataxis	_	_
 13	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	12	nsubj	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	obj	_	_
-15	dtugadh	tabhair	VERB	VTI	Form=Ecl|Mood=Imp|Tense=Past	13	acl:relcl	_	_
+15	dtugadh	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Tense=Past	13	acl:relcl	_	_
 16	siad	siad	PRON	Pers	Number=Plur|Person=3	15	nsubj	_	_
 17	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	15	obj	_	_
 18	Seoighe	Seoighe	PROPN	Noun	Gender=Fem|Number=Sing	17	flat:name	_	_
@@ -8264,7 +8264,7 @@
 36	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	9	advcl	_	_
 37	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	36	nsubj	_	_
 38	go	go	PART	Vb	PartType=Cmpl	39	mark:prt	_	_
-39	dtugtaí	tabhair	VERB	VTI	Form=Ecl|Mood=Imp|Person=0|Tense=Past	36	ccomp	_	_
+39	dtugtaí	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Person=0|Tense=Past	36	ccomp	_	_
 40	Ára	ára	PROPN	Noun	Gender=Fem|Number=Sing	39	obj	_	_
 41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	40	flat	_	_
 42	ar	ar	ADP	Simp	_	44	case	_	_
@@ -8751,7 +8751,7 @@
 
 # sent_id = 808
 # text = Bhíodh fíoracha na ndéithe snoite as cabhlacha crann sna doirí úd agus ina dteannta altóirí ar a ndéanadh na draoithe íobairtí.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	fíoracha	fíor	NOUN	Noun	Gender=Fem|Number=Plur	1	nsubj	_	_
 3	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
 4	ndéithe	dia	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
@@ -8768,7 +8768,7 @@
 15	altóirí	altóir	NOUN	Noun	Gender=Fem|Number=Plur	7	conj	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	obl	_	_
-18	ndéanadh	déan	VERB	VTI	Form=Ecl|Mood=Imp|Tense=Past	15	acl:relcl	_	_
+18	ndéanadh	déan	VERB	VTI	Aspect=Imp|Form=Ecl|Tense=Past	15	acl:relcl	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
 20	draoithe	draoi	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
 21	íobairtí	íobairt	NOUN	Noun	Gender=Fem|Number=Plur	20	nmod	_	SpaceAfter=No
@@ -8931,12 +8931,12 @@
 10	peannaideacha	peannaideach	ADJ	Adj	NounType=NotSlender|Number=Plur	9	amod	_	_
 11	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
-13	fheictí	feic	VERB	VTI	Form=Len|Mood=Imp|Person=0|Tense=Past	9	acl:relcl	_	_
+13	fheictí	feic	VERB	VTI	Aspect=Imp|Form=Len|Person=0|Tense=Past	9	acl:relcl	_	_
 14	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	obl:prep	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
 16	nuair	nuair	SCONJ	Subord	_	18	mark	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	mark:prt	_	_
-18	chuimhníodh	cuimhnigh	VERB	VTI	Form=Len|Mood=Imp|Tense=Past	2	advcl	_	_
+18	chuimhníodh	cuimhnigh	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	2	advcl	_	_
 19	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	18	nsubj	_	_
 20	orthu	ar	ADP	Prep	Number=Plur|Person=3	18	obl:prep	_	_
 21	faoi	faoi	ADP	Simp	_	22	case	_	_
@@ -11115,7 +11115,7 @@
 31	scéil	scéal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	_
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
 33	a	a	PART	Vb	PartType=Vb|PronType=Rel	34	mark:prt	_	_
-34	mbíodh	bí	VERB	PastImp	Form=Ecl|Mood=Imp|Tense=Past	27	conj	_	_
+34	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	27	conj	_	_
 35	Nóra	Nóra	PROPN	Noun	Gender=Fem|Number=Sing	34	nsubj	_	_
 36	ag	ag	ADP	Simp	_	37	case	_	_
 37	suirí	suirí	NOUN	Noun	Gender=Fem|Number=Sing	34	xcomp:pred	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -332,7 +332,7 @@
 10	magistri	magistri	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	8	xcomp:pred	_	_
 11	tráth	tráth	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl:tmod	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
-13	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	1	csubj:cleft	_	_
+13	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	1	csubj:cleft	_	_
 14	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	xcomp:pred	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	13	punct	_	_
 
@@ -1451,7 +1451,7 @@
 1	Oighe	Oighe	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	chuimealta	cuimealta	ADJ	Adj	VerbForm=Part	1	amod	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
-4	bhíos	bí	VERB	PastImp	Form=Len|Mood=Imp|PronType=Rel|Tense=Past	1	csubj:cleft	_	_
+4	bhíos	bí	VERB	PresImp	Form=Len|PronType=Rel	1	csubj:cleft	_	_
 5	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	_
 6	leis	le	ADP	Simp	_	12	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
@@ -2175,7 +2175,7 @@
 2	iomartha	iomramh	NOUN	Noun	Case=Gen|VerbForm=Inf	1	nmod	_	_
 3	adhmaid	adhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	mark:prt	_	_
-5	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	1	csubj:cleft	_	_
+5	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	1	csubj:cleft	_	_
 6	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	xcomp:pred	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3731,7 +3731,7 @@
 
 # sent_id = 154
 # text = Dhéanadh sé an turas seo uair in aghaidh na míosa chun roinnt ama a chaitheamh lena iníon, Siobhán, agus leis na leanaí.
-1	Dhéanadh	déan	VERB	VTI	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Dhéanadh	déan	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	turas	turas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
@@ -3916,7 +3916,7 @@
 47	bíobla	bíobla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	41	appos	_	SpaceAfter=No
 48	,	,	PUNCT	Punct	_	49	punct	_	_
 49	dá	dá	SCONJ	Subord	_	50	mark	_	_
-50	n-abrainn	abair	VERB	PastImp	Mood=Imp|Number=Sing|Person=1|Tense=Past	47	advcl	_	_
+50	n-abrainn	abair	VERB	_	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	47	advcl	_	_
 51	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	50	obj	_	SpaceAfter=No
 52	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -4603,7 +4603,7 @@
 
 # sent_id = 191
 # text = Bhíodh Conall Ó Dochartaigh ag airneál ag an mháistir go mion is go minic.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	Conall	Conall	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	Ó	ó	PART	Pat	PartType=Pat	2	flat:name	_	_
 4	Dochartaigh	Dochartaigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	_
@@ -4752,7 +4752,7 @@
 1	Sé	is	AUX	Cop	Gender=Masc|Number=Sing|Person=3|VerbForm=Cop	2	cop	_	_
 2	deacracht	deacracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	nsubj	_	_
-4	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	2	acl:relcl	_	_
+4	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	2	acl:relcl	_	_
 5	agam	ag	ADP	Prep	Number=Sing|Person=1	4	obl:prep	_	_
 6	teacht	teacht	NOUN	Noun	VerbForm=Inf	4	csubj:cop	_	_
 7	amach	amach	ADV	Dir	_	6	advmod	_	_
@@ -8350,14 +8350,14 @@
 14	cha	cha	PART	Vb	Dialect=Ulster|PartType=Vb|Polarity=Neg	15	advmod	_	_
 15	chuireann	cuir	VERB	VTI	Form=Len|Mood=Ind|Polarity=Neg|Tense=Pres	1	parataxis	_	_
 16	/	/	PUNCT	Punct	_	17	punct	_	_
-17	chuireadh	cuir	VERB	VTI	Form=Len|Mood=Imp|Polarity=Neg|Tense=Past	15	parataxis	_	_
+17	chuireadh	cuir	VERB	VTI	Aspect=Imp|Form=Len|Polarity=Neg|Tense=Past	15	parataxis	_	_
 18	/	/	PUNCT	Punct	_	19	punct	_	_
 19	chuirfeadh	cuir	VERB	VTI	Form=Len|Mood=Cnd|Polarity=Neg	15	parataxis	_	_
 20	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nsubj	_	_
 21	chan	chan	PART	Vb	Dialect=Ulster|PartType=Vb|Polarity=Neg	22	advmod	_	_
 22	fhágann	fág	VERB	VTI	Form=Len|Mood=Ind|Polarity=Neg|Tense=Pres	1	xcomp	_	_
 23	/	/	PUNCT	Punct	_	24	punct	_	_
-24	fhágadh	fág	VERB	VTI	Form=Len|Mood=Imp|Polarity=Neg|Tense=Past	22	parataxis	_	_
+24	fhágadh	fág	VERB	VTI	Aspect=Imp|Form=Len|Polarity=Neg|Tense=Past	22	parataxis	_	_
 25	/	/	PUNCT	Punct	_	26	punct	_	_
 26	fhágfadh	fág	VERB	VTI	Form=Len|Mood=Cnd|Polarity=Neg	22	parataxis	_	_
 27	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	26	nsubj	_	_
@@ -8483,7 +8483,7 @@
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
-13	thugadh	tabhair	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	11	acl:relcl	_	_
+13	thugadh	tabhair	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	11	acl:relcl	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 15	d'	do	ADP	Simp	_	16	case	_	SpaceAfter=No
 16	Iníon	iníon	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	_
@@ -8631,7 +8631,7 @@
 2	gheall	geall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 3	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
 4	sin	sin	PRON	Dem	PronType=Dem	3	det	_	_
-5	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+5	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 6	sliocht	sliocht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	6	amod	_	_
 8	ar	ar	ADP	Simp	_	10	case	_	_
@@ -8639,7 +8639,7 @@
 10	Sapa	Sapa	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 11	Inca	Inca	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
-13	roghnaíodh	roghnaigh	VERB	VT	Form=Len|Mood=Imp|Tense=Past	5	conj	_	_
+13	roghnaíodh	roghnaigh	VERB	VT	Aspect=Imp|Form=Len|Tense=Past	5	conj	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
 16	chúirt	cúirt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
@@ -9076,7 +9076,7 @@
 1	Iad	iad	PRON	Pers	Number=Plur|Person=3	0	root	_	_
 2	seo	seo	DET	Det	PronType=Dem	1	det	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
-4	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	1	csubj:cleft	_	_
+4	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	1	csubj:cleft	_	_
 5	ag	ag	ADP	Simp	_	6	case	_	_
 6	magadh	magadh	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
 7	faoi	faoi	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	obl:prep	_	SpaceAfter=No
@@ -9294,7 +9294,7 @@
 
 # sent_id = 365
 # text = Bhíodh féar is fiche againn amach in éineacht Bhíodh an 'turnkey' amach romhainn sa bpáirc Ní raibh aon tsamhail againn ach mar a bheadh caoirigh A bheadh ag gabháil thart timpeall leis an ngalra cam.
-1	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	féar	féar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	is	agus	CCONJ	Coord	_	4	cc	_	_
 4	fiche	fiche	NUM	Num	NumType=Card	2	conj	_	_
@@ -9302,7 +9302,7 @@
 6	amach	amach	ADV	Dir	_	1	advmod	_	_
 7	in	i	ADP	Simp	_	8	case	_	_
 8	éineacht	éineacht	NOUN	Subst	Number=Sing	1	obl	_	_
-9	Bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	1	parataxis	_	_
+9	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	1	parataxis	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 11	'	'	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 12	turnkey	turnkey	X	Foreign	Foreign=Yes	9	nsubj	_	SpaceAfter=No
@@ -9565,7 +9565,7 @@
 12	dhamhsaigh	damhsaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 13	Dónall	Dónall	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	nsubj	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
-15	bhíodh	bí	VERB	PastImp	Form=Len|Mood=Imp|Tense=Past	13	acl:relcl	_	_
+15	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	13	acl:relcl	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	freastal	freastal	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
 18	ar	ar	ADP	Simp	_	19	case	_	_
@@ -10186,7 +10186,7 @@
 # sent_id = 403
 # text = Ar chasadh ar ais do Dhamien b'in roimhe é.
 1	Ar	ar	PART	Vb	PartType=Vb|PronType=Rel|Tense=Past	2	mark:prt	_	_
-2	chasadh	cas	VERB	VTI	Form=Len|Mood=Imp|Tense=Past	9	xcomp	_	_
+2	chasadh	cas	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	9	xcomp	_	_
 3	ar	ar	ADV	Dir	_	2	advmod	_	_
 4	ais	ais	ADV	Dir	_	3	fixed	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
@@ -10585,7 +10585,7 @@
 # sent_id = 421
 # text = Dá dtugadh patról nó spiairí faoi deara go rabhthas ag réiteach chun cogaidh dhéanadh na Rómhánaigh ionsaí ar dtús.
 1	Dá	dá	SCONJ	Subord	_	2	mark	_	_
-2	dtugadh	tabhair	VERB	VTI	Form=Ecl|Mood=Imp|Tense=Past	14	advcl	_	_
+2	dtugadh	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Tense=Past	14	advcl	_	_
 3	patról	patról	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
 4	nó	nó	CCONJ	Coord	_	5	cc	_	_
 5	spiairí	spiaire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	conj	_	_
@@ -10597,7 +10597,7 @@
 11	réiteach	réiteach	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 12	chun	chun	ADP	Simp	_	13	case	_	_
 13	cogaidh	cogadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	_
-14	dhéanadh	déan	VERB	VTI	Form=Len|Mood=Imp|Tense=Past	0	root	_	_
+14	dhéanadh	déan	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
 16	Rómhánaigh	Rómhánach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	14	nsubj	_	_
 17	ionsaí	ionsaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obj	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -3916,7 +3916,7 @@
 47	bíobla	bíobla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	41	appos	_	SpaceAfter=No
 48	,	,	PUNCT	Punct	_	49	punct	_	_
 49	dá	dá	SCONJ	Subord	_	50	mark	_	_
-50	n-abrainn	abair	VERB	_	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	47	advcl	_	_
+50	n-abrainn	abair	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	47	advcl	_	_
 51	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	50	obj	_	SpaceAfter=No
 52	.	.	PUNCT	.	_	6	punct	_	_
 


### PR DESCRIPTION
Note that this includes some manual corrections to verbs that were incorrectly annotated as imperfect (bhíos a few times, and some past autonomous verbs)