### PR TITLE
Continuing work on lemmatization

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -715,7 +715,7 @@
 2	Céadaoin	Céadaoin	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	flat	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	4	punct	_	_
 4	28	28	NUM	Num	_	1	nmod	_	_
-5	Bealtaine	bealtaine	PROPN	Noun	Gender=Fem|Number=Sing	4	flat	_	_
+5	Bealtaine	Bealtaine	PROPN	Noun	Gender=Fem|Number=Sing	4	flat	_	_
 6	1986	1986	NUM	Num	_	4	flat	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -847,7 +847,7 @@
 8	chistin	cistin	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	tuilshoilse	solas	NOUN	Noun	Gender=Masc|Number=Plur	8	nmod	_	_
+11	tuilshoilse	tuilsolas	NOUN	Noun	Gender=Masc|Number=Plur	8	nmod	_	_
 12	-	-	PUNCT	Punct	_	13	punct	_	_
 13	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
@@ -870,7 +870,7 @@
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	obl	_	_
 32	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	30	acl:relcl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	cúldoras	doras	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	obj	_	SpaceAfter=No
+34	cúldoras	cúldoras	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	obj	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 492
@@ -908,7 +908,7 @@
 2	seachtain	seachtain	NOUN	Noun	Gender=Fem|Number=Sing	4	obl:tmod	_	_
 3	anuas	anuas	ADV	Dir	_	2	advmod	_	_
 4	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-5	Comhchomhairle	comhairle	NOUN	Noun	Gender=Fem|Number=Sing	4	nsubj	_	_
+5	Comhchomhairle	comhchomhairle	NOUN	Noun	Gender=Fem|Number=Sing	4	nsubj	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
 7	bun	bun	NOUN	Noun	Gender=Masc|Number=Sing	4	xcomp:pred	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
@@ -2393,7 +2393,7 @@
 3	Pasáiste	pasáiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	go	go	PART	Ad	PartType=Ad	5	mark:prt	_	_
 5	batrálta	batrálta	ADJ	Adj	VerbForm=Part	1	advmod	_	_
-6	tréithlag	lag	ADJ	Adj	Degree=Pos	1	amod	_	_
+6	tréithlag	tréithlag	ADJ	Adj	Degree=Pos	1	amod	_	_
 7	is	agus	CCONJ	Coord	_	8	cc	_	_
 8	thángas-sa	tar	VERB	VI	Form=Len|Mood=Ind|Number=Sing|Person=1|Tense=Past	1	conj	_	_
 9	go	go	ADP	Simp	_	10	case	_	_
@@ -2558,7 +2558,7 @@
 15	nglaoitear	glaoigh	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	11	ccomp	_	_
 16	Boilg	boilg	NOUN	Noun	Gender=Fem|Number=Sing	15	obj	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	flat	_	_
-18	Chruaidh	Chruaidh	NOUN	Noun	Gender=Masc|Number=Sing	16	flat	_	_
+18	Chruaidh	cruaidh	NOUN	Noun	Gender=Masc|Number=Sing	16	flat	_	_
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -2811,7 +2811,7 @@
 23	chailliúnt	cailliúint	NOUN	Noun	Form=Len|Typo=Yes|VerbForm=Inf	19	conj	_	SpaceAfter=No
 24	)	)	PUNCT	Punct	_	23	punct	_	_
 25	ar	ar	ADP	Simp	_	26	case	_	_
-26	scairmhargaí	margadh	NOUN	Noun	Gender=Masc|Number=Plur	19	obl	_	_
+26	scairmhargaí	scairmhargadh	NOUN	Noun	Gender=Masc|Number=Plur	19	obl	_	_
 27	thar	thar	ADP	Simp	_	19	nmod	_	_
 28	lear	lear	NOUN	Noun	Gender=Masc|Number=Sing	27	fixed	_	_
 29	ag	ag	ADP	Simp	_	31	case	_	_
@@ -3050,9 +3050,9 @@
 
 # sent_id = 573
 # text = Fás na nGaelscoileanna.
-1	Fás	fás	NOUN	Noun	_	0	root	_	_
+1	Fás	fás	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 2	na	na	DET	Art	PronType=Art	3	det	_	_
-3	nGaelscoileanna	scoil	NOUN	Noun	_	1	nmod	_	SpaceAfter=No
+3	nGaelscoileanna	Gaelscoil	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 574
@@ -3164,7 +3164,7 @@
 1	Ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 2	mór	mór	ADJ	Adj	Degree=Pos	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	t-aimpmhéadar	méadar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
+4	t-aimpmhéadar	aimpmhéadar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
 6	cheangal	ceangal	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 7	go	go	PART	Ad	PartType=Ad	8	mark:prt	_	_
@@ -4859,7 +4859,7 @@
 6	Chomhphobail	comhphobal	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	2	punct	_	_
 8	cuirfidh	cuir	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
-9	Ballstáit	stát	PROPN	Noun	Gender=Masc|Number=Plur	8	nsubj	_	_
+9	Ballstáit	ballstát	NOUN	Noun	Gender=Masc|Number=Plur	8	nsubj	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	Aontais	aontas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	Eorpaigh	Eorpach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	flat	_	_
@@ -5205,7 +5205,7 @@
 1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
-4	brionglóidigh	each	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	xcomp	_	_
+4	brionglóidigh	brionglóideach	NOUN	Noun	Case=Dat|Gender=Fem|Number=Sing	1	xcomp	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
 6	oíche	oíche	NOUN	Noun	Gender=Fem|Number=Sing	1	obl	_	_
 7	go	go	PART	Vb	PartType=Cmpl	8	mark:prt	_	_
@@ -7150,7 +7150,7 @@
 20	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	19	obl:prep	_	_
 21	ar	ar	ADP	Simp	_	23	case	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	slioscharr	carr	NOUN	Noun	Gender=Masc|Number=Sing	19	nmod	_	_
+23	slioscharr	slioscharr	NOUN	Noun	Gender=Masc|Number=Sing	19	nmod	_	_
 24	sea	is	AUX	Cop	Tense=Pres|VerbForm=Cop	25	cop	_	_
 25	tharla	tarlaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
@@ -9150,7 +9150,7 @@
 51	,	,	PUNCT	Punct	_	50	punct	_	_
 52	tar	tar	ADP	Cmpd	PrepForm=Cmpd	54	case	_	_
 53	éis	éis	ADP	Cmpd	PrepForm=Cmpd	52	fixed	_	_
-54	tráthchuid	cuid	NOUN	Noun	Gender=Fem|Number=Sing	60	nmod	_	_
+54	tráthchuid	tráthchuid	NOUN	Noun	Gender=Fem|Number=Sing	60	nmod	_	_
 55	amháin	amháin	ADJ	Adj	Number=Sing	54	amod	_	_
 56	nó	nó	CCONJ	Coord	_	58	cc	_	_
 57	níos	níos	NOUN	Subst	Number=Sing|PartType=Comp	58	obl	_	_
@@ -10024,7 +10024,7 @@
 14	mura	mura	SCONJ	Subord	_	15	mark	_	_
 15	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	1	advcl	_	_
 16	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	17	det	_	_
-17	sciarshealbhóirí	sealbhóir	NOUN	Noun	Gender=Masc|Number=Plur	15	nsubj	_	_
+17	sciarshealbhóirí	sciarshealbhóir	NOUN	Noun	Gender=Masc|Number=Plur	15	nsubj	_	_
 18	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	19	case	_	_
 19	n-úinéirí	úinéir	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	15	xcomp:pred	_	_
 20	cláraithe	cláraithe	ADJ	Adj	VerbForm=Part	19	amod	_	SpaceAfter=No

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -2401,7 +2401,7 @@
 11	Láirge	Láirge	PROPN	Noun	Gender=Masc|Number=Sing	10	flat	_	_
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	cosa-in-airde	cosa-in-airde	NOUN	Noun	Gender=Fem|Number=Sing	8	obl	_	_
-14	im	im	ADP	Det	Number=Sing|Person=1|Poss=Yes	15	case	_	_
+14	im	i_mo	ADP	_	Number=Sing|Person=1|Poss=Yes	15	case	_	_
 15	aonar	aonar	NOUN	Noun	Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -6713,7 +6713,7 @@
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
 48	céadtadán	céatadán	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	57	obj	_	_
 49	íseal	íseal	ADJ	Adj	Gender=Masc|Number=Sing	48	amod	_	_
-50	rannpáirtíochta	rannpháirtíocht	ADJ	Adj	Typo=Yes|VerbForm=Part	48	amod	_	_
+50	rannpáirtíochta	rannpháirtíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	48	nmod	_	_
 51	i	i	ADP	Simp	_	52	case	_	_
 52	gcás	cás	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	48	nmod	_	_
 53	aicmí	aicme	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Strong|Number=Plur	52	nmod	_	_
@@ -9010,11 +9010,11 @@
 39	ná	ná	CCONJ	Coord	_	40	cc	_	_
 40	sin	sin	PRON	Dem	PronType=Dem	35	conj	_	SpaceAfter=No
 41	,	,	PUNCT	Punct	_	42	punct	_	_
-42	eadar	eadar	NOUN	Noun	Gender=Masc|Number=Sing	29	nmod	_	_
+42	eadar	idir	ADP	_	_	44	case	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
-44	fhilíocht	filíocht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	42	nmod	_	_
+44	fhilíocht	filíocht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	35	obl	_	_
 45	agus	agus	CCONJ	Coord	_	46	cc	_	_
-46	éachtaí	éacht	NOUN	Noun	Gender=Masc|Number=Plur	42	conj	_	_
+46	éachtaí	éacht	NOUN	Noun	Gender=Masc|Number=Plur	44	conj	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
 48	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
@@ -9173,7 +9173,7 @@
 74	a	a	PART	Vb	PartType=Vb|PronType=Rel	75	obl	_	_
 75	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	73	acl:relcl	_	_
 76	le	le	ADP	Simp	_	77	case	_	_
-77	bailiú	bailigh	NOUN	Noun	VerbForm=Inf	75	xcomp	_	_
+77	bailiú	bailiú	NOUN	Noun	VerbForm=Inf	75	xcomp	_	_
 78	i	i	ADP	Simp	_	79	case	_	_
 79	dtráthchodanna	tráthchuid	NOUN	Noun	Gender=Fem|Number=Plur	77	obl	_	_
 80	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	81	case	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -88,7 +88,7 @@
 15	Mac	mac	PART	Pat	PartType=Pat	14	flat:name	_	_
 16	Diarmada	Diarmaid	PROPN	Noun	Case=Gen|Gender=Masc	14	flat:name	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
-18	bailiú	bailigh	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
+18	bailiú	bailiú	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
 19	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	18	obl:prep	_	_
 20	ag	ag	ADP	Simp	_	22	case	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
@@ -193,7 +193,7 @@
 # sent_id = 8
 # text = Sa seanam, d'imíodh sealgairí go Corrán Binne ag crochaireacht i gcuracha céasla le héin a ribeadh agus a chaitheamh.
 1	Sa	i	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	seanam	seanam	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
+2	seanam	sean-am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	2	punct	_	_
 4	d'	do	PART	Vb	PartType=Vb	5	mark:prt	_	SpaceAfter=No
 5	imíodh	imigh	VERB	VI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
@@ -295,7 +295,7 @@
 # sent_id = 14
 # text = 'Cad chuige nach n-abrófá féin staic d'amhrán dúinn, is gur tú an fear ceoil is fearr ar an mbaile?
 1	'	'	PUNCT	Punct	_	5	punct	_	SpaceAfter=No
-2	Cad	cad	ADV	Q	PronType=Int	5	obl	_	_
+2	Cad	cad	PRON	Q	PronType=Int	5	obl	_	_
 3	chuige	chuig	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
 4	nach	nach	PART	Vb	PartType=Cmpl|Polarity=Neg	5	mark:prt	_	_
 5	n-abrófá	abair	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Sing|Person=2	0	root	_	_
@@ -1680,7 +1680,7 @@
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	det	_	_
 3	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	agat	ag	ADP	Prep	Number=Sing|Person=2	1	obl:prep	_	_
-5	cad	cad	DET	Det	PronType=Int	1	ccomp	_	_
+5	cad	cad	PRON	Q	PronType=Int	1	ccomp	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	éagóir	éagóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
@@ -5412,7 +5412,7 @@
 4	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	acl:relcl	_	_
 5	muid	muid	PRON	Pers	Number=Plur|Person=1	4	nsubj	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
-7	brath	braith	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
+7	brath	brath	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
 8	chun	chun	ADP	Simp	_	12	case	_	_
 9	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	12	obj	_	_
 10	sin	sin	PRON	Dem	PronType=Dem	9	det	_	_
@@ -7048,7 +7048,7 @@
 3	mé	mé	PRON	Pers	Number=Sing|Person=1	2	nsubj	_	_
 4	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	2	obl:prep	_	_
 5	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	6	cop	_	_
-6	iomaí	iomaí	DET	Det	Definite=Def	2	ccomp	_	_
+6	iomaí	iomaí	ADJ	_	Degree=Pos	2	ccomp	_	_
 7	athair	athair	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	máthair	máthair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	conj	_	_
@@ -10063,7 +10063,7 @@
 
 # sent_id = 394
 # text = Ha?
-1	Ha	Ha	INTJ	Itj	_	0	root	_	SpaceAfter=No
+1	Ha	ha	INTJ	Itj	_	0	root	_	SpaceAfter=No
 2	?	?	PUNCT	?	_	1	punct	_	_
 
 # sent_id = 395

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -104,7 +104,7 @@
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	nsubj	_	_
 32	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	30	acl:relcl	_	_
 33	le	le	ADP	Simp	_	34	case	_	_
-34	feiceáil	feic	NOUN	Noun	VerbForm=Inf	32	xcomp	_	_
+34	feiceáil	feiceáil	NOUN	Noun	VerbForm=Inf	32	xcomp	_	_
 35	i	i	ADP	Simp	_	36	case	_	_
 36	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	34	obl	_	_
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	36	flat	_	_
@@ -1962,7 +1962,7 @@
 # sent_id = 82
 # text = Tá colmlanna áille ann ar chrot tithe beaga ceanntuí.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	colmlanna	lann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	nsubj	_	_
+2	colmlanna	colmlann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	nsubj	_	_
 3	áille	álainn	ADJ	Adj	Case=NomAcc|NounType=Slender|Number=Plur	2	amod	_	_
 4	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
@@ -2902,7 +2902,7 @@
 13	le	le	ADP	Simp	_	14	case	_	_
 14	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	mballstát	stát	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Weak|Number=Plur	14	nmod	_	SpaceAfter=No
+16	mballstát	ballstát	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Weak|Number=Plur	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 118
@@ -3116,7 +3116,7 @@
 30	láthair	láthair	ADP	Cmpd	_	29	fixed	_	_
 31	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	28	nsubj	_	_
 32	de	de	ADP	Simp	_	33	case	_	_
-33	thimthriall	triall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	_
+33	thimthriall	timthriall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	beatha	beatha	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	7	punct	_	_
@@ -3232,7 +3232,7 @@
 39	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	42	cop	_	_
 40	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	42	nmod	_	_
 41	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	42	nmod:poss	_	_
-42	dheaslámh	lámh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	ccomp	_	_
+42	dheaslámh	deaslámh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	ccomp	_	_
 43	féin	féin	PRON	Ref	Reflex=Yes	42	nmod	_	_
 44	a	a	PART	Vb	PartType=Vb|PronType=Rel	45	mark:prt	_	_
 45	shaor	saor	VERB	PastInd	Mood=Ind|Tense=Past	42	csubj:cleft	_	_
@@ -3690,7 +3690,7 @@
 10	éis	éis	ADP	Cmpd	_	9	fixed	_	_
 11	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	scoilbhliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	_
+13	scoilbhliain	scoilbhliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	chríochnú	críochnú	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
@@ -4574,7 +4574,7 @@
 13	bhéidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	11	acl:relcl	_	_
 14	i	i	ADP	Simp	_	15	case	_	_
 15	ndán	dán	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	13	xcomp:pred	_	_
-16	láimhscríbhinn	scríbhinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nmod	_	_
+16	láimhscríbhinn	láimhscríbhinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nmod	_	_
 17	iomlán	iomlán	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	16	amod	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	13	xcomp	_	_
@@ -6020,7 +6020,7 @@
 81	teorainneacha	teorainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	86	obj	_	_
 82	seachtracha	seachtrach	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	81	amod	_	_
 83	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	84	det	_	_
-84	mBallstát	stát	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	81	nmod	_	_
+84	mBallstát	ballstát	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	81	nmod	_	_
 85	a	a	PART	Inf	PartType=Inf	86	mark	_	_
 86	thrasnú	trasnú	NOUN	Noun	Form=Len|VerbForm=Inf	78	xcomp	_	_
 87	a	a	PART	Vb	PartType=Vb|PronType=Rel	88	obj	_	_
@@ -6034,7 +6034,7 @@
 95	a	a	PART	Vb	PartType=Vb|PronType=Rel	96	obj	_	_
 96	leanfaidh	lean	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	91	acl:relcl	_	_
 97	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	98	det	_	_
-98	Ballstáit	stát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	96	nsubj	_	_
+98	Ballstáit	ballstát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	96	nsubj	_	_
 99	agus	agus	CCONJ	Coord	_	100	mark	_	_
 100	seiceálacha	seiceáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	102	obj	_	_
 101	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	102	case	_	_
@@ -6110,7 +6110,7 @@
 171	coinníollacha	coinníoll	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	131	conj	_	_
 172	maidir	maidir	ADP	CmpdNoGen	_	174	case	_	_
 173	le	le	ADP	CmpdNoGen	_	172	fixed	_	_
-174	Ballstáit	stát	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	171	nmod	_	_
+174	Ballstáit	ballstát	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	171	nmod	_	_
 175	d'	de	ADP	Simp	_	176	case	_	SpaceAfter=No
 176	eisiúint	eisiúint	NOUN	Noun	VerbForm=Inf	174	nmod	_	_
 177	víosaí	víosa	NOUN	Noun	Case=NomAcc|Gender=Fem|NounType=Strong|Number=Plur	176	nmod	_	SpaceAfter=No
@@ -6146,7 +6146,7 @@
 207	ar	ar	ADP	Simp	_	208	case	_	_
 208	chríoch	críoch	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	206	nmod	_	_
 209	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	210	det	_	_
-210	mBallstát	stát	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	208	nmod	_	_
+210	mBallstát	ballstát	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	208	nmod	_	_
 211	le	le	ADP	Cmpd	PrepForm=Cmpd	213	case	_	_
 212	linn	linn	ADP	Cmpd	_	211	fixed	_	_
 213	tréimhse	tréimhse	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	200	obl	_	_
@@ -6260,7 +6260,7 @@
 3	breathnú	breathnú	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	staitisticí	staitistic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	3	obl	_	_
-6	scrúdúcháin	cáin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
+6	scrúdúcháin	scrúdúchán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	Bhéarla	béarla	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	nó	nó	CCONJ	Coord	_	11	cc	_	_
@@ -6518,7 +6518,7 @@
 4	difríocht	difríocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nsubj	_	_
 5	mhór	mór	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	4	amod	_	_
 6	idir	idir	ADP	Simp	_	7	case	_	_
-7	bogadhmaid	adhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
+7	bogadhmaid	bogadhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	crua-adhmaid	adhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	conj	_	_
 10	ná	ná	CCONJ	Coord	_	14	mark:prt	_	_
@@ -6527,7 +6527,7 @@
 13	a	a	PART	Inf	PartType=Inf	14	mark	_	_
 14	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	0	root	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
-16	mbogadhmaid	adhmad	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	14	xcomp:pred	_	SpaceAfter=No
+16	mbogadhmaid	bogadhmad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	14	xcomp:pred	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	18	punct	_	_
 18	agus	agus	CCONJ	Coord	_	21	cc	_	_
 19	piocháin	piochán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	21	obj	_	_
@@ -8910,7 +8910,7 @@
 13	de	de	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	15	det	_	_
 15	Cumainn	cumann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	_
-16	Thíreolaíocha	thíreolaíocha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	15	flat	_	_
+16	Thíreolaíocha	tíreolaíoch	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	15	amod	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	nsubj	_	_
 18	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	12	acl:relcl	_	_
 19	níos	níos	PART	Cmp	PartType=Comp	20	mark:prt	_	_
@@ -10205,7 +10205,7 @@
 4	'	'	PUNCT	Punct	_	5	punct	_	SpaceAfter=No
 5	teacht	teacht	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
-7	mhalrait	malairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
+7	mhalrait	malairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing|Typo=Yes	5	obl	_	_
 8	intinne	intinn	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
 9	anois	anois	ADV	Gn	_	5	advmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
@@ -10573,7 +10573,7 @@
 27	a	a	PART	Inf	PartType=Inf	28	mark	_	_
 28	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	16	csubj:cop	_	_
 29	de	de	ADP	Simp	_	30	case	_	_
-30	ghlanmheabhair	meabhair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	obl	_	_
+30	ghlanmheabhair	glanmheabhair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	obl	_	_
 31	éireoidh	éirigh	VERB	VI	Mood=Ind|Tense=Fut	16	advcl	_	_
 32	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	31	obl:prep	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_


### PR DESCRIPTION
Many of these are prefixes or compounds that were split when lemmatizing. "ballstát" was particularly annoying since it's common in the treebank and before this patch was about 50/50 between "ballstát" and "stát" as the lemma.  As with prefixes, the best approach is to keep examples like this unsplit. The danger of splitting too aggressively shows up in some examples here, like "brionglóideach" lemmatized to "each", or "colmlann" to "lann".