### PR TITLE
Add Definite=Def everywhere

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -8988,7 +8988,7 @@
 17	amháin	amháin	ADJ	Adj	Degree=Pos	16	amod	_	_
 18	Cathal	Cathal	PROPN	Noun	Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	Mac	mac	PART	Pat	PartType=Pat	18	flat:name	_	NamedEntity=Yes
-20	Eachmharcaigh	marcach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
+20	Eachmharcaigh	Eachmharcach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
 21	agus	agus	CCONJ	Coord	_	22	cc	_	_
 22	mé	mé	PRON	Pers	Number=Sing|Person=1	18	conj	_	_
 23	féin	féin	PRON	Ref	Reflex=Yes	22	nmod	_	_

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -21,7 +21,7 @@
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	leanbh	leanbh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	_
 21	ó	ó	ADP	Simp	_	22	case	_	_
-22	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
+22	thaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	_
 25	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	22	obl:prep	_	SpaceAfter=No
@@ -240,19 +240,19 @@
 7	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	xcomp:pred	_	_
 8	lárnach	lárnach	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	7	amod	_	_
 9	de	de	ADP	Simp	_	10	case	_	_
-10	shaol	saol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+10	shaol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	gcimí	cime	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	10	nmod	_	_
 13	poblachtacha	poblachtach	ADJ	Adj	Case=Gen|NounType=Strong|Number=Plur	12	amod	_	_
 14	i	i	ADP	Simp	_	15	case	_	_
-15	stair	stair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+15	stair	stair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 468
 # text = Muintir na Fraince bhí an-tóir go deo acu orthu bhí sé ráite, ach níorbh aon iontas é sin, bhí an-tóir ag na Francaigh ar chuile shórt, ar loscáin lathaí, ar phortáin agus ar ghailléisc bhréana.
-1	Muintir	muintir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
+1	Muintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 2	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
 3	Fraince	Frainc	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	1	nmod	_	_
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
@@ -312,9 +312,9 @@
 
 # sent_id = 470
 # text = Cur amú óige na cruinne a bhí sa dá chogadh dhomhanda a d'fhág a lorg fuilteach ar na mílte a chuaigh chun troda i bpáirceanna an áir san Eoraip agus níos mó faide ón bhaile.
-1	Cur	cur	NOUN	Noun	VerbForm=Inf	0	root	_	_
+1	Cur	cur	NOUN	Noun	Definite=Def|VerbForm=Inf	0	root	_	_
 2	amú	amú	ADV	Gn	_	1	advmod	_	_
-3	óige	óige	NOUN	Noun	Gender=Fem|Number=Sing	1	nmod	_	_
+3	óige	óige	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	cruinne	cruinne	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	mark:prt	_	_
@@ -337,7 +337,7 @@
 23	chun	chun	ADP	Simp	_	24	case	_	_
 24	troda	troid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	22	obl	_	_
 25	i	i	ADP	Simp	_	26	case	_	_
-26	bpáirceanna	páirc	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	24	nmod	_	_
+26	bpáirceanna	páirc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	24	nmod	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	áir	ár	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
@@ -400,12 +400,12 @@
 1	Dé	Dé	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl:tmod	_	NamedEntity=Yes
 2	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	i	i	ADP	Simp	_	4	case	_	_
-4	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
+4	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 5	poist	post	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
 6	Dhoirí	Doirí	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
 7	Beaga	beag	ADJ	Adj	NounType=NotSlender|Number=Plur	6	amod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
-9	dTír	tír	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
+9	dTír	tír	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
 10	Chonaill	Conall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
@@ -473,7 +473,7 @@
 22	sa	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	bhfarraige	farraige	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
-25	beannacht	beannacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	parataxis	_	_
+25	beannacht	beannacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	parataxis	_	_
 26	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	_
 27	lena	le	ADP	Poss	Number=Plur|Person=3|Poss=Yes	28	case	_	_
 28	n-anamnacha	anam	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
@@ -502,7 +502,7 @@
 15	is	agus	SCONJ	Subord	_	17	mark	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	obj	_	_
 17	thaispeáin	taispeáin	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	advcl	_	_
-18	muintir	muintir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	nsubj	_	_
+18	muintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	nsubj	_	_
 19	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
 20	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	18	nmod	_	_
 21	le	le	ADP	Simp	_	23	case	_	_
@@ -527,9 +527,9 @@
 12	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	13	nmod:poss	_	_
 13	oifig	oifig	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	conj	_	_
 14	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	15	nmod:poss	_	_
-15	leithéidí	leithéid	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	17	nmod	_	_
-16	d'	de	ADP	Simp	_	20	case	_	SpaceAfter=No
-17	armais	armas	NOUN	Noun	Gender=Masc|Number=Plur	20	obj	_	_
+15	leithéidí	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	20	obj	_	_
+16	d'	de	ADP	Simp	_	17	case	_	SpaceAfter=No
+17	armais	armas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	15	nmod	_	_
 18	sochraide	sochraid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
 20	cheadú	ceadú	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	SpaceAfter=No
@@ -538,7 +538,7 @@
 # sent_id = 479
 # text = 'Ceoltóirí na háite, Fearghas Ó hÍr, Brian Ó Mórdha, Éamann Mór, Mary Ryan as Baile Átha Cliath, Deirdre Nic Con Uisce, b'fhéidir, agus an réalta is nua agus is gile i spéir an Tuaiscirt, chan ea, ach spéir na hÉireann, mar atá, Gráinne Holland.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Ceoltóirí	ceoltóir	NOUN	Noun	Gender=Masc|Number=Plur	0	root	_	_
+2	Ceoltóirí	ceoltóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -577,7 +577,7 @@
 38	is	is	PART	Sup	PartType=Sup	36	mark:prt	_	_
 39	gile	geal	ADJ	Adj	Degree=Cmp,Sup	36	conj	_	_
 40	i	i	ADP	Simp	_	41	case	_	_
-41	spéir	spéir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	34	nmod	_	_
+41	spéir	spéir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	34	nmod	_	_
 42	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	43	det	_	_
 43	Tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	41	nmod	_	SpaceAfter=No
 44	,	,	PUNCT	Punct	_	45	punct	_	_
@@ -585,7 +585,7 @@
 46	ea	ea	PRON	Pers	Number=Sing|Person=3	2	parataxis	_	SpaceAfter=No
 47	,	,	PUNCT	Punct	_	48	punct	_	_
 48	ach	ach	SCONJ	Subord	_	49	mark	_	_
-49	spéir	spéir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	41	nmod	_	_
+49	spéir	spéir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	41	nmod	_	_
 50	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	51	det	_	_
 51	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	49	nmod	_	SpaceAfter=No
 52	,	,	PUNCT	Punct	_	53	punct	_	_
@@ -605,8 +605,8 @@
 5	móra	mór	ADJ	Adj	NounType=NotSlender|Number=Plur	4	amod	_	_
 6	molta	molta	ADJ	Adj	Degree=Pos	3	xcomp:pred	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
-9	stádas	stádas	NOUN	Noun	Gender=Masc|Number=Sing	8	nmod	_	_
+8	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
+9	stádas	stádas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
 11	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	16	punct	_	_
@@ -653,7 +653,7 @@
 5	go	go	ADP	Simp	_	6	case	_	_
 6	Meiriceá	Meiriceá	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
-8	Foras	foras	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+8	Foras	foras	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
 10	Mara	muir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
 11	agus	agus	CCONJ	Coord	_	12	mark	_	_
@@ -695,7 +695,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	líne	líne	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 5	ghlas	glas	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
-6	teorainn	teorainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
+6	teorainn	teorainn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	4	csubj:cleft	_	_
@@ -765,12 +765,12 @@
 11	Roland	Roland	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 12	Neher	Neher	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	de	de	ADP	Simp	_	14	case	_	_
-14	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
+14	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
 15	Chrócaigh	Crócach	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	Airne	Airne	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gcluiche	cluiche	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	nmod	_	_
+19	gcluiche	cluiche	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	nmod	_	_
 20	leathcheannais	leathcheannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	Chontae	contae	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
@@ -939,7 +939,7 @@
 33	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	16	conj	_	_
 34	seisear	seisear	NOUN	Noun	Gender=Masc|Number=Sing	33	nsubj	_	_
 35	as	as	ADP	Simp	_	36	case	_	_
-36	Eaglais	Eaglais	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	33	obl	_	_
+36	Eaglais	Eaglais	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	obl	_	_
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	_
 38	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	36	nmod	_	_
 39	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	33	xcomp:pred	_	SpaceAfter=No
@@ -1036,7 +1036,7 @@
 # text = 'Tá deireadh an domhain ag teacht!
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-3	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+3	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 5	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
@@ -1176,7 +1176,7 @@
 29	fadó	fadó	ADV	Gn	_	27	advmod	_	SpaceAfter=No
 30	'	'	PUNCT	Punct	_	27	punct	_	SpaceAfter=No
 31	,	,	PUNCT	Punct	_	32	punct	_	_
-32	siombail	siombail	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	appos	_	_
+32	siombail	siombail	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	24	appos	_	_
 33	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
 34	glaineachta	glaineacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	32	nmod	_	_
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
@@ -1211,7 +1211,7 @@
 64	ghné	gné	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	48	conj	_	_
 65	aimrid	aimrid	ADJ	Adj	Gender=Fem|Number=Sing	64	amod	_	_
 66	de	de	ADP	Simp	_	67	case	_	_
-67	nádúr	nádúr	NOUN	Noun	Gender=Masc|Number=Sing	64	nmod	_	_
+67	nádúr	nádúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	64	nmod	_	_
 68	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	69	det	_	_
 69	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	67	nmod	_	SpaceAfter=No
 70	.	.	PUNCT	.	_	1	punct	_	_
@@ -1235,7 +1235,7 @@
 15	eile	eile	DET	Det	PronType=Dem	14	det	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	fhaoistin	faoistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
+18	fhaoistin	faoistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	appos	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	22	punct	_	_
 20	ná	ná	CCONJ	Coord	_	22	mark	_	_
 21	le	le	ADP	Simp	_	22	case	_	_
@@ -1313,7 +1313,7 @@
 19	chun	chun	ADP	Simp	_	20	case	_	_
 20	teacht	teacht	NOUN	Noun	VerbForm=Inf	17	xcomp	_	_
 21	ar	ar	ADP	Simp	_	22	case	_	_
-22	réiteach	réiteach	NOUN	Noun	Gender=Masc|Number=Sing	20	obl	_	_
+22	réiteach	réiteach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	faidhbe	fadhb	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	_
 25	seo	seo	DET	Det	PronType=Dem	24	det	_	SpaceAfter=No
@@ -1335,7 +1335,7 @@
 # sent_id = 509
 # text = Tá Eaglais Naomh Odhran anseo an eaglais a thóg Tiarnaí na nEilean agus é deisithe anois.
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
-2	Eaglais	Eaglais	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Eaglais	Eaglais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	Naomh	naomh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 4	Odhran	Odhran	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
 5	anseo	anseo	ADV	Loc	_	1	advmod	_	_
@@ -1343,7 +1343,7 @@
 7	eaglais	eaglais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	obj	_	_
 9	thóg	tóg	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	acl:relcl	_	_
-10	Tiarnaí	tiarna	NOUN	Noun	Gender=Masc|Number=Plur	9	nsubj	_	NamedEntity=Yes
+10	Tiarnaí	tiarna	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	9	nsubj	_	NamedEntity=Yes
 11	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	12	det	_	NamedEntity=Yes
 12	nEilean	eilean	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	10	nmod	_	NamedEntity=Yes
 13	agus	agus	CCONJ	Coord	_	14	mark	_	_
@@ -1367,7 +1367,7 @@
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
 12	mór-réimse	mór-réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 13	de	de	ADP	Simp	_	14	case	_	_
-14	ghníomhaíocht	gníomhaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
+14	ghníomhaíocht	gníomhaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Chomhphobail	comhphobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
@@ -1486,7 +1486,7 @@
 # sent_id = 515
 # text = Ag tús na hócáide, bhí siamsa bríomhar ó cheoltóirí óga Scoil Francis McPeake agus chan na páistí ón dara bliain i mbunscoil Mhic Reachtain amhrán breá faoi chur chun cinn na Gaeilge.
 1	Ag	ag	ADP	Simp	_	2	case	_	_
-2	tús	tús	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obl	_	_
+2	tús	tús	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	hócáide	ócáid	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -1494,9 +1494,9 @@
 7	siamsa	siamsa	NOUN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
 8	bríomhar	bríomhar	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	ó	ó	ADP	Simp	_	10	case	_	_
-10	cheoltóirí	ceoltóir	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	6	obl	_	_
+10	cheoltóirí	ceoltóir	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Plur	6	obl	_	_
 11	óga	óg	ADJ	Adj	NounType=Slender|Number=Plur	10	amod	_	_
-12	Scoil	scoil	NOUN	Noun	Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+12	Scoil	scoil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 13	Francis	Francis	PROPN	Noun	Definite=Def	12	nmod	_	NamedEntity=Yes
 14	McPeake	McPeake	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	16	cc	_	_
@@ -1513,7 +1513,7 @@
 26	amhrán	amhrán	NOUN	Noun	Gender=Masc|Number=Sing	16	obj	_	_
 27	breá	breá	ADJ	Adj	Gender=Masc|Number=Sing	26	amod	_	_
 28	faoi	faoi	ADP	Simp	_	29	case	_	_
-29	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	16	obl	_	_
+29	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	16	obl	_	_
 30	chun	chun	ADP	Simp	_	31	case	_	_
 31	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	_
 32	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
@@ -1690,7 +1690,7 @@
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
 19	amuigh	amuigh	ADV	Dir	_	17	advmod	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
-21	gcearnóg	cearnóg	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	_
+21	gcearnóg	cearnóg	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
 23	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
@@ -1778,8 +1778,8 @@
 # sent_id = 526
 # text = D'ainneoin fíoch na filíochta idir an bheirt thug fear Ceann Tíre isteach an strainséir agus thug béile aráin rósta dó agus im tíre air a thug a bhean anall ón Chill san Cheann Deas.
 1	D'	de	ADP	Simp	_	2	case	_	SpaceAfter=No
-2	ainneoin	ainneoin	NOUN	Subst	Case=NomAcc|Number=Sing	9	obl	_	_
-3	fíoch	fíoch	NOUN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+2	ainneoin	ainneoin	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	9	obl	_	_
+3	fíoch	fíoch	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	filíochta	filíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	idir	idir	ADP	Simp	_	8	case	_	_
@@ -1875,7 +1875,7 @@
 # text = Ba é Oileán an Deargánaigh an chéad fhaiche phoiblí a bhí i mBéal Feirste agus b'fhada ina ionad caitheamh aimsire ag a chuid saoránach é.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	Oileán	oileán	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	Oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
 5	Deargánaigh	Deargánach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
@@ -1934,7 +1934,7 @@
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	plaistigh	plaisteach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	4	nmod	_	_
 8	faoi	faoi	ADP	Simp	_	9	case	_	_
-9	sholas	solas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
+9	sholas	solas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
 10	díreach	díreach	ADJ	Adj	Gender=Masc|Number=Sing	9	amod	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
@@ -1963,7 +1963,7 @@
 8	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 9	amach	amach	ADV	Dir	_	8	advmod	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	gceartlár	ceartlár	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
+11	gceartlár	ceartlár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	gheimhridh	geimhreadh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	_
 14	agus	agus	CCONJ	Coord	_	15	cc	_	_
@@ -1994,7 +1994,7 @@
 39	-	-	PUNCT	Punct	_	42	punct	_	_
 40	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	42	cop	_	_
 41	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	42	nmod	_	_
-42	Easpag	easpag	NOUN	Noun	Gender=Masc|Number=Sing	31	parataxis	_	_
+42	Easpag	easpag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	31	parataxis	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	fhíona	fíon	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	42	nmod	_	_
 45	is	agus	CCONJ	Coord	_	47	cc	_	_
@@ -2050,7 +2050,7 @@
 14	Daoibhse	do	ADP	Prep	Number=Plur|Person=2|PronType=Emp	1	parataxis	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	14	acl:relcl	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
-17	bheagán	beagán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
+17	bheagán	beagán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
 18	Shakespeare	Shakespeare	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
@@ -2074,10 +2074,10 @@
 38	go	go	PART	Ad	PartType=Ad	39	mark:prt	_	_
 39	gonta	gonta	ADJ	Adj	Degree=Pos	36	advmod	_	SpaceAfter=No
 40	,	,	PUNCT	Punct	_	41	punct	_	_
-41	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	36	nsubj	_	_
+41	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	36	nsubj	_	_
 42	traigéideach	traigéideach	ADJ	Adj	Case=NomAcc|Number=Sing	41	amod	_	_
 43	marfach	marfach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	41	amod	_	_
-44	Phrionsa	prionsa	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	41	nmod	_	_
+44	Phrionsa	prionsa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	41	nmod	_	_
 45	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	46	det	_	_
 46	Danmhairge	Danmhairg	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	44	nmod	_	SpaceAfter=No
 47	.	.	PUNCT	.	_	1	punct	_	_
@@ -2233,7 +2233,7 @@
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
 10	fheachtas	feachtas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
-12	bhfabhar	fabhar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
+12	bhfabhar	fabhar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
 13	Nice	Nice	PROPN	Noun	Definite=Def|Number=Sing	12	nmod	_	SpaceAfter=No
 14	?	?	PUNCT	?	_	2	punct	_	_
 
@@ -2263,7 +2263,7 @@
 2	nach	nach	PART	Vb	PartType=Cmpl	3	mark:prt	_	_
 3	ngluaisfeá	gluais	VERB	VTI	Form=Ecl|Mood=Cnd|Number=Sing|Person=2	0	root	_	_
 4	go	go	ADP	Simp	_	5	case	_	_
-5	hÁth	áth	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+5	hÁth	áth	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	NamedEntity=Yes
 7	Sceire	sceir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	go	go	ADP	Simp	_	3	advmod	_	_
@@ -2282,7 +2282,7 @@
 8	:	:	PUNCT	Punct	_	11	punct	_	_
 9	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
 10	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	11	cop	_	_
-11	Aifreann	Aifreann	NOUN	Noun	Gender=Masc|Number=Sing	1	parataxis	_	NamedEntity=Yes
+11	Aifreann	Aifreann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	NamedEntity=Yes
 12	Domhnaigh	Domhnach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	níor	níor	PART	Vb	PartType=Vb|Tense=Past	14	advmod	_	_
 14	éist	éist	VERB	VTI	Mood=Ind|Tense=Past	11	ccomp	_	_
@@ -2308,7 +2308,7 @@
 14	'	'	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
 15	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	nsubj	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
-17	Mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	obl	_	NamedEntity=Yes
+17	Mac	mac	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	obl	_	NamedEntity=Yes
 18	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	go	go	PART	Vb	PartType=Cmpl	20	mark:prt	_	_
 20	bhfaca	feic	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	13	ccomp	_	_
@@ -2350,7 +2350,7 @@
 1	'	'	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
 2	De	de	ADP	Simp	_	4	case	_	_
 3	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	fixed	_	_
-4	phobalbhreith	pobalbhreith	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
+4	phobalbhreith	pobalbhreith	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	Galway	Galway	PROPN	Noun	Foreign=Yes	4	nmod	_	_
 7	Advertiser	Advertiser	PROPN	Noun	Foreign=Yes	6	flat:foreign	_	SpaceAfter=No
@@ -2407,14 +2407,14 @@
 
 # sent_id = 550
 # text = Campa samhraidh Óg-Eagras, Ionad Mosney, Co. na Mí.
-1	Campa	campa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Campa	campa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	samhraidh	samhradh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	Óg-Eagras	Óg-Eagras	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	flat	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
-5	Ionad	ionad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+5	Ionad	ionad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 6	Mosney	Mosney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
-8	Co.	contae	NOUN	Abr	Abbr=Yes	1	nmod	_	NamedEntity=Yes
+8	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	1	nmod	_	NamedEntity=Yes
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
 10	Mí	Mí	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
@@ -2556,7 +2556,7 @@
 13	beag	beag	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	12	amod	_	_
 14	go	go	PART	Vb	PartType=Cmpl	15	mark:prt	_	_
 15	nglaoitear	glaoigh	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	11	ccomp	_	_
-16	Boilg	boilg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	NamedEntity=Yes
+16	Boilg	boilg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obj	_	NamedEntity=Yes
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
 18	Chruaidh	cruaidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
@@ -2578,7 +2578,7 @@
 6	a	a	PART	Inf	PartType=Inf	7	nsubj	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	acl:relcl	_	_
 8	ar	ar	ADP	Simp	_	9	case	_	_
-9	bhinse	binse	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
+9	bhinse	binse	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
 10	Charoline	Caroline	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 11	is	agus	CCONJ	Coord	_	12	cc	_	_
 12	scuab	scuab	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
@@ -2688,7 +2688,7 @@
 21	áirleacan	airleacan	NOUN	Noun	Gender=Masc|Number=Sing	18	obl	_	_
 22	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	18	obl:prep	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
-24	noiméad	nóiméad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	28	obj	_	_
+24	noiméad	nóiméad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	28	obj	_	_
 25	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
 26	chloig	clog	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	_
 27	le	le	ADP	Simp	_	28	case	_	_
@@ -2788,10 +2788,10 @@
 # text = Má tá cumas eacnamaíochta na tíre á choimeád siar toisc easpa caipitil, agus airgead an phobail á infheistiú (is á chailliúnt) ar scairmhargaí thar lear ag an am céanna, ní straitéis chiallmhar í sin.
 1	Má	má	SCONJ	Subord	_	2	mark	_	_
 2	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	35	advcl	_	_
-3	cumas	cumas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
-4	eacnamaíochta	eacnamaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	3	nmod	_	_
+3	cumas	cumas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	eacnamaíochta	eacnamaíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
+6	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 7	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	case	_	_
 8	choimeád	coimeád	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	2	xcomp	_	_
 9	siar	siar	ADV	Dir	_	8	advmod	_	_
@@ -2800,7 +2800,7 @@
 12	caipitil	caipiteal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	agus	agus	CCONJ	Coord	_	19	cc	_	_
-15	airgead	airgead	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
+15	airgead	airgead	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	obj	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 18	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	19	case	_	_
@@ -2853,7 +2853,7 @@
 5	tseimineár	seimineár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 6	seo	seo	DET	Det	PronType=Dem	2	det	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
-8	fhorbairt	forbairt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+8	fhorbairt	forbairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
@@ -2873,7 +2873,7 @@
 25	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
 26	léargas	léargas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obj	_	_
 27	ar	ar	ADP	Simp	_	28	case	_	_
-28	bhunús	bunús	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
+28	bhunús	bunús	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
 29	agus	agus	CCONJ	Coord	_	30	cc	_	_
 30	todhchaí	todhchaí	NOUN	Noun	Gender=Fem|Number=Sing	28	conj	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
@@ -2896,7 +2896,7 @@
 48	fite	fite	ADJ	Adj	VerbForm=Part	45	xcomp:pred	_	_
 49	fuaite	fuaite	ADJ	Adj	VerbForm=Part	48	fixed	_	_
 50	le	le	ADP	Simp	_	51	case	_	_
-51	traidisiún	traidisiún	NOUN	Noun	Gender=Masc|Number=Sing	48	obl	_	_
+51	traidisiún	traidisiún	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	48	obl	_	_
 52	scéalaíochta	scéalaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	51	nmod	_	_
 53	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	54	det	_	_
 54	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	51	nmod	_	_
@@ -2907,7 +2907,7 @@
 59	Ó	ó	PART	Pat	PartType=Pat	57	flat:name	_	NamedEntity=Yes
 60	Criomhthainn	Criomhthainn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat:name	_	NamedEntity=Yes
 61	ó	ó	ADP	Simp	_	62	case	_	_
-62	Choláiste	coláiste	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
+62	Choláiste	coláiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
 63	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	64	det	_	NamedEntity=Yes
 64	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	62	nmod	_	NamedEntity=Yes|SpaceAfter=No
 65	,	,	PUNCT	Punct	_	66	punct	_	_
@@ -2996,7 +2996,7 @@
 1	Agus	agus	CCONJ	Coord	_	2	cc	_	_
 2	sin	sin	PRON	Dem	PronType=Dem	0	root	_	_
 3	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nmod	_	_
-4	umhlaíocht	umhlaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nsubj	_	_
+4	umhlaíocht	umhlaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	fhíornaofa	fíornaofa	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	7	nmod:poss	_	_
 7	dTiarna	tiarna	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
@@ -3050,7 +3050,7 @@
 
 # sent_id = 573
 # text = Fás na nGaelscoileanna.
-1	Fás	fás	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Fás	fás	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	na	na	DET	Art	PronType=Art	3	det	_	_
 3	nGaelscoileanna	Gaelscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
@@ -3070,7 +3070,7 @@
 11	Londain	Londain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 12	is	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	14	cop	_	_
 13	ea	ea	PRON	Pers	Number=Sing|Person=3	14	nmod	_	_
-14	príomhcharachtar	príomhcharachtar	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+14	príomhcharachtar	príomhcharachtar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	úrscéil	úrscéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	Deoraíocht	deoraíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	appos	_	SpaceAfter=No
@@ -3111,8 +3111,8 @@
 7	phointe	pointe	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	nsubj	_	_
 9	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	7	acl:relcl	_	_
-10	tuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
-11	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+10	tuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	_
+11	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	na	na	DET	Art	Case=Gen|Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	Náisiún	náisiún	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Weak|Number=Plur	11	nmod	_	NamedEntity=Yes
 14	i	i	ADP	Simp	_	15	case	_	_
@@ -3133,7 +3133,7 @@
 29	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	27	acl:relcl	_	_
 30	bonn	bonn	NOUN	Noun	Gender=Masc|Number=Sing	29	obj	_	_
 31	faoi	faoi	ADP	Simp	_	32	case	_	_
-32	theangeolaíocht	teangeolaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	29	obl	_	_
+32	theangeolaíocht	teangeolaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	29	obl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
 34	lae	lá	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	_
 35	inniu	inniu	ADV	Temp	_	34	amod	_	SpaceAfter=No
@@ -3142,7 +3142,7 @@
 # sent_id = 577
 # text = Ag barr an chnoic, ar scáth crainn chnó chapall, casann an bheirt ar deis.
 1	Ag	ag	ADP	Simp	_	2	case	_	_
-2	barr	barr	NOUN	Noun	Gender=Masc|Number=Sing	12	obl	_	_
+2	barr	barr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	chnoic	cnoc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -3218,7 +3218,7 @@
 9	Paul	Paul	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	appos	_	NamedEntity=Yes
 10	Pritchard	Pritchard	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	ar	ar	ADP	Simp	_	12	case	_	_
-12	pháipéar	páipéar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+12	pháipéar	páipéar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	Teastais	teastas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 15	Shóisearaigh	sóisearach	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	14	amod	_	NamedEntity=Yes
@@ -3284,9 +3284,9 @@
 # sent_id = 582
 # text = Bhí albam aonair amhránaithe an iarghrúpa In Tua Nua le bheith sna siopaí sa samhradh, ach is cosúil anois go mbeidh an t-albam ar fáil sna siopaí an chéad mhí eile....
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	albam	albam	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	albam	albam	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	aonair	aonar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
-4	amhránaithe	amhránaí	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
+4	amhránaithe	amhránaí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	iarghrúpa	iarghrúpa	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	In	i	ADP	Simp	_	8	case	_	NamedEntity=Yes
@@ -3342,7 +3342,7 @@
 11	vótáil	vótáil	NOUN	Noun	VerbForm=Inf	9	csubj:cop	_	_
 12	de	de	ADP	Cmpd	PrepForm=Cmpd	14	case	_	_
 13	réir	réir	ADP	Cmpd	PrepForm=Cmpd	12	fixed	_	_
-14	thoil	toil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
+14	thoil	toil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 15	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	16	nmod:poss	_	_
 16	máistrí	máistir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	9	punct	_	_
@@ -3397,7 +3397,7 @@
 17	mar	mar	ADP	Simp	_	18	case	_	_
 18	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 19	d'	de	ADP	Simp	_	20	case	_	SpaceAfter=No
-20	obair	obair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	nmod	_	_
+20	obair	obair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	nmod	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	stáit	stát	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	_	_
@@ -3411,7 +3411,7 @@
 5	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	conj	_	_
 6	cáidheach	cáidheach	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
-8	roidealach	roidealach	NOUN	Noun	Gender=Masc|Number=Sing	5	nmod	_	_
+8	roidealach	roidealach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	bhóthair	bóthar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
@@ -3450,7 +3450,7 @@
 2	méadú	méadú	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
 3	56%	56	NUM	Num	_	2	nmod	_	_
 4	i	i	ADP	Simp	_	5	case	_	_
-5	lion	líon	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	1	obl	_	_
+5	lion	líon	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	1	obl	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	dturasóirí	turasóir	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	5	nmod	_	_
 8	go	go	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
@@ -3462,8 +3462,8 @@
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	100%	100	NUM	Num	_	2	conj	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
-18	chathair	cathair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	_
+17	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+18	chathair	cathair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	_
 19	Dhoire	Doire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
 21	1995	1995	NUM	Num	_	1	obl	_	SpaceAfter=No
@@ -3471,7 +3471,7 @@
 23	cruthú	cruthú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	parataxis	_	_
 24	praiticiúil	praiticiúil	ADJ	Adj	Gender=Masc|Number=Sing	23	amod	_	_
 25	de	de	ADP	Simp	_	26	case	_	_
-26	bhrabach	brabach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+26	bhrabach	brabach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
 28	síochána	síocháin	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	26	nmod	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	1	punct	_	_
@@ -3577,7 +3577,7 @@
 18	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	case	_	_
 19	béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
-21	íochtar	íochtar	NOUN	Noun	Gender=Masc|Number=Sing	14	conj	_	_
+21	íochtar	íochtar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	conj	_	_
 22	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
 23	cóta	cóta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	25	case	_	_
@@ -3646,7 +3646,7 @@
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	chéidh	céidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	nDeisceart	deisceart	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
+13	nDeisceart	deisceart	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	oileáin	oileán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	_
 16	nuair	nuair	SCONJ	Subord	_	18	mark	_	_
@@ -3696,7 +3696,7 @@
 # sent_id = 600
 # text = Bunaíodh Gailearaí Náisiúnta na hÉireann de réir Acht Parlaiminte i 1854 agus osclaíodh don phobal í i 1864.
 1	Bunaíodh	bunaigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	0	root	_	_
-2	Gailearaí	gailearaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
+2	Gailearaí	gailearaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
 3	Náisiúnta	náisiúnta	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	NamedEntity=Yes
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
 5	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
@@ -3773,7 +3773,7 @@
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	mark:prt	_	_
 32	chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	21	advcl	_	_
 33	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	32	nsubj	_	_
-34	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	32	obj	_	_
+34	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	32	obj	_	_
 35	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
 36	uillinneacha	uillinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Strong|Number=Plur	34	nmod	_	_
 37	sa	i	ADP	Art	Number=Sing|PronType=Art	38	case	_	_
@@ -3928,7 +3928,7 @@
 68	,	,	PUNCT	Punct	_	71	punct	_	_
 69	in	in	ADP	Cmpd	PrepForm=Cmpd	71	case	_	_
 70	aghaidh	aghaidh	ADP	Cmpd	PrepForm=Cmpd	69	fixed	_	_
-71	ceartdhlí	ceartdlí	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	52	nmod	_	_
+71	ceartdhlí	ceartdlí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	52	nmod	_	_
 72	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	73	det	_	_
 73	bhfáidhe	fáidh	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	71	nmod	_	_
 74	agus	agus	CCONJ	Coord	_	76	cc	_	_
@@ -3946,15 +3946,15 @@
 86	chúirte	cúirt	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	81	nmod	_	_
 87	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	89	det	_	_
 88	naoi	naoi	NUM	Num	NumType=Card	89	nummod	_	_
-89	mbéithe	bé	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	81	nmod	_	_
+89	mbéithe	bé	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	86	nmod	_	_
 90	agus	agus	CCONJ	Coord	_	91	cc	_	_
-91	Apolló	Apolló	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	81	conj	_	SpaceAfter=No
+91	Apolló	Apolló	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	89	conj	_	SpaceAfter=No
 92	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 608
 # text = Le linn an imshruthaithe tugann an ocsahaemaglóibin an ocsaigin do na fíocháin.
 1	Le	le	ADP	Simp	_	2	case	_	_
-2	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
+2	linn	linn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	imshruthaithe	imshruthú	NOUN	Noun	Case=Gen|Definite=Def|VerbForm=Inf	2	nmod	_	_
 5	tugann	tabhair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
@@ -3981,7 +3981,7 @@
 10	le	le	ADP	Simp	_	11	case	_	_
 11	rá	rá	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
 12	meascadh	measc	VERB	PastInd	Mood=Ind|Person=0|Tense=Past	11	nmod	_	_
-13	síol	síol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
+13	síol	síol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obj	_	_
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 15	croise	cros	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	_
 16	leis	le	ADP	Simp	_	18	case	_	_
@@ -3997,7 +3997,7 @@
 26	gcuntas	cuntas	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 27	suntasach	suntasach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	26	amod	_	_
 28	ó	ó	ADP	Simp	_	29	case	_	_
-29	Chontae	contae	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
+29	Chontae	contae	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
 30	Loch	Loch	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
 31	Garman	Garman	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes|SpaceAfter=No
 32	:	:	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
@@ -4180,7 +4180,7 @@
 36	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	31	nmod	_	_
 37	faoi	faoi	ADP	Simp	_	38	case	_	_
 38	deara	deara	NOUN	Subst	Number=Sing	31	nmod	_	_
-39	oibriú	oibriú	NOUN	Noun	VerbForm=Inf	43	obj	_	_
+39	oibriú	oibriú	NOUN	Noun	Definite=Def|VerbForm=Inf	43	obj	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
 41	fhógra	fógra	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	39	nmod	_	_
 42	a	a	PART	Inf	PartType=Inf	43	mark	_	_
@@ -4211,7 +4211,7 @@
 67	ordú	ordú	NOUN	Noun	VerbForm=Inf	55	xcomp	_	_
 68	go	go	PART	Vb	PartType=Cmpl	69	mark:prt	_	_
 69	bhfionrófar	fionraigh	VERB	FutInd	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	67	ccomp	_	_
-70	oibriú	oibriú	NOUN	Noun	VerbForm=Inf	69	obj	_	_
+70	oibriú	oibriú	NOUN	Noun	Definite=Def|VerbForm=Inf	69	obj	_	_
 71	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	72	det	_	_
 72	fhógra	fógra	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	70	nmod	_	_
 73	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	74	case	_	_
@@ -4234,7 +4234,7 @@
 11	214	214	NUM	Num	_	6	nmod	_	SpaceAfter=No
 12	)	)	PUNCT	Punct	_	2	punct	_	_
 13	I	i	ADP	Simp	_	14	case	_	_
-14	gCath	cath	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	NamedEntity=Yes
+14	gCath	cath	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	NamedEntity=Yes
 15	Almhaine	Almhain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	17	cop	_	_
 17	léir	léir	ADJ	Adj	Degree=Pos	0	root	_	_
@@ -4317,7 +4317,7 @@
 24	,	,	PUNCT	Punct	_	3	punct	_	_
 25	cuirtear	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 26	i	i	ADP	Simp	_	27	case	_	_
-27	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	25	obl	_	_
+27	leith	leith	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	25	obl	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
 29	Aire	aire	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
 30	Oideachais	oideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -4367,7 +4367,7 @@
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
 2	bháine	báine	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 3	idir	idir	ADP	Simp	_	4	case	_	_
-4	dhúch	dúch	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+4	dhúch	dúch	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
 6	bhfocal	focal	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	4	nmod	_	_
 7	mar	mar	SCONJ	Subord	_	9	mark	_	_
@@ -4378,7 +4378,7 @@
 12	ag	ag	ADP	Simp	_	13	case	_	_
 13	trilsiú	trilsiú	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 14	trí	trí	ADP	Simp	_	15	case	_	_
-15	fholt	folt	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+15	fholt	folt	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	gcrann	crann	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	15	nmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	_	_
@@ -4417,7 +4417,7 @@
 15	Johanna	Johanna	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	conj	_	NamedEntity=Yes
 16	McInerney	McInerney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 17	,	,	PUNCT	Punct	_	18	punct	_	_
-18	Teach	teach	NOUN	Noun	Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+18	Teach	teach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 19	Cheeverstown	Cheeverstown	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
@@ -4465,11 +4465,11 @@
 7	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	csubj:cop	_	_
 8	spéis	spéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nsubj	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
-10	bunáite	bunáite	NOUN	Noun	Gender=Fem|Number=Sing	7	obl	_	_
+10	bunáite	bunáite	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	vótóirí	vótóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	mionfhorálacha	mionfhoráil	NOUN	Noun	Gender=Fem|Number=Plur	7	obl	_	_
+14	mionfhorálacha	mionfhoráil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	7	obl	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Chonartha	conradh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
@@ -4477,7 +4477,7 @@
 # sent_id = 633
 # text = Ó thaobh na gréine de, ba é an gath ba ghile a shoilsigh orainn i rith na bliana seo caite ná an tsíocháin a deineadh ó thuaidh.
 1	Ó	ó	ADP	Simp	_	2	case	_	_
-2	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
+2	thaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 5	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	SpaceAfter=No
@@ -4529,7 +4529,7 @@
 19	mar	mar	SCONJ	Subord	_	21	mark	_	_
 20	a	a	PART	Vb	PartType=Vb	21	mark:prt	_	_
 21	thaispeáin	taispeáin	VERB	VT	Form=Len|Mood=Ind|Tense=Past	10	advcl	_	_
-22	suirbhé	suirbhé	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nsubj	_	_
+22	suirbhé	suirbhé	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
 23	Nielson	Nielson	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	_
 24	ach	ach	SCONJ	Subord	_	26	mark	_	_
 25	ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	26	cop	_	_
@@ -4540,7 +4540,7 @@
 # sent_id = 635
 # text = I gceantar Anagaire mar shampla tá ar a laghad deich mbaile fearainn nach dtugtar aitheantas díobhtha i seoladh an vótóra rud a chiallaíonn go mbíonn an seoladh poist céanna ag na vótóirí uilig.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
+2	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
 3	Anagaire	Anagaire	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 4	mar	mar	ADP	Simp	_	5	case	_	_
 5	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
@@ -4556,7 +4556,7 @@
 15	aitheantas	aitheantas	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
 16	díobhtha	de	ADP	Prep	Number=Plur|Person=3	14	obl:prep	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
-18	seoladh	seoladh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
+18	seoladh	seoladh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	vótóra	vótóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	_
 21	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	parataxis	_	_
@@ -4736,7 +4736,7 @@
 4	díreach	díreach	ADJ	Adj	Degree=Pos	2	advmod	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	las	las	VERB	VTI	Mood=Ind|Tense=Past	2	csubj:cleft	_	_
-7	solas	solas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
+7	solas	solas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	dearg	dearg	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
 10	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
@@ -4747,14 +4747,14 @@
 15	agus	agus	CCONJ	Coord	_	17	cc	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	obj	_	_
 17	shioc	sioc	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	6	conj	_	_
-18	fuil	fuil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	nsubj	_	_
+18	fuil	fuil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	nsubj	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	chuairteora	cuairteoir	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	aonair	aonar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	_
 22	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
 23	chuislí	cuisle	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	17	obl	_	SpaceAfter=No
 24	:	:	PUNCT	Punct	_	25	punct	_	_
-25	cloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	parataxis	_	_
+25	cloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	parataxis	_	_
 26	gearrtha	gearrtha	ADJ	Adj	VerbForm=Part	25	amod	_	_
 27	Eoin	Eoin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 28	Baiste	baiste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	flat:name	_	NamedEntity=Yes
@@ -4811,7 +4811,7 @@
 # sent_id = 643
 # text = Is gnéithe de dhearcadh iad chomh maith an tsuim a léiríonn páiste i gcríochnú tascanna agus in úsáid fhéinmhuiníneach na matamaitice i réimsí eile an churaclaim agus sa ghnáthshaol.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	gnéithe	gné	NOUN	Noun	Gender=Fem|Number=Plur	0	root	_	_
+2	gnéithe	gné	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 3	de	de	ADP	Simp	_	4	case	_	_
 4	dhearcadh	dearcadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	iad	iad	PRON	Pers	Number=Plur|Person=3	2	nsubj	_	_
@@ -4827,12 +4827,12 @@
 15	tascanna	tasc	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	14	nmod	_	_
 16	agus	agus	CCONJ	Coord	_	18	cc	_	_
 17	in	i	ADP	Simp	_	18	case	_	_
-18	úsáid	úsáid	NOUN	Noun	VerbForm=Inf	14	conj	_	_
+18	úsáid	úsáid	NOUN	Noun	Definite=Def|VerbForm=Inf	14	conj	_	_
 19	fhéinmhuiníneach	féinmhuiníneach	ADJ	Adj	Degree=Pos|Form=Len	18	amod	_	_
 20	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	21	det	_	_
 21	matamaitice	matamaitic	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	18	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	réimsí	réimse	NOUN	Noun	Gender=Masc|Number=Plur	11	obl	_	_
+23	réimsí	réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
 24	eile	eile	DET	Det	PronType=Dem	26	det	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
 26	churaclaim	curaclam	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
@@ -4854,12 +4854,12 @@
 1	Gan	gan	ADP	Simp	_	2	case	_	_
 2	dochar	dochar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	_
 3	d'	do	ADP	Simp	_	4	case	_	SpaceAfter=No
-4	inniúlachtaí	inniúlacht	NOUN	Noun	Gender=Fem|Number=Plur	2	nmod	_	_
+4	inniúlachtaí	inniúlacht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	2	nmod	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	Chomhphobail	comhphobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	2	punct	_	_
 8	cuirfidh	cuir	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
-9	Ballstáit	ballstát	NOUN	Noun	Gender=Masc|Number=Plur	8	nsubj	_	_
+9	Ballstáit	ballstát	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	8	nsubj	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	Aontais	aontas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 12	Eorpaigh	Eorpach	ADJ	Adj	Case=Gen|Gender=Masc|Number=Sing	11	amod	_	NamedEntity=Yes
@@ -4896,7 +4896,7 @@
 43	-	-	PUNCT	Punct	_	42	punct	_	_
 44	sáruithe	sárú	NOUN	Noun	Gender=Masc|Number=Plur	37	conj	_	_
 45	ar	ar	ADP	Simp	_	46	case	_	_
-46	fhorálacha	foráil	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	44	nmod	_	_
+46	fhorálacha	foráil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	44	nmod	_	_
 47	custaim	custam	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	46	nmod	_	_
 48	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	49	det	_	_
 49	Chomhphobail	comhphobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	nmod	_	_
@@ -4918,7 +4918,7 @@
 3	fostaithe	fostaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	ag	ag	ADP	Simp	_	6	case	_	_
-6	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+6	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	seachtaine	seachtain	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
@@ -5027,7 +5027,7 @@
 3	gné	gné	NOUN	Noun	Gender=Fem|Number=Sing	1	ccomp	_	_
 4	thábhachtach	tábhachtach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	amod	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	bhforbairt	forbairt	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	3	nmod	_	_
+6	bhforbairt	forbairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	3	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	fhórsa	fórsa	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	saothair	saothar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
@@ -5060,7 +5060,7 @@
 2	ansin	ansin	ADV	Loc	_	3	advmod	_	_
 3	chuala	clois	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
-5	ardséideadh	ardséideadh	NOUN	Noun	Gender=Masc|Number=Sing	3	obj	_	_
+5	ardséideadh	ardséideadh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	dtrumpaí	trumpa	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -5226,13 +5226,13 @@
 # sent_id = 658
 # text = Tháinig lá an chluiche ceannais in aghaidh Thír Eoghain agus d'éirigh leis na Laighnigh cúl cinniúnach a ghnóthú - scór na bua, gan amhras.
 1	Tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	chluiche	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	ceannais	ceannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
 6	in	in	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 7	aghaidh	aghaidh	ADP	Cmpd	PrepForm=Cmpd	6	fixed	_	_
-8	Thír	Tír	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
+8	Thír	Tír	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 9	Eoghain	Eoghan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	agus	agus	CCONJ	Coord	_	12	cc	_	_
 11	d'	do	PART	Vb	PartType=Vb	12	mark:prt	_	SpaceAfter=No
@@ -5245,7 +5245,7 @@
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	ghnóthú	gnóthú	NOUN	Noun	Form=Len|VerbForm=Inf	12	xcomp	_	_
 20	-	-	PUNCT	Punct	_	21	punct	_	_
-21	scór	scór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	parataxis	_	_
+21	scór	scór	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	_
 22	na	na	DET	Art	PronType=Art	23	det	_	_
 23	bua	bua	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
@@ -5292,7 +5292,7 @@
 13	nua	nua	ADJ	Adj	Degree=Pos	12	amod	_	_
 14	maidir	maidir	ADP	CmpdNoGen	_	16	case	_	_
 15	le	le	ADP	CmpdNoGen	_	14	fixed	_	_
-16	múineadh	múineadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
+16	múineadh	múineadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
 18	teanga	teanga	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	7	punct	_	_
@@ -5307,7 +5307,7 @@
 6	seachtaine	seachtain	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	compound	_	_
 7	Gaelach	gaelach	ADJ	Adj	Degree=Pos	5	amod	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+9	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
 11	scoile	scoil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
@@ -5327,7 +5327,7 @@
 6	Padaí	Padaí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
 7	Mór	Mór	ADJ	Adj	Gender=Masc|Number=Sing	6	amod	_	NamedEntity=Yes
 8	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-9	dtigh	teach	NOUN	Noun	Case=Dat|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
+9	dtigh	teach	NOUN	Noun	Case=Dat|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
 10	Dhónaill	Dónall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	Bhrocaigh	Brocach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	-	-	PUNCT	Punct	_	13	punct	_	_
@@ -5378,7 +5378,7 @@
 
 # sent_id = 666
 # text = FEIDHMEANNA NA mBAILTE.
-1	FEIDHMEANNA	feidhm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
+1	FEIDHMEANNA	feidhm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	0	root	_	_
 2	NA	na	DET	Art	PronType=Art	3	det	_	_
 3	mBAILTE	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
@@ -5392,7 +5392,7 @@
 5	imithe	imithe	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 6	isteach	isteach	ADV	Dir	_	1	advmod	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	muileann	muileann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+8	muileann	muileann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	ama	am	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 11	orm	ar	ADP	Prep	Number=Sing|Person=1	1	obl:prep	_	SpaceAfter=No
@@ -5467,7 +5467,7 @@
 # sent_id = 671
 # text = Bhí céadsoilse na gréine ag cur dealraimh sa mhuir.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	céadsoilse	céadsolas	NOUN	Noun	Gender=Masc|Number=Plur	1	nsubj	_	_
+2	céadsoilse	céadsolas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	nsubj	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 5	ag	ag	ADP	Simp	_	6	case	_	_
@@ -5494,7 +5494,7 @@
 13	agus	agus	CCONJ	Coord	_	16	cc	_	_
 14	ar	ar	ADP	Simp	_	16	case	_	_
 15	'	'	PUNCT	Punct	_	16	punct	_	SpaceAfter=No
-16	Bodach	bodach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+16	Bodach	bodach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
 17	an	an	DET	Art	Case=Gen|Definite=Def|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
 18	Chóta	cóta	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	Lachna	lachna	ADJ	Adj	Case=Gen|Gender=Masc|Number=Sing	18	amod	_	NamedEntity=Yes|SpaceAfter=No
@@ -5503,20 +5503,20 @@
 
 # sent_id = 673
 # text = Lá Mhaghnuis an Phíce, Lá na ngunnaí mór ar Loch Súilighe, Oídhche na Gaoithe Móire, Lá Ghleann Bheithe, An Lá a cuireadh Butt agus An Lá a d'éag Parnell (Rácáil agus Scuabadh (1955) 27).
-1	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	Mhaghnuis	Maghnus	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	Phíce	píce	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	1	conj	_	_
+6	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	ngunnaí	gunna	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	6	nmod	_	_
 9	mór	mór	ADJ	Adj	Case=Gen|NounType=Weak|Number=Plur	8	amod	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	Loch	loch	NOUN	Noun	Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
+11	Loch	loch	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
 12	Súilighe	Súilighe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	Oídhche	oídhche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	conj	_	NamedEntity=Yes
+14	Oídhche	oídhche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	conj	_	NamedEntity=Yes
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	NamedEntity=Yes
 16	Gaoithe	gaoth	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Móire	mór	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	NamedEntity=Yes|SpaceAfter=No
@@ -5550,7 +5550,7 @@
 # sent_id = 674
 # text = Faoi lár an 18ú aois baineadh úsáid fhorleathan as inneall Newcomen le huisce a chaidéalú.
 1	Faoi	faoi	ADP	Simp	_	2	case	_	_
-2	lár	lár	NOUN	Noun	Gender=Masc|Number=Sing	6	obl	_	_
+2	lár	lár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 4	18ú	18	NUM	Num	NumType=Ord	5	amod	_	_
 5	aois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
@@ -5558,7 +5558,7 @@
 7	úsáid	úsáid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obj	_	_
 8	fhorleathan	forleathan	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	amod	_	_
 9	as	as	ADP	Simp	_	10	case	_	_
-10	inneall	inneall	NOUN	Noun	Gender=Masc|Number=Sing	7	nmod	_	_
+10	inneall	inneall	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 11	Newcomen	Newcomen	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 12	le	le	ADP	Simp	_	15	case	_	_
 13	huisce	uisce	NOUN	Noun	Form=HPref|Gender=Masc|Number=Sing	15	obj	_	_
@@ -5638,7 +5638,7 @@
 7	anseo	anseo	ADV	Loc	_	1	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	tugadh	tabhair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
-10	tí	tí	NOUN	Noun	Gender=Masc|Number=Sing	9	obj	_	_
+10	tí	tí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
 11	Tom	Tom	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	Tommy	Tommy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
@@ -5675,11 +5675,11 @@
 # text = Níorbh ionann tithe na gcathracha agus tithe na mbailte beaga.
 1	Níorbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	_
 2	ionann	ionann	ADJ	Adj	Degree=Pos	0	root	_	_
-3	tithe	teach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	nsubj	_	_
+3	tithe	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	2	nsubj	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	gcathracha	cathair	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	3	nmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
-7	tithe	teach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	conj	_	_
+7	tithe	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	3	conj	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	mbailte	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	7	nmod	_	_
 10	beaga	beag	ADJ	Adj	Case=Gen|Gender=Fem|Number=Plur	9	amod	_	SpaceAfter=No
@@ -5779,7 +5779,7 @@
 22	agus	agus	CCONJ	Coord	_	23	mark	_	_
 23	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	16	advcl	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
-25	líonadh	líonadh	NOUN	Noun	VerbForm=Vnoun	23	xcomp	_	_
+25	líonadh	líonadh	NOUN	Noun	Definite=Def|VerbForm=Vnoun	23	xcomp	_	_
 26	amach	amach	ADV	Dir	_	25	advmod	_	_
 27	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	28	det	_	_
 28	seolta	seol	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
@@ -5826,7 +5826,7 @@
 6	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
 7	sheirbhís	seirbhís	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nsubj	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	gCathaoir	cathaoir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
+9	gCathaoir	cathaoir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
 10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
 12	tréimhse	tréimhse	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
@@ -5881,7 +5881,7 @@
 4	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	obl	_	_
 5	nach	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	6	cop	_	_
 6	féidir	féidir	NOUN	Subst	Number=Sing	4	acl:relcl	_	_
-7	ainm	ainm	NOUN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
+7	ainm	ainm	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 10	lena	le	PART	Rel	PronType=Rel	11	obl	_	_
@@ -5981,7 +5981,7 @@
 6	dhul	dul	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 7	go	go	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 8	dtí	dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	7	fixed	_	_
-9	rútaí	rúta	NOUN	Noun	Gender=Masc|Number=Plur	6	nmod	_	_
+9	rútaí	rúta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	seo	seo	DET	Det	PronType=Dem	11	det	_	SpaceAfter=No
@@ -6030,7 +6030,7 @@
 22	iad	iad	PRON	Pers	Number=Plur|Person=3	16	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	2	punct	_	_
 24	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-25	mianach	mianach	NOUN	Noun	Gender=Masc|Number=Sing	24	nsubj	_	_
+25	mianach	mianach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
 27	hindibhidiúlachta	indibhidiúlacht	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	25	nmod	_	_
 28	fós	fós	ADV	Gn	_	24	advmod	_	_
@@ -6064,7 +6064,7 @@
 5	a	a	ADV	Its	_	4	fixed	_	_
 6	bheith	bheith	ADV	Its	Form=Len	4	fixed	_	_
 7	éasca	éasca	ADJ	Adj	Degree=Pos	2	xcomp:pred	_	_
-8	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	_
+8	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obj	_	_
 9	mhaith	maith	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	8	amod	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
 11	nithe	ní	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
@@ -6115,7 +6115,7 @@
 4	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	3	flat	_	NamedEntity=Yes
 5	Lughach	Lughach	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	bean	bean	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	appos	_	_
+7	bean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	appos	_	_
 8	Chaoil	caol	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	mhic	mac	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	Criomhthain	Criomhthain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
@@ -6147,7 +6147,7 @@
 20	BSLT	BSLT	PROPN	Abr	Abbr=Yes	14	appos	_	SpaceAfter=No
 21	)	)	PUNCT	Punct	_	20	punct	_	_
 22	agus	agus	CCONJ	Coord	_	23	cc	_	_
-23	Ospidéal	ospidéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
+23	Ospidéal	ospidéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
 24	Beaumont	Beaumont	PROPN	Noun	Definite=Def	23	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -6230,7 +6230,7 @@
 18	im	i_mo	ADP	Det	Number=Sing|Person=1|Poss=Yes	19	case	_	_
 19	thimpeall	timpeall	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
-21	Cluasa	cluas	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	14	parataxis	_	_
+21	Cluasa	cluas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	14	parataxis	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
 23	ghiorraí	giorria	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
 24	Ag	ag	ADP	Simp	_	25	case	_	_
@@ -6334,7 +6334,7 @@
 3	ar	ar	ADP	Simp	_	4	case	_	_
 4	uachtar	uachtar	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	bpoll	poll	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+6	bpoll	poll	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	aeir	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
@@ -6355,7 +6355,7 @@
 3	mar	mar	ADP	Simp	_	4	case	_	_
 4	bhunmhúinteoir	bunmhúinteoir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+6	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 7	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	6	nmod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
 9	nDroim	droim	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
@@ -6514,7 +6514,7 @@
 10	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	1	ccomp	_	_
 11	iontas	iontas	NOUN	Noun	Gender=Masc|Number=Sing	10	nsubj	_	_
 12	ar	ar	ADP	Simp	_	13	case	_	_
-13	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
+13	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	cheantair	ceantar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	20	punct	_	_
@@ -6547,7 +6547,7 @@
 
 # sent_id = 717
 # text = toiliú an Aire Airgeadais, féadfaidh an tAire, as airgead a sholáthróidh an tOireachtas, deontais a thabhairt d'údaráis phleanála i leith aon cheann nó gach ceann dá bhfeidhmeanna faoin Acht seo, lena n-áirítear deontais chun go nglanfar an caiteachas iomlán nó cuid den chaiteachas a bheidh tabhaithe acu (a) le linn cúnamh le daoine ar a seirbheáiltear fógra faoi alt 10(1) nó 11(2) agus oibreacha á ndéanamh acu de réir an fhógra, agus (b) le linn cúnamh le haon duine eile agus oibreacha á ndéanamh aige nó aici ar dhéanmhais chosanta de réir cibé coinníollacha a shonróidh údarás pleanála chun cúnamh den sórt sin a fháil.
-1	toiliú	toiliú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	toiliú	toiliú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	Aire	aire	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	Airgeadais	airgeadas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -6764,7 +6764,7 @@
 3	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl:tmod	_	_
 4	céanna	céanna	ADJ	Adj	Degree=Pos	3	amod	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-6	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
+6	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	gcraobhacha	craobh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	6	nmod	_	_
 9	den	de	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
@@ -6797,7 +6797,7 @@
 9	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 10	seo	seo	DET	Det	PronType=Dem	9	det	_	_
 11	chun	chun	ADP	Simp	_	12	case	_	_
-12	tairbhe	tairbhe	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
+12	tairbhe	tairbhe	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 13	Shinn	Sinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 14	Fein	Féin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	13	flat	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
@@ -6867,7 +6867,7 @@
 # sent_id = 727
 # text = Bhí togha na Gaeilge aici; thóg sí léi í óna seanmháthair agus d'fhoghlaim sise í óna hathair siúd.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	togha	togha	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	togha	togha	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 5	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	SpaceAfter=No
@@ -6916,7 +6916,7 @@
 9	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	6	csubj:cop	_	_
 10	ar	ar	ADP	Cmpd	PrepForm=Cmpd	12	case	_	_
 11	son	son	ADP	Cmpd	PrepForm=Cmpd	10	fixed	_	_
-12	litríocht	litríocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	nmod	_	_
+12	litríocht	litríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 13	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
 14	n-aosánach	aosánach	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	12	nmod	_	_
 15	a	a	PART	Inf	PartType=Inf	16	mark	_	_
@@ -6926,7 +6926,7 @@
 19	ar	ar	ADP	Simp	_	20	case	_	_
 20	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	18	nmod	_	_
 21	ó	ó	ADP	Simp	_	22	case	_	_
-22	litríocht	litríocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	nmod	_	_
+22	litríocht	litríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 23	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	22	amod	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
 25	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
@@ -6991,7 +6991,7 @@
 6	gcáineadh	cáineadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	nmod	_	_
 7	sin	sin	DET	Det	PronType=Dem	6	det	_	_
 8	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-9	triúr	triúr	NOUN	Noun	Gender=Masc|Number=Sing	8	nsubj	_	_
+9	triúr	triúr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	_
 10	eile	eile	DET	Det	PronType=Dem	9	det	_	_
 11	le	le	ADP	Simp	_	12	case	_	_
 12	ceapadh	ceapadh	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
@@ -6999,10 +6999,10 @@
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	mBord	bord	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	Mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	NamedEntity=Yes
+17	Mí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	NamedEntity=Yes
 18	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
-20	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+20	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	appos	_	NamedEntity=Yes
 21	Noone	Noone	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
 22	ón	ó	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	SELC	SELC	PROPN	Abr	Abbr=Yes	20	nmod	_	SpaceAfter=No
@@ -7012,7 +7012,7 @@
 27	le	le	ADP	Simp	_	28	case	_	_
 28	turasóireacht	turasóireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	obl	_	_
 29	i	i	ADP	Simp	_	30	case	_	_
-30	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	28	nmod	_	_
+30	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	nmod	_	_
 31	Iorrais	Iorras	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
 33	Joe	Joe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
@@ -7066,7 +7066,7 @@
 22	ag	ag	ADP	Simp	_	23	case	_	_
 23	freastal	freastal	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 24	ar	ar	ADP	Simp	_	25	case	_	_
-25	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	23	obl	_	_
+25	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	23	obl	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
 27	iarthair	iarthar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
@@ -7141,7 +7141,7 @@
 11	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 12	a	a	PART	Vb	PartType=Vb	13	obl	_	_
 13	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	11	acl:relcl	_	_
-14	Teach	teach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	nsubj	_	_
+14	Teach	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Phosta	post	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
 17	anois	anois	ADV	Gn	_	13	advmod	_	_
@@ -7446,8 +7446,8 @@
 # text = Is in Áras Chumann Ríoga Bhaile Átha Cliath i nDroichead na Dothra, Baile Átha Cliath 4, a bheidh an spórt seo á imirt.
 1	Is	is	AUX	Cop	VerbForm=Cop	3	cop	_	_
 2	in	i	ADP	Simp	_	3	case	_	_
-3	Áras	áras	NOUN	Noun	_	0	root	_	NamedEntity=Yes
-4	Chumann	cumann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+3	Áras	áras	NOUN	Noun	Definite=Def	0	root	_	NamedEntity=Yes
+4	Chumann	cumann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	Ríoga	ríoga	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	4	amod	_	NamedEntity=Yes
 6	Bhaile	Baile	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 7	Átha	Átha	PROPN	Noun	Definite=Def	6	nmod	_	NamedEntity=Yes
@@ -7484,7 +7484,7 @@
 9	dul	dul	NOUN	Noun	VerbForm=Vnoun	3	xcomp	_	_
 10	suas	suas	ADV	Dir	_	9	advmod	_	_
 11	go	go	ADP	Simp	_	12	case	_	_
-12	barr	barr	NOUN	Noun	Gender=Masc|Number=Sing	9	obl	_	_
+12	barr	barr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	chnoic	cnoc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	_	_
@@ -7505,7 +7505,7 @@
 4	dhá	do	ADP	Poss	Form=Len|Number=Plur|Person=3|Poss=Yes	5	case	_	_
 5	n-úsáid	úsáid	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	2	xcomp	_	_
 6	ó	ó	ADP	Simp	_	7	case	_	_
-7	thús	tús	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+7	thús	tús	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	chine	cine	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 10	dhaonna	daonna	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	9	amod	_	SpaceAfter=No
@@ -7563,9 +7563,9 @@
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	siúl	siúl	NOUN	Noun	VerbForm=Inf	10	xcomp	_	_
 14	i	i	ADP	Simp	_	15	case	_	_
-15	dtithe	teach	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	13	obl	_	_
+15	dtithe	teach	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	13	obl	_	_
 16	eile	eile	DET	Det	PronType=Dem	15	det	_	_
-17	Chillín	Cillín	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Chillín	Cillín	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 18	Chaoimhín	Caoimhín	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	17	nmod	_	NamedEntity=Yes
 19	ach	ach	SCONJ	Subord	_	20	mark	_	_
 20	oiread	oiread	NOUN	Subst	Number=Sing	10	advcl	_	SpaceAfter=No
@@ -7703,7 +7703,7 @@
 5	-	-	PUNCT	Punct	_	6	punct	_	_
 6	Druid	druid	NOUN	Noun	Foreign=Yes|Number=Sing	3	appos	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
-8	iar-stiúrthóir	iarstiúrthóir	NOUN	Noun	Gender=Masc|Number=Sing	6	conj	_	_
+8	iar-stiúrthóir	iarstiúrthóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 9	ealaíne	ealaín	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
 10	conspóideach	conspóideach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
@@ -7835,13 +7835,13 @@
 5	áfach	áfach	ADV	Gn	_	7	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	5	punct	_	_
 7	saolaíodh	saolaigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	0	root	_	_
-8	mac	mac	NOUN	Noun	Gender=Masc|Number=Sing	7	obj	_	_
+8	mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obj	_	_
 9	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	7	obl:prep	_	_
 10	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
 12	Höskuld	Höskuld	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
 13	-	-	PUNCT	Punct	_	14	punct	_	_
-14	Ólaf	Ólaf	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
+14	Ólaf	Ólaf	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 769
@@ -7879,7 +7879,7 @@
 31	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	30	nsubj	_	_
 32	fíorthábhachtach	fíorthábhachtach	ADJ	Adj	Degree=Pos	30	xcomp:pred	_	_
 33	ó	ó	ADP	Simp	_	34	case	_	_
-34	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	32	obl	_	_
+34	thaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	32	obl	_	_
 35	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	36	det	_	_
 36	staire	stair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	34	nmod	_	_
 37	agus	agus	CCONJ	Coord	_	39	cc	_	_
@@ -8027,7 +8027,7 @@
 # sent_id = 777
 # text = Tá leas an tomhaltóra gach pioc chomh tábhachtach le leas an táirgtheora.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	leas	leas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	leas	leas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	tomhaltóra	tomhaltóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	gach	gach	DET	Det	Definite=Def	6	det	_	_
@@ -8035,7 +8035,7 @@
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	tábhachtach	tábhachtach	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 9	le	le	ADP	Simp	_	10	case	_	_
-10	leas	leas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+10	leas	leas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	táirgtheora	táirgtheoir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
@@ -8068,7 +8068,7 @@
 2	éifeachtach	éifeachtach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	focalspárálach	focalspárálach	ADJ	Adj	Gender=Masc|Number=Sing	1	amod	_	_
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nmod	_	_
-5	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+5	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 6	Mháire	Máire	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	Mhac	mac	PART	Pat	Form=Len|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
 8	an	an	PART	Pat	Definite=Def|Number=Sing|PronType=Art	6	flat:name	_	NamedEntity=Yes
@@ -8090,7 +8090,7 @@
 24	anama	anam	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	_
 25	seo	seo	DET	Det	PronType=Dem	22	det	_	_
 26	i	i	ADP	Simp	_	27	case	_	_
-27	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	18	obl	_	_
+27	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	18	obl	_	_
 28	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
 29	mná	bean	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	_
 30	óige	óg	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	29	amod	_	_
@@ -8139,7 +8139,7 @@
 20	mhaith	maith	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	19	amod	_	_
 21	acu	ag	ADP	Prep	Number=Plur|Person=3	19	obl:prep	_	_
 22	ar	ar	ADP	Simp	_	23	case	_	_
-23	ghramadach	gramadach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	_
+23	ghramadach	gramadach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	_
 24	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
 25	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	29	punct	_	_
@@ -8149,7 +8149,7 @@
 30	Oifigiúil	oifigiúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	29	amod	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	_
 32	ar	ar	ADP	Simp	_	33	case	_	_
-33	mhórchanúintí	mórchanúint	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	23	conj	_	_
+33	mhórchanúintí	mórchanúint	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	23	conj	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	2	punct	_	_
@@ -8158,7 +8158,7 @@
 # text = Is ar bhonn na hargóna sin a tháinig de Valera i gceannas ar an Sinn Féin nua 'Poblachtach' i 1917.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 2	ar	ar	ADP	Simp	_	3	case	_	_
-3	bhonn	bonn	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+3	bhonn	bonn	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	hargóna	argóint	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	3	nmod	_	_
 6	sin	sin	DET	Det	PronType=Dem	5	det	_	_
@@ -8235,7 +8235,7 @@
 7	-	-	PUNCT	Punct	_	8	punct	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	nsubj	_	_
 9	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	4	acl:relcl	_	_
-10	Stair	stair	NOUN	Noun	Gender=Fem|Number=Sing	9	obj	_	NamedEntity=Yes
+10	Stair	stair	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	9	obj	_	NamedEntity=Yes
 11	Iar-Chonnacht	Iar-Chonnachta	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	i	i	ADP	Simp	_	13	case	_	_
 13	1684	1684	NUM	Num	_	9	obl:tmod	_	SpaceAfter=No
@@ -8245,7 +8245,7 @@
 17	Inis	inis	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 18	Oírr	Oírr	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	timpeall	timpeall	ADV	Dir	_	20	advmod	_	_
-20	lár	lár	NOUN	Noun	Gender=Masc|Number=Sing	3	obl	_	_
+20	lár	lár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 21	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
 22	seachtú	seachtú	NUM	Num	NumType=Ord	23	amod	_	_
 23	aoise	aois	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
@@ -8332,12 +8332,12 @@
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	obj	_	_
 12	fhoilseofar	foilsigh	VERB	VT	Form=Len|Mood=Ind|Person=0|Tense=Fut	2	acl:relcl	_	_
 13	roimh	roimh	ADP	Simp	_	14	case	_	_
-14	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+14	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
 16	mílaoise	mílaois	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 17	)	)	PUNCT	Punct	_	12	punct	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gceannáras	ceannáras	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
+19	gceannáras	ceannáras	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	Roinne	roinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	agus	agus	CCONJ	Coord	_	26	cc	_	_
@@ -8411,7 +8411,7 @@
 42	daltaí	dalta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	39	nmod	_	_
 43	agus	agus	CCONJ	Coord	_	45	cc	_	_
 44	ar	ar	ADP	Simp	_	45	case	_	_
-45	thorthaí	toradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	52	obj	_	_
+45	thorthaí	toradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	52	obj	_	_
 46	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	47	nmod:poss	_	_
 47	dtascanna	tasc	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	45	nmod	_	_
 48	foghlama	foghlaim	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	47	nmod	_	_
@@ -8424,7 +8424,7 @@
 # sent_id = 791
 # text = Dhein Bord na gCeantar Cúng an-obair chun feirmeacha bídeacha san iarthar a chónascadh.
 1	Dhein	dein	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Bord	bord	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Bord	bord	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	NamedEntity=Yes
 4	gCeantar	ceantar	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	2	nmod	_	NamedEntity=Yes
 5	Cúng	cúng	ADJ	Adj	Case=Gen|NounType=Weak|Number=Plur	4	amod	_	NamedEntity=Yes
@@ -8464,7 +8464,7 @@
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	easaontóirí	easaontóir	NOUN	Noun	Gender=Masc|Number=Plur	12	nmod	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
-16	bpáirtí	páirtí	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
+16	bpáirtí	páirtí	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
 17	David	David	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	Trimble	Trimble	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
@@ -8497,7 +8497,7 @@
 # text = B'é cur isteach an tSeanadóra a shlánaigh é!
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	3	cop	_	SpaceAfter=No
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	cur	cur	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+3	cur	cur	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 4	isteach	isteach	ADV	Dir	_	3	advmod	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	tSeanadóra	seanadóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
@@ -8509,7 +8509,7 @@
 # sent_id = 796
 # text = I mí Mheán Fómhair 1940, bhí áit pioctha ag Séamus i Kaji-htu, chun misean nua a chur ar bun.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obl:tmod	_	_
+2	mí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	obl:tmod	_	_
 3	Mheán	Meán	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 4	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	1940	1940	NUM	Num	_	3	nmod	_	SpaceAfter=No
@@ -8614,9 +8614,9 @@
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	3	appos	_	_
 8	de	de	ADP	Simp	_	9	case	_	_
-9	choiste	coiste	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
-10	eagraithe	eagrú	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
-11	Fhéile	féile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+9	choiste	coiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+10	eagraithe	eagrú	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
+11	Fhéile	féile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	Sean-Nós	sean-nós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	Cois	cois	PROPN	Noun	Definite=Def	11	nmod	_	NamedEntity=Yes
 14	Life	Life	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
@@ -8624,7 +8624,7 @@
 16	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	2	ccomp	_	_
 17	díomá	díomá	NOUN	Noun	Gender=Fem|Number=Sing	16	nsubj	_	_
 18	ar	ar	ADP	Simp	_	19	case	_	_
-19	lucht	lucht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	_
+19	lucht	lucht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	féile	féile	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
@@ -8653,7 +8653,7 @@
 17	thagann	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Pres	14	acl:relcl	_	_
 18	isteach	isteach	ADV	Dir	_	17	advmod	_	_
 19	go	go	ADP	Simp	_	20	case	_	_
-20	Coláiste	coláiste	NOUN	Noun	Gender=Masc|Number=Sing	18	obl	_	NamedEntity=Yes
+20	Coláiste	coláiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	obl	_	NamedEntity=Yes
 21	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
 23	Droim	droim	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
@@ -8691,7 +8691,7 @@
 25	Stáit	stát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	22	obl	_	NamedEntity=Yes
 26	Aontaithe	aontaithe	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	25	amod	_	NamedEntity=Yes
 27	roimh	roimh	ADP	Simp	_	28	case	_	_
-28	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
+28	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
 30	h-aoise	aois	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Sing	28	nmod	_	_
 31	seo	seo	DET	Det	PronType=Dem	30	det	_	SpaceAfter=No
@@ -8743,7 +8743,7 @@
 19	fhaigheann	faigh	VERB	VT	Form=Len|Mood=Ind|Tense=Pres	13	acl:relcl	_	_
 20	uisce	uisce	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
 21	ó	ó	ADP	Simp	_	22	case	_	_
-22	Thaiscumar	taiscumar	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	obl	_	_
+22	Thaiscumar	taiscumar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	obl	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	Phoill	poll	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 25	Ghlais	glas	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	amod	_	NamedEntity=Yes|SpaceAfter=No
@@ -8752,7 +8752,7 @@
 # sent_id = 808
 # text = Bhíodh fíoracha na ndéithe snoite as cabhlacha crann sna doirí úd agus ina dteannta altóirí ar a ndéanadh na draoithe íobairtí.
 1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
-2	fíoracha	fíor	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	nsubj	_	_
+2	fíoracha	fíor	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	nsubj	_	_
 3	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
 4	ndéithe	dia	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
 5	snoite	snoite	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
@@ -8851,8 +8851,8 @@
 10	foirne	foireann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
 11	nó	nó	CCONJ	Coord	_	13	cc	_	_
 12	le	le	ADP	Simp	_	13	case	_	_
-13	monatóireacht	monatóireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	conj	_	_
-14	chaighdeán	caighdeán	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|NounType=Weak|Number=Plur	13	nmod	_	_
+13	monatóireacht	monatóireacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	9	conj	_	_
+14	chaighdeán	caighdeán	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|NounType=Weak|Number=Plur	13	nmod	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	tsoláthair	soláthar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
@@ -8957,13 +8957,13 @@
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	anuas	anuas	ADV	Dir	_	1	advmod	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	fhéith	féith	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+5	fhéith	féith	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	réabhlóideachais	réabhlóideachas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	troda	troid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	conj	_	_
 10	de	de	ADP	Simp	_	11	case	_	_
-11	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
+11	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 12	Skinner	Skinner	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -9014,7 +9014,7 @@
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	fhilíocht	filíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	35	obl	_	_
 45	agus	agus	CCONJ	Coord	_	46	cc	_	_
-46	éachtaí	éacht	NOUN	Noun	Gender=Masc|Number=Plur	44	conj	_	_
+46	éachtaí	éacht	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	44	conj	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
 48	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
@@ -9024,12 +9024,12 @@
 53	go	go	ADJ	Adj	_	52	amod	_	_
 54	leor	leor	NOUN	Subst	Number=Sing	53	fixed	_	_
 55	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	56	case	_	_
-56	bhealach	bealach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	58	obj	_	_
+56	bhealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	58	obj	_	_
 57	a	a	PART	Inf	PartType=Inf	58	mark	_	_
 58	throid	troid	NOUN	Noun	Form=Len|VerbForm=Inf	51	xcomp	_	_
 59	thart	thart	ADV	Dir	_	58	advmod	_	_
 60	ceithre	ceathair	NUM	Num	NumType=Card	61	nummod	_	_
-61	ceathrúna	ceathrú	NOUN	Noun	Gender=Fem|Number=Plur	58	obl	_	_
+61	ceathrúna	ceathrú	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	58	obl	_	_
 62	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	63	det	_	_
 63	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	61	nmod	_	SpaceAfter=No
 64	.	.	PUNCT	.	_	4	punct	_	_
@@ -9071,12 +9071,12 @@
 24	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	_
 25	thiar	thiar	ADV	Dir	_	24	advmod	_	_
 26	de	de	ADP	Simp	_	27	case	_	_
-27	theorainn	teorainn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	24	nmod	_	_
+27	theorainn	teorainn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	24	nmod	_	_
 28	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
 29	cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
-32	oileáin	oileán	NOUN	Noun	Gender=Masc|Number=Plur	23	conj	_	NamedEntity=Yes
+32	oileáin	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	23	conj	_	NamedEntity=Yes
 33	Árann	Árainn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	32	nmod	_	NamedEntity=Yes
 34	san	i	ADP	Art	Number=Sing|PronType=Art	35	case	_	_
 35	áireamh	áireamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	SpaceAfter=No
@@ -9099,7 +9099,7 @@
 # text = (ii) I gcás na bliana 1999-2000 nó aon bhliana measúnachta dá éis, féadfaidh an tArd-Bhailitheoir, in aon chás áirithe, d'fhonn íoc réamhchánach de réir an fho-ailt seo a éascú, aontú líon na dtráthchodanna comhionanna míosúla a bheidh le bailiú i rith bliana a athrú nó, tar éis tráthchuid amháin nó níos mó a bheith íoctha sa bhliain sin, aontú le méadú nó laghdú ar an méid a bheidh le bailiú i dtráthchodanna dá éis sin sa bhliain sin; ach ní dhéileálfar le duine inmhuirearaithe mar dhuine a mbeidh méid réamhchánach íoctha aige nó aici de réir an fho-ailt seo mura rud é - (I) nach lú ná 10 líon na dtráthchodanna míosúla a bheidh íoctha ag an duine sin sa bhliain mheasúnachta, agus (II) go ndéantar méid nach lú ná 70 faoin gcéad de mhéid na réamhchánach is iníoctha ag an duine sin don bhliain sin a íoc i dtráthchodanna ar nó roimh an 31ú lá de Nollaig sa bhliain sin.
 1	(ii)	(ii)	NUM	Item	_	14	list	_	_
 2	I	I	ADP	Simp	_	3	case	_	_
-3	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	14	obl	_	_
+3	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	obl	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	bliana	bliain	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	1999-2000	1999-2000	NUM	Num	_	5	nmod	_	_
@@ -9131,8 +9131,8 @@
 32	a	a	PART	Inf	PartType=Inf	33	mark	_	_
 33	éascú	éascú	NOUN	Noun	VerbForm=Inf	14	xcomp	_	SpaceAfter=No
 34	,	,	PUNCT	Punct	_	35	punct	_	_
-35	aontú	aontú	NOUN	Noun	VerbForm=Inf	33	obj	_	_
-36	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	nmod	_	_
+35	aontú	aontú	NOUN	Noun	Definite=Def|VerbForm=Inf	33	obj	_	_
+36	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	35	nmod	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
 38	dtráthchodanna	tráthchuid	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	36	nmod	_	_
 39	comhionanna	comhionann	ADJ	Adj	NounType=Strong|Number=Plur	38	amod	_	_
@@ -9213,7 +9213,7 @@
 114	lú	beag	ADJ	Adj	Degree=Cmp,Sup	14	parataxis	_	_
 115	ná	ná	CCONJ	Coord	_	117	cc	_	_
 116	10	10	NUM	Num	_	117	nummod	_	_
-117	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	114	conj	_	_
+117	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	114	conj	_	_
 118	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	119	det	_	_
 119	dtráthchodanna	tráthchuid	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	117	nmod	_	_
 120	míosúla	míosúil	ADJ	Adj	NounType=NotSlender|Number=Plur	119	amod	_	_
@@ -9240,7 +9240,7 @@
 141	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	142	case	_	_
 142	gcéad	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	136	nmod	_	_
 143	de	de	ADP	Simp	_	144	case	_	_
-144	mhéid	méid	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	142	nmod	_	_
+144	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	142	nmod	_	_
 145	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	146	det	_	_
 146	réamhchánach	réamhcháin	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	144	nmod	_	_
 147	is	is	PART	Sup	PartType=Sup	148	mark:prt	_	_
@@ -9399,7 +9399,7 @@
 7	prátaí	práta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	2	obl	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
-10	formhór	formhór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
+10	formhór	formhór	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 11	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	10	amod	_	_
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
 13	dtornapaí	tornapa	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	10	nmod	_	_
@@ -9445,7 +9445,7 @@
 21	chuadar	téigh	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=3|Tense=Past	1	parataxis	_	_
 22	timpeall	timpeall	ADV	Dir	_	21	advmod	_	_
 23	ag	ag	ADP	Simp	_	24	case	_	_
-24	tógaint	tógáil	NOUN	Noun	Gender=Fem|Number=Sing	21	xcomp	_	_
+24	tógaint	tógáil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	21	xcomp	_	_
 25	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	26	nmod:poss	_	_
 26	seoltaí	seol	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	30	punct	_	_
@@ -9514,14 +9514,14 @@
 26	ag	ag	ADP	Simp	_	27	case	_	_
 27	teannadh	teannadh	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 28	le	le	ADP	Simp	_	29	case	_	_
-29	doras	doras	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	nmod	_	_
+29	doras	doras	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	tí	teach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	a	a	PART	Vb	PartType=Vb|PronType=Rel	33	nsubj	_	_
 33	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	29	acl:relcl	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
-35	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	obl	_	_
-36	dhoras	doras	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	_
+35	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	_
+36	dhoras	doras	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	_
 37	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
 38	agaird	agard	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 39	.	.	PUNCT	.	_	9	punct	_	_
@@ -9538,7 +9538,7 @@
 8	chomh	chomh	ADV	Its	_	9	advmod	_	_
 9	fada	fada	ADJ	Adj	Degree=Pos	2	advmod	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
-11	Cuas	cuas	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	NamedEntity=Yes
+11	Cuas	cuas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	NamedEntity=Yes
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	Naoi	naoi	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	_	_
@@ -9562,7 +9562,7 @@
 15	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	2	conj	_	_
 16	muid	muid	PRON	Pers	Number=Plur|Person=1	15	nsubj	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
-18	fiosrú	fiosrú	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
+18	fiosrú	fiosrú	NOUN	Noun	Definite=Def|VerbForm=Vnoun	15	xcomp	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	_
 21	leis	le	ADP	Simp	_	23	case	_	_
@@ -9579,7 +9579,7 @@
 5	buanaithe	buanaithe	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 6	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+8	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 9	Mháirtín	Máirtín	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	Uí	uí	PART	Pat	PartType=Pat	9	flat:name	_	NamedEntity=Yes
 11	Mhéalóid	Méalóid	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes
@@ -9615,8 +9615,8 @@
 21	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	18	nsubj	_	_
 22	dá	dá	SCONJ	Subord	_	23	mark	_	_
 23	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	18	advcl	_	_
-24	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	nsubj	_	_
-25	Bhráthar	bráthair	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
+24	beirt	beirt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	nsubj	_	_
+25	Bhráthar	bráthair	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
 26	Saidhclaps	Saidhclaps	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 27	i	i	ADP	Simp	_	28	case	_	_
 28	bprobhinse	proibhinse	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing|Typo=Yes	23	obl	_	_
@@ -9709,7 +9709,7 @@
 
 # sent_id = 840
 # text = Tuaisceart na Mór-Roinne ón bhFrainc soir go dtí an Áise.
-1	Tuaisceart	tuaisceart	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Tuaisceart	tuaisceart	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	NamedEntity=Yes
 3	Mór-Roinne	Mór-Roinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	ón	ó	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
@@ -9738,7 +9738,7 @@
 13	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	advcl	_	_
 14	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	15	mark:prt	_	_
 15	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	13	acl:relcl	_	_
-16	ceird	ceird	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nsubj	_	_
+16	ceird	ceird	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nsubj	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	ionramhálaí	ionramhálaí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 19	ná	ná	CCONJ	Coord	_	21	cc	_	_
@@ -9770,7 +9770,7 @@
 17	ansiúd	ansiúd	ADV	Loc	_	15	conj	_	_
 18	scríofa	scríofa	ADJ	Adj	VerbForm=Part	14	amod	_	_
 19	faoi	faoi	ADP	Simp	_	20	case	_	_
-20	scáth	scáth	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	obl	_	_
+20	scáth	scáth	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	amhrais	amhras	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	;	;	PUNCT	Punct	_	24	punct	_	_
@@ -9814,7 +9814,7 @@
 3	siad	siad	PRON	Pers	Number=Plur|Person=3	2	nsubj	_	_
 4	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	5	nmod:poss	_	_
 5	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obj	_	_
-6	airgid	airgead	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
+6	airgid	airgead	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 7	ballraíochta	ballraíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
 8	-	-	PUNCT	Punct	_	9	punct	_	_
 9	Euro	Euro	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -9842,13 +9842,13 @@
 2	ball	ball	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 3	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
-5	Rúnaíocht	rúnaíocht	NOUN	Noun	Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
-6	Institiúid	institiúid	NOUN	Noun	Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+5	Rúnaíocht	rúnaíocht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
+6	Institiúid	institiúid	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	NamedEntity=Yes
 8	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	27	27	NUM	Num	_	5	nmod	_	_
-11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	Phiarsaigh	Piarsach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
@@ -9941,7 +9941,7 @@
 2	ansin	ansin	ADV	Loc	_	1	advmod	_	_
 3	go	go	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
 4	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
-5	beairic	beairic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
+5	beairic	beairic	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
 7	bpíléar	píléar	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	nmod	_	_
 8	dúnta	dúnta	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	SpaceAfter=No
@@ -10014,7 +10014,7 @@
 4	ó	ó	ADP	Simp	_	5	case	_	_
 5	choinníoll	coinníoll	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	de	de	ADP	Simp	_	7	case	_	_
-7	Chlárlann	clárlann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+7	Chlárlann	clárlann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	NamedEntity=Yes
 9	Talún	talamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 10	nach	nach	PART	Vb	PartType=Cmpl	11	mark:prt	_	_
@@ -10111,7 +10111,7 @@
 17	le	le	ADP	Simp	_	18	case	_	_
 18	páiste	páiste	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
 19	i	i	ADP	Simp	_	20	case	_	_
-20	gcontae	contae	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	18	nmod	_	_
+20	gcontae	contae	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	18	nmod	_	_
 21	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
 23	mar	mar	ADP	Simp	_	24	case	_	_
@@ -10144,7 +10144,7 @@
 3	sa	i	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
 4	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
-6	mheath	meath	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	mheath	meath	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	chreidimh	creideamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 9	:	:	PUNCT	Punct	_	10	punct	_	_
@@ -10236,7 +10236,7 @@
 32	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	31	nsubj	_	_
 33	dho	do	ADP	Simp	Form=Len|Gender=Fem|Number=Sing|Person=3|Typo=Yes	31	obl:prep	_	_
 34	i	i	ADP	Simp	_	35	case	_	_
-35	mbarra	barra	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
+35	mbarra	barra	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
 36	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	37	nmod:poss	_	_
 37	shróna	srón	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
@@ -10246,7 +10246,7 @@
 1	Níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	glacadh	glacadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
-4	formhór	formhór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+4	formhór	formhór	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 7	náisiúnaigh	náisiúnach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -10283,7 +10283,7 @@
 14	Ard	ard	NOUN	Noun	Case=NomAcc|Gender=Masc	12	conj	_	NamedEntity=Yes
 15	Leataoibh	leataobh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
-17	Ard	ard	NOUN	Noun	Case=NomAcc|Gender=Masc	12	conj	_	NamedEntity=Yes
+17	Ard	ard	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc	12	conj	_	NamedEntity=Yes
 18	Bhaile	Baile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	NamedEntity=Yes
 20	nÁith	áith	NOUN	Noun	Definite=Def|Form=Ecl	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -10296,7 +10296,7 @@
 3	as	as	ADP	Simp	_	4	case	_	_
 4	insileadh	insileadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 5	nó	nó	CCONJ	Coord	_	6	cc	_	_
-6	síoróip	síoróip	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	conj	_	_
+6	síoróip	síoróip	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	conj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	mogóirí	mogóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	6	nmod	_	_
 9	chun	chun	ADP	Simp	_	10	case	_	_
@@ -10314,7 +10314,7 @@
 2	imigh	imigh	VERB	VI	Mood=Ind|Tense=Past	0	root	_	_
 3	Bríd	Bríd	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	NamedEntity=Yes
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	NamedEntity=Yes
-5	mBróg	bróg	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	3	nmod	_	NamedEntity=Yes
+5	mBróg	bróg	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	3	nmod	_	NamedEntity=Yes
 6	in	i	ADP	Simp	_	2	obl:tmod	_	_
 7	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	fixed	_	_
 8	trátha	tráth	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	fixed	_	_
@@ -10343,8 +10343,8 @@
 31	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
 32	botháin	bothán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	obj	_	_
 33	ag	ag	ADP	Simp	_	34	case	_	_
-34	cúl	cúl	NOUN	Noun	Gender=Masc|Number=Sing	22	obl	_	_
-35	halla	halla	NOUN	Noun	Gender=Masc|Number=Sing	34	nmod	_	_
+34	cúl	cúl	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	obl	_	_
+35	halla	halla	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
 37	bhaile	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
@@ -10364,7 +10364,7 @@
 11	ar	ar	ADP	Simp	_	13	case	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	ghnóthaigh	gnóthaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
-14	gradam	gradam	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
+14	gradam	gradam	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
 15	Grammy	Grammy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	le	le	ADP	Simp	_	17	case	_	_
 17	déanaí	déanach	ADJ	Adj	Degree=Cmp,Sup	13	obl:tmod	_	SpaceAfter=No
@@ -10463,7 +10463,7 @@
 
 # sent_id = 872
 # text = Cath Bhéal Átha na Muice Bhí duine de mhuintir Uí Chorrabháin, an Muilteoir Rua, ar na mílte a d'fhulaing an díbirt a rinneadh ar chaitlicigh Ard Macha idir 1780 agus 1795.
-1	Cath	cath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Cath	cath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
@@ -10490,8 +10490,8 @@
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	obj	_	_
 26	rinneadh	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Past	24	acl:relcl	_	_
 27	ar	ar	ADP	Simp	_	28	case	_	_
-28	chaitlicigh	caitliceach	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	26	obl	_	_
-29	Ard	ard	NOUN	Noun	Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
+28	chaitlicigh	caitliceach	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl	_	_
+29	Ard	ard	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
 30	Macha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	29	nmod	_	NamedEntity=Yes
 31	idir	idir	ADP	Simp	_	32	case	_	_
 32	1780	1780	NUM	Num	_	26	obl:tmod	_	_
@@ -10525,7 +10525,7 @@
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	nsubj	_	_
 23	tharraingeodh	tarraing	VERB	VTI	Form=Len|Mood=Cnd	16	acl:relcl	_	_
 24	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	23	obl:prep	_	_
-25	bunadh	bunadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	obj	_	_
+25	bunadh	bunadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	obj	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
 27	tí	teach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	_
 28	agus	agus	CCONJ	Coord	_	38	cc	_	SpaceAfter=No
@@ -10555,7 +10555,7 @@
 3	go	go	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
 4	gcuirfí	cuir	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	2	csubj:cop	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
-6	chumas	cumas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
+6	chumas	cumas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	pháiste	páiste	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	-	-	PUNCT	Punct	_	10	punct	_	_
@@ -10661,7 +10661,7 @@
 4	anois	anois	ADV	Gn	_	1	advmod	_	_
 5	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	7	cop	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	bPáirc	páirc	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	1	ccomp	_	NamedEntity=Yes
+7	bPáirc	páirc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	ccomp	_	NamedEntity=Yes
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	NamedEntity=Yes
 9	Chrócaigh	Crócach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 10	Dé	Dé	PROPN	Subst	Definite=Def	7	obl:tmod	_	NamedEntity=Yes
@@ -10684,7 +10684,7 @@
 9	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	obl:prep	_	_
 10	a	a	PART	Inf	PartType=Inf	11	mark:prt	_	_
 11	dhul	dul	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
-12	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
+12	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 13	Chondae	contae	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	NamedEntity=Yes
 15	Chláir	Clár	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -10694,7 +10694,7 @@
 # text = 'Bhí monabhar na beirte chuici aníos ón seomra.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-3	monabhar	monabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+3	monabhar	monabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	beirte	beirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	chuici	chuig	ADP	Prep	Gender=Fem|Number=Sing|Person=3	2	obl:prep	_	_
@@ -10710,8 +10710,8 @@
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
 4	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	gclós	clós	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
-7	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
+6	gclós	clós	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+7	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 8	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	nmod	_	_
 9	-	-	PUNCT	Punct	_	10	punct	_	_
 10	níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
@@ -10719,9 +10719,9 @@
 12	chompánach	compánach	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 13	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	10	obl:prep	_	_
 14	ach	ach	SCONJ	Subord	_	15	mark:prt	_	_
-15	cearc	cearc	NOUN	Noun	Gender=Fem|Number=Sing	10	nsubj	_	_
+15	cearc	cearc	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nsubj	_	_
 16	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	amod	_	_
-17	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
+17	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
 18	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10767,7 +10767,7 @@
 3	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	case	_	_
 4	suí	suí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
-6	fhiacail	fiacail	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+6	fhiacail	fiacail	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	mbeann	beann	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	6	nmod	_	_
 9	suas	suas	ADV	Dir	_	4	advmod	_	_
@@ -10857,11 +10857,11 @@
 19	Giolla	Giolla	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 20	Riabhaigh	Riabhaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	Easpag	easpag	NOUN	Noun	Gender=Masc|Number=Sing	16	conj	_	_
+22	Easpag	easpag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 23	Dhroim	droim	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 24	Mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	amod	_	NamedEntity=Yes|SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Ardeaspag	ardeaspag	NOUN	Noun	Gender=Masc|Number=Sing	16	conj	_	_
+26	Ardeaspag	ardeaspag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 27	Ard	Ard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
 28	Mhacha	Mhacha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
@@ -11025,7 +11025,7 @@
 17	Uí	uí	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
 18	Dhrisceoil	Drisceoil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	as	as	ADP	Simp	_	20	case	_	_
-20	Béal	béal	NOUN	Noun	Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
+20	Béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
 21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	NamedEntity=Yes
 23	Ghaorthaigh	Gaorthach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -11055,7 +11055,7 @@
 47	Ní	ní	PART	Pat	PartType=Pat	46	flat:name	_	NamedEntity=Yes
 48	Chéilleachair	Céilleachar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	flat:name	_	NamedEntity=Yes
 49	as	as	ADP	Simp	_	50	case	_	_
-50	Raidió	raidió	NOUN	Noun	Gender=Masc|Number=Sing	46	nmod	_	NamedEntity=Yes
+50	Raidió	raidió	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	NamedEntity=Yes
 51	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	52	det	_	_
 52	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	50	nmod	_	NamedEntity=Yes|SpaceAfter=No
 53	.	.	PUNCT	.	_	1	punct	_	_
@@ -11103,14 +11103,14 @@
 19	Liam	Liam	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
 20	Bhid	Bhid	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	17	appos	_	_
+22	fear	fear	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	bhearna	bearna	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	22	nmod	_	_
 25	mhíl	míol	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	compound	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	obj	_	_
 27	luaitear	luaigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	22	acl:relcl	_	_
 28	i	i	ADP	Simp	_	29	case	_	_
-29	dteideal	teideal	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
+29	dteideal	teideal	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
@@ -11154,7 +11154,7 @@
 19	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	20	nmod:poss	_	_
 20	gheallúint	geallúint	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
 21	i	i	ADP	Simp	_	22	case	_	_
-22	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
+22	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	oileáin	oileán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	_
 25	úd	úd	DET	Det	PronType=Dem	24	det	_	_
@@ -11218,7 +11218,7 @@
 43	sa	i	ADP	Art	Number=Sing|PronType=Art	44	case	_	_
 44	Bhainc	banc	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
 45	de	de	ADP	Simp	_	46	case	_	_
-46	los	los	NOUN	Noun	Gender=Masc|Number=Sing	40	obl	_	_
+46	los	los	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	40	obl	_	_
 47	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	48	nmod:poss	_	_
 48	bhfaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	;	;	PUNCT	Punct	_	50	punct	_	_
@@ -11252,7 +11252,7 @@
 4	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 5	cruthaitheóir	cruthaitheoir	NOUN	Noun	Gender=Masc|Number=Sing	4	nmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
-7	cosantóir	cosantóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	conj	_	_
+7	cosantóir	cosantóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	conj	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	beatha	beatha	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
@@ -11260,7 +11260,7 @@
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nsubj	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	ceartlár	ceartlár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	_
+15	ceartlár	ceartlár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	appos	_	_
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	cruinne	cruinne	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
@@ -11276,7 +11276,7 @@
 4	chorraigh	corraigh	VERB	VTI	Form=Len|Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
 5	a	a	NOUN	Subst	Number=Sing	4	advmod	_	_
 6	thuilleadh	tuilleadh	NOUN	Subst	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	fixed	_	_
-7	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obl	_	_
+7	linn	linn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	tosta	tost	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 10	Ach	ach	SCONJ	Subord	_	11	mark	_	_

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -9,12 +9,12 @@
 7	mar	mar	SCONJ	Subord	_	8	mark	_	_
 8	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	5	advcl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	cur	cur	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	_
+10	cur	cur	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 11	chuige	chuig	ADP	Prep	Gender=Masc|Number=Sing|Person=3	10	fixed	_	_
 12	cumarsáideach	cumarsáideach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	10	amod	_	_
 13	seo	seo	DET	Det	PronType=Dem	10	det	_	_
 14	sa	i	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	Ghaelscoil	Gaelscoil	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	8	obl	_	_
+15	Ghaelscoil	Gaelscoil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	8	obl	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
 17	dtaca	taca	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
 18	leis	le	ADP	Simp	_	20	case	_	_
@@ -35,7 +35,7 @@
 4	mé	mé	PRON	Pers	Number=Sing|Person=1	3	nsubj	_	_
 5	buartha	buartha	ADJ	Adj	Degree=Pos	3	xcomp:pred	_	_
 6	fán	faoi	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	trioblóid	trioblóid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obl	_	_
+7	trioblóid	trioblóid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	obl	_	_
 8	uilig	uile	DET	Det	_	7	det	_	_
 9	ach	ach	SCONJ	Subord	_	10	mark	_	_
 10	tabhair	tabhair	VERB	VTI	Mood=Imp|Number=Sing|Person=2	3	advcl	_	_
@@ -53,7 +53,7 @@
 22	,	,	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
 23	'	'	PUNCT	Punct	_	3	punct	_	_
 24	arsa	arsa	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
-25	Peadar	Peadar	PROPN	Noun	Gender=Masc|Number=Sing	24	nsubj	_	SpaceAfter=No
+25	Peadar	Peadar	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	24	punct	_	_
 
 # sent_id = 457
@@ -81,7 +81,7 @@
 14	chearnaigh	cearnach	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	13	amod	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	13	acl:relcl	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
-17	bhinn	binn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	obl	_	_
+17	bhinn	binn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	obl	_	_
 18	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	amod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	4	punct	_	_
 
@@ -102,7 +102,7 @@
 13	fiche	fiche	NUM	Num	NumType=Card	14	nummod	_	_
 14	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obl:tmod	_	_
 15	den	de	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
+16	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 460
@@ -127,16 +127,16 @@
 # text = Ba é Bryan McFadden ón bPopghrúpa 'Westlife' agus Kerry Katona, cailín a bhíodh mar amhranaí sa ghrúpa 'Atomic Kitten', a bhí ag pósadh.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	Bryan	Bryan	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-4	McFadden	McFadden	PROPN	Noun	Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
+3	Bryan	Bryan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+4	McFadden	McFadden	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 5	ón	ó	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	bPopghrúpa	popghrúpa	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	3	nmod	_	_
+6	bPopghrúpa	popghrúpa	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	nmod	_	_
 7	'	'	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
-8	Westlife	Westlife	PROPN	Noun	Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
+8	Westlife	Westlife	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
 9	'	'	PUNCT	Punct	_	8	punct	_	_
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
-11	Kerry	Kerry	PROPN	Noun	Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
-12	Katona	Katona	PROPN	Noun	Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+11	Kerry	Kerry	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
+12	Katona	Katona	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	cailín	cailín	NOUN	Noun	Gender=Masc|Number=Sing	11	appos	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
@@ -144,10 +144,10 @@
 17	mar	mar	ADP	Simp	_	18	case	_	_
 18	amhranaí	amhránaí	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	ghrúpa	grúpa	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+20	ghrúpa	grúpa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
-22	Atomic	Atomic	PROPN	Noun	Gender=Masc|Number=Sing	20	flat	_	_
-23	Kitten	Kitten	PROPN	Noun	Gender=Masc|Number=Sing	22	flat:foreign	_	SpaceAfter=No
+22	Atomic	Atomic	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat	_	_
+23	Kitten	Kitten	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	flat:foreign	_	SpaceAfter=No
 24	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	mark:prt	_	_
@@ -166,7 +166,7 @@
 6	'	'	PUNCT	Punct	_	2	punct	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	mark:prt	_	_
 8	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-9	Tom	Tom	PROPN	Noun	Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
+9	Tom	Tom	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 463
@@ -195,7 +195,7 @@
 9	baistithe	baistithe	ADJ	Adj	VerbForm=Part	8	xcomp:pred	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	8	obl	_	_
+12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	8	obl	_	_
 13	is	is	PART	Sup	PartType=Sup	14	mark:prt	_	_
 14	faide	fada	ADJ	Adj	Degree=Cmp,Sup	12	amod	_	_
 15	thiar	thiar	ADV	Dir	_	14	advmod	_	_
@@ -203,7 +203,7 @@
 17	,	,	PUNCT	Punct	_	7	punct	_	_
 18	ná	ná	SCONJ	Subord	_	20	mark:prt	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	Aill	aill	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
+20	Aill	aill	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	20	punct	_	_
 
 # sent_id = 465
@@ -237,7 +237,7 @@
 4	i	i	ADP	Simp	_	5	case	_	_
 5	gcónaí	cónaí	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 6	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	7	case	_	_
-7	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	xcomp:pred	_	_
+7	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	xcomp:pred	_	_
 8	lárnach	lárnach	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	7	amod	_	_
 9	de	de	ADP	Simp	_	10	case	_	_
 10	shaol	saol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -254,7 +254,7 @@
 # text = Muintir na Fraince bhí an-tóir go deo acu orthu bhí sé ráite, ach níorbh aon iontas é sin, bhí an-tóir ag na Francaigh ar chuile shórt, ar loscáin lathaí, ar phortáin agus ar ghailléisc bhréana.
 1	Muintir	muintir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
 2	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-3	Fraince	Frainc	PROPN	Noun	Case=Gen|Gender=Fem	1	nmod	_	_
+3	Fraince	Frainc	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	1	nmod	_	_
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 5	an-tóir	an-tóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	go	go	ADP	Simp	_	4	advmod	_	_
@@ -321,17 +321,17 @@
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
 9	dá	dó	NUM	Num	Definite=Def|NumType=Card	10	nummod	_	_
-10	chogadh	cogadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
+10	chogadh	cogadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
 11	dhomhanda	domhanda	ADJ	Adj	Form=Len|Gender=Masc|Number=Sing	10	amod	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	obl	_	_
 13	d'	do	PART	Vb	PartType=Vb	14	mark:prt	_	SpaceAfter=No
 14	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	acl:relcl	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	lorg	lorg	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
+16	lorg	lorg	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
 17	fuilteach	fuilteach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	16	amod	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-20	mílte	míle	NOUN	Noun	Gender=Masc|Number=Plur	14	obl	_	_
+20	mílte	míle	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	14	obl	_	_
 21	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	nsubj	_	_
 22	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
 23	chun	chun	ADP	Simp	_	24	case	_	_
@@ -341,13 +341,13 @@
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	áir	ár	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
-30	Eoraip	Eoraip	PROPN	Noun	Gender=Fem|Number=Sing	22	obl	_	_
+30	Eoraip	Eoraip	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	22	obl	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
 32	níos	níos	PART	Cmp	PartType=Comp	33	mark:prt	_	_
 33	mó	mór	ADJ	Adj	Degree=Cmp,Sup	34	amod	_	_
 34	faide	fada	ADJ	Adj	Degree=Cmp,Sup	36	amod	_	_
 35	ón	ó	ADP	Art	Number=Sing|PronType=Art	36	case	_	_
-36	bhaile	baile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	26	conj	_	SpaceAfter=No
+36	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	conj	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 471
@@ -375,7 +375,7 @@
 21	'	'	PUNCT	Punct	_	19	punct	_	_
 22	a	a	PART	Inf	PartType=Inf	23	mark	_	_
 23	phéinteáil	péinteáil	NOUN	Noun	Form=Len|VerbForm=Inf	9	xcomp	_	_
-24	Jack	Jack	PROPN	Noun	_	23	nsubj	_	SpaceAfter=No
+24	Jack	Jack	PROPN	Noun	Definite=Def	23	nsubj	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 472
@@ -392,21 +392,21 @@
 10	rinne	déan	VERB	PastInd	Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
-13	buaiceacha	buaic	NOUN	Noun	Gender=Fem|Number=Plur	10	obj	_	SpaceAfter=No
+13	buaiceacha	buaic	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	10	obj	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 473
 # text = Dé Luan i gceantar poist Dhoirí Beaga i dTír Chonaill bhí an chuma ar an scéal nach raibh aon ghéarchéim ann.
-1	Dé	Dé	PROPN	Noun	Gender=Masc|Number=Sing	11	obl:tmod	_	NamedEntity=Yes
-2	Luan	Luan	PROPN	Noun	Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+1	Dé	Dé	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl:tmod	_	NamedEntity=Yes
+2	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	i	i	ADP	Simp	_	4	case	_	_
 4	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 5	poist	post	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
-6	Dhoirí	Doirí	PROPN	Noun	Form=Len|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
+6	Dhoirí	Doirí	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
 7	Beaga	beag	ADJ	Adj	NounType=NotSlender|Number=Plur	6	amod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
 9	dTír	tír	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
-10	Chonaill	Conall	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
+10	Chonaill	Conall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	chuma	cuma	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nsubj	_	_
@@ -428,7 +428,7 @@
 4	1955	1955	NUM	Num	_	3	nmod	_	_
 5	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	7	cop	_	_
 6	ea	ea	PRON	Pers	Number=Sing|Person=3	7	nmod	_	_
-7	Moloney	Moloney	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
+7	Moloney	Moloney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 475
@@ -471,15 +471,15 @@
 20	coirp	corp	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
 21	isteach	isteach	ADV	Dir	_	20	advmod	_	_
 22	sa	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	bhfarraige	farraige	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
+23	bhfarraige	farraige	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	beannacht	beannacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	parataxis	_	_
-26	Dé	Dia	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
+26	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	_
 27	lena	le	ADP	Poss	Number=Plur|Person=3|Poss=Yes	28	case	_	_
-28	n-anamnacha	anam	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
+28	n-anamnacha	anam	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	31	det	_	_
-31	créatúirí	créatúr	NOUN	Noun	Gender=Masc|Number=Plur	28	nmod	_	_
+31	créatúirí	créatúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	28	nmod	_	_
 32	bochta	bocht	ADJ	Adj	NounType=NotSlender|Number=Plur	31	amod	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -515,7 +515,7 @@
 # text = Dar le Hawkins ní raibh údarás ach aige féin amháin agus a oifig a leithéidí d'armais sochraide a cheadú.
 1	Dar	dar	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	le	le	ADP	Simp	_	3	case	_	_
-3	Hawkins	Hawkins	PROPN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+3	Hawkins	Hawkins	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 4	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	5	advmod	_	_
 5	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 6	údarás	údarás	NOUN	Noun	Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -525,9 +525,9 @@
 10	amháin	amháin	ADJ	Adj	Degree=Pos	9	amod	_	_
 11	agus	agus	CCONJ	Coord	_	13	mark	_	_
 12	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	13	nmod:poss	_	_
-13	oifig	oifig	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	conj	_	_
+13	oifig	oifig	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	conj	_	_
 14	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	15	nmod:poss	_	_
-15	leithéidí	leithéid	NOUN	Noun	Gender=Fem|Number=Plur	17	nmod	_	_
+15	leithéidí	leithéid	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	17	nmod	_	_
 16	d'	de	ADP	Simp	_	20	case	_	SpaceAfter=No
 17	armais	armas	NOUN	Noun	Gender=Masc|Number=Plur	20	obj	_	_
 18	sochraide	sochraid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
@@ -542,28 +542,28 @@
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Fearghas	Fearghas	PROPN	Noun	Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
+6	Fearghas	Fearghas	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 7	Ó	ó	PART	Pat	PartType=Pat	6	flat:name	_	NamedEntity=Yes
-8	hÍr	Ír	PROPN	Noun	Form=HPref|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+8	hÍr	Ír	PROPN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
-10	Brian	Brian	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
+10	Brian	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
 11	Ó	ó	PART	Pat	PartType=Pat	10	flat:name	_	NamedEntity=Yes
-12	Mórdha	Mórdha	PROPN	Noun	Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+12	Mórdha	Mórdha	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	Éamann	Éamann	PROPN	Noun	Gender=Masc|Number=Sing	6	conj	_	_
+14	Éamann	Éamann	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 15	Mór	Mór	ADJ	Adj	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
-17	Mary	Mary	PROPN	Noun	Gender=Fem|Number=Sing	6	conj	_	NamedEntity=Yes
-18	Ryan	Ryan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes
+17	Mary	Mary	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	6	conj	_	NamedEntity=Yes
+18	Ryan	Ryan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes
 19	as	as	ADP	Simp	_	20	case	_	_
-20	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
-21	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
-22	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+22	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
-24	Deirdre	Deirdre	PROPN	Noun	Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
+24	Deirdre	Deirdre	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
 25	Nic	nic	PART	Pat	PartType=Pat	24	flat:name	_	NamedEntity=Yes
-26	Con	Con	PROPN	Noun	Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
-27	Uisce	Uisce	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+26	Con	Con	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
+27	Uisce	Uisce	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	30	punct	_	_
 29	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	30	cop	_	SpaceAfter=No
 30	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	2	parataxis	_	SpaceAfter=No
@@ -579,7 +579,7 @@
 40	i	i	ADP	Simp	_	41	case	_	_
 41	spéir	spéir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	34	nmod	_	_
 42	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	43	det	_	_
-43	Tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	41	nmod	_	SpaceAfter=No
+43	Tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	41	nmod	_	SpaceAfter=No
 44	,	,	PUNCT	Punct	_	45	punct	_	_
 45	chan	is	AUX	Cop	Dialect=Ulster|Form=Len|VerbForm=Cop	46	cop	_	_
 46	ea	ea	PRON	Pers	Number=Sing|Person=3	2	parataxis	_	SpaceAfter=No
@@ -592,8 +592,8 @@
 53	mar	mar	SCONJ	Subord	_	54	mark	_	_
 54	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	46	advcl	_	SpaceAfter=No
 55	,	,	PUNCT	Punct	_	56	punct	_	_
-56	Gráinne	Gráinne	PROPN	Noun	Gender=Fem|Number=Sing	54	nsubj	_	NamedEntity=Yes
-57	Holland	Holland	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	56	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+56	Gráinne	Gráinne	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	54	nsubj	_	NamedEntity=Yes
+57	Holland	Holland	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	56	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 58	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 480
@@ -614,9 +614,9 @@
 14	mar	mar	SCONJ	Subord	_	16	mark	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	obj	_	_
 16	mhíníonn	mínigh	VERB	VT	Form=Len|Mood=Ind|Tense=Pres	3	parataxis	_	_
-17	Máirtín	Máirtín	PROPN	Noun	Gender=Masc|Number=Sing	16	nsubj	_	NamedEntity=Yes
+17	Máirtín	Máirtín	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	NamedEntity=Yes
 18	Ó	ó	PART	Pat	PartType=Pat	17	flat:name	_	NamedEntity=Yes
-19	Catháin	Catháin	PROPN	Noun	Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Catháin	Catháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 20	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 481
@@ -625,22 +625,22 @@
 2	hé	é	PRON	Pers	Form=HPref|Gender=Masc|Number=Sing|Person=3	0	root	_	_
 3	nach	nach	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
 4	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	csubj:cop	_	_
-5	Cois	cois	PROPN	Noun	_	4	nsubj	_	NamedEntity=Yes
-6	Fharraige	farraige	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+5	Cois	cois	PROPN	Noun	Definite=Def	4	nsubj	_	NamedEntity=Yes
+6	Fharraige	farraige	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	spéisiúil	spéisiúil	ADJ	Adj	Degree=Pos	4	xcomp:pred	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	leath	leath	NOUN	Noun	Gender=Fem|Number=Sing	4	obl	_	_
+11	leath	leath	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 12	thiar	thiar	ADV	Gn	_	11	advmod	_	_
 13	de	de	ADP	Simp	_	14	case	_	_
-14	Chonamara	Conamara	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+14	Chonamara	Conamara	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 15	Theas	theas	ADJ	Adj	Case=NomAcc|Number=Sing	14	amod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	ach	ach	SCONJ	Subord	_	18	mark	_	_
 18	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	4	advcl	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	saol	saol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nsubj	_	_
+20	saol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 21	ró-ghearr	róghearr	ADJ	Adj	Degree=Pos	18	xcomp:pred	_	SpaceAfter=No
 22	!	!	PUNCT	!	_	2	punct	_	_
 
@@ -651,11 +651,11 @@
 3	léinn	léann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	compound	_	_
 4	curtha	curtha	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	go	go	ADP	Simp	_	6	case	_	_
-6	Meiriceá	Meiriceá	PROPN	Noun	Gender=Masc|Number=Sing	4	obl	_	_
+6	Meiriceá	Meiriceá	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	Foras	foras	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
-10	Mara	muir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
+10	Mara	muir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
 11	agus	agus	CCONJ	Coord	_	12	mark	_	_
 12	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	advcl	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
@@ -680,7 +680,7 @@
 # sent_id = 483
 # text = Cheannaigh Seán leabhar agus léigh sé é.
 1	Cheannaigh	ceannaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
 4	agus	agus	CCONJ	Coord	_	5	cc	_	_
 5	léigh	léigh	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
@@ -697,12 +697,12 @@
 5	ghlas	glas	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	teorainn	teorainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	cheantar	ceantar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
+8	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	4	csubj:cleft	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	feiceáil	feiceáil	NOUN	Noun	VerbForm=Inf	9	xcomp	_	_
 12	san	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	aerfótagraf	aerfótagraf	NOUN	Noun	Gender=Masc|Number=Sing	11	obl	_	_
+13	aerfótagraf	aerfótagraf	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	ghabhann	gabh	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	13	acl:relcl	_	_
 16	leis	le	ADP	Simp	_	17	case	_	_
@@ -711,11 +711,11 @@
 
 # sent_id = 485
 # text = Dé Céadaoin, 28 Bealtaine 1986.
-1	Dé	Dé	PROPN	Subst	Number=Sing	0	root	_	NamedEntity=Yes
-2	Céadaoin	Céadaoin	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes|SpaceAfter=No
+1	Dé	Dé	PROPN	Subst	Definite=Def|Number=Sing	0	root	_	NamedEntity=Yes
+2	Céadaoin	Céadaoin	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes|SpaceAfter=No
 3	,	,	PUNCT	Punct	_	4	punct	_	_
 4	28	28	NUM	Num	_	1	nmod	_	NamedEntity=Yes
-5	Bealtaine	Bealtaine	PROPN	Noun	Gender=Fem|Number=Sing	4	flat	_	NamedEntity=Yes
+5	Bealtaine	Bealtaine	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	flat	_	NamedEntity=Yes
 6	1986	1986	NUM	Num	_	4	flat	_	NamedEntity=Yes|SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -736,7 +736,7 @@
 13	sin	sin	PRON	Dem	PronType=Dem	11	obj	_	_
 14	i	i	ADP	Simp	_	16	case	_	_
 15	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	16	nmod:poss	_	_
-16	chroí	croí	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
+16	chroí	croí	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 487
@@ -755,20 +755,20 @@
 1	Amharc	amharc	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 2	géar	géar	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
-4	Dara	Dara	PROPN	Noun	Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+4	Dara	Dara	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 5	Ó	ó	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Cinnéide	Cinnéide	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+6	Cinnéide	Cinnéide	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 7	ó	ó	ADP	Simp	_	8	case	_	_
-8	Chiarraí	Chiarraí	PROPN	Noun	Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+8	Chiarraí	Chiarraí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 9	Thiar	thiar	ADV	Dir	_	8	amod	_	NamedEntity=Yes
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	Roland	Roland	PROPN	Noun	Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-12	Neher	Neher	PROPN	Noun	Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
+11	Roland	Roland	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+12	Neher	Neher	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	de	de	ADP	Simp	_	14	case	_	_
 14	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
-15	Chrócaigh	Crócach	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
-16	Chill	Cill	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
-17	Airne	Airne	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
+15	Chrócaigh	Crócach	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+16	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Airne	Airne	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	i	i	ADP	Simp	_	19	case	_	_
 19	gcluiche	cluiche	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	nmod	_	_
 20	leathcheannais	leathcheannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	_
@@ -792,7 +792,7 @@
 5	do	do	PART	Vb	PartType=Vb	6	nsubj	_	_
 6	raghadh	téigh	VERB	VTI	Mood=Cnd	3	acl:relcl	_	_
 7	á	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	case	_	_
-8	múscailt	múscailt	NOUN	Noun	VerbForm=Inf	6	xcomp	_	_
+8	múscailt	múscailt	NOUN	Noun	Definite=Def|VerbForm=Inf	6	xcomp	_	_
 9	nách	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	10	cop	_	_
 10	me	mé	PRON	Pers	Number=Sing|Person=1|Typo=Yes	1	ccomp	_	_
 11	féin	féin	PRON	Ref	Reflex=Yes	10	nmod	_	_
@@ -818,7 +818,7 @@
 31	inniu	inniu	ADV	Temp	_	26	advmod	_	_
 32	ar	ar	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	gcuma	cuma	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	28	obl	_	_
+34	gcuma	cuma	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	28	obl	_	_
 35	chéanna	céanna	ADJ	Adj	Form=Len|Number=Sing	34	amod	_	SpaceAfter=No
 36	,	,	PUNCT	Punct	_	37	punct	_	_
 37	agus	agus	CCONJ	Coord	_	39	cc	_	_
@@ -844,10 +844,10 @@
 5	;	;	PUNCT	Punct	_	6	punct	_	_
 6	ceann	ceann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	parataxis	_	_
 7	sa	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	chistin	cistin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
+8	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	tuilshoilse	tuilsolas	NOUN	Noun	Gender=Masc|Number=Plur|Typo=Yes	8	nmod	_	_
+11	tuilshoilse	tuilsolas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur|Typo=Yes	8	nmod	_	_
 12	-	-	PUNCT	Punct	_	13	punct	_	_
 13	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
@@ -861,7 +861,7 @@
 22	eile	eile	DET	Det	PronType=Dem	15	det	_	_
 23	ag	ag	ADP	Simp	_	25	case	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
-25	chúl	cúl	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
+25	chúl	cúl	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 26	;	;	PUNCT	Punct	_	27	punct	_	_
 27	ise	ise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	13	parataxis	_	_
 28	frámaithe	frámaithe	ADJ	Adj	VerbForm=Part	27	xcomp:pred	_	_
@@ -915,7 +915,7 @@
 9	Anglacánaigh	Anglacánach	NOUN	Noun	Gender=Masc|Number=Plur	4	obl	_	_
 10	as	as	ADP	Simp	_	12	case	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
-12	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nmod	_	_
+12	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 13	den	de	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
 14	domhan	domhan	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 15	:	:	PUNCT	Punct	_	16	punct	_	_
@@ -953,32 +953,32 @@
 4	maith	maith	ADJ	Adj	Degree=Pos	3	fixed	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	mark:prt	_	_
 6	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
-7	Máire	Máire	PROPN	Noun	Gender=Fem|Number=Sing	6	nsubj	_	NamedEntity=Yes
+7	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	6	nsubj	_	NamedEntity=Yes
 8	Ní	ní	PART	Pat	PartType=Pat	7	flat:name	_	NamedEntity=Yes
-9	Choilm	Colm	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
+9	Choilm	Colm	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
 10	cé	cé	SCONJ	Subord	_	12	mark	_	_
 11	nach	nach	PART	Vb	PartType=Cmpl	12	mark:prt	_	_
 12	bhfaca	feic	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	6	advcl	_	_
 13	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	12	nsubj	_	_
 14	mórán	mórán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
 15	dá	de	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	16	case	_	_
-16	muintir	muintir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
+16	muintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 497
 # text = Mo léan go mbeidh ar na Gaeil luí síos arís ina dtír féin.
 1	Mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	2	nmod:poss	_	_
-2	léan	léan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+2	léan	léan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	go	go	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
 4	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	2	ccomp	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
-7	Gaeil	Gael	PROPN	Noun	Gender=Masc|Number=Plur	4	obl	_	_
+7	Gaeil	Gael	PROPN	Noun	Definite=Def|Gender=Masc|Number=Plur	4	obl	_	_
 8	luí	luí	NOUN	Noun	VerbForm=Inf	7	xcomp:pred	_	_
 9	síos	síos	ADV	Dir	_	8	advmod	_	_
 10	arís	arís	ADV	Gn	_	8	advmod	_	_
 11	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	12	case	_	_
-12	dtír	tír	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	4	obl	_	_
+12	dtír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	4	obl	_	_
 13	féin	féin	PRON	Ref	Reflex=Yes	12	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1006,19 +1006,19 @@
 20	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	19	nsubj	_	_
 21	riamh	riamh	ADV	Gn	_	19	advmod	_	_
 22	cén	cé	PRON	Q	Number=Sing|PronType=Int	19	ccomp	_	_
-23	fáth	fáth	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nsubj	_	_
+23	fáth	fáth	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	nsubj	_	_
 24	nár	nár	PART	Vb	PartType=Cmpl|Tense=Past	25	mark:prt	_	_
 25	íoc	íoc	VERB	VTI	Mood=Ind|Tense=Past	19	ccomp	_	_
 26	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	25	nsubj	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
-28	liúntas	liúntas	NOUN	Noun	Gender=Masc|Number=Sing	25	obj	_	_
+28	liúntas	liúntas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	obj	_	_
 29	míosúil	míosúil	ADJ	Adj	Gender=Masc|Number=Sing	28	amod	_	_
 30	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	case	_	_
-31	bhean	bean	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	25	obl	_	_
+31	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	25	obl	_	_
 32	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	31	compound	_	_
 33	tríd	trí	ADP	Simp	_	35	case	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	35	det	_	_
-35	mbanc	banc	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
+35	mbanc	banc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
 36	in	i	ADP	Simp	_	37	case	_	_
 37	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	35	nmod	_	_
 38	seic	seic	NOUN	Noun	Gender=Masc|Number=Sing	40	obj	_	_
@@ -1029,7 +1029,7 @@
 43	i	i	ADP	Cmpd	PrepForm=Cmpd	46	case	_	_
 44	ndiaidh	ndiaidh	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	43	fixed	_	_
 45	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	46	nmod:poss	_	_
-46	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	40	obl	_	SpaceAfter=No
+46	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	SpaceAfter=No
 47	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 499
@@ -1038,7 +1038,7 @@
 2	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 3	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	domhain	domhan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
+5	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
 7	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	SpaceAfter=No
 8	!	!	PUNCT	!	_	2	punct	_	_
@@ -1065,7 +1065,7 @@
 # text = Ó a Rí na trua, tóg dínn an ghannchuid seo, Go mbeimis id shamhailt gach uair den Lá.
 1	Ó	ó	INTJ	Itj	_	7	discourse	_	_
 2	a	a	PART	Voc	PartType=Voc	3	case:voc	_	_
-3	Rí	rí	NOUN	Noun	Case=Voc|Gender=Masc|Number=Sing	7	vocative	_	_
+3	Rí	rí	NOUN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	7	vocative	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	trua	trua	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	3	punct	_	_
@@ -1078,11 +1078,11 @@
 13	Go	go	PART	Vb	Mood=Sub|PartType=Vb	14	mark:prt	_	_
 14	mbeimis	bí	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Plur|Person=1	7	parataxis	_	_
 15	id	i_do	ADP	Det	Number=Sing|Person=2|Poss=Yes	16	case	_	_
-16	shamhailt	samhailt	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
+16	shamhailt	samhailt	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 17	gach	gach	DET	Det	Definite=Def	18	det	_	_
-18	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	obl:tmod	_	_
+18	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	obl:tmod	_	_
 19	den	de	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
+20	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 502
@@ -1102,7 +1102,7 @@
 13	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	conj	_	_
 14	agus	agus	CCONJ	Coord	_	20	cc	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	imshaol	imshaol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	conj	_	_
+16	imshaol	imshaol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	conj	_	_
 17	nádúrtha	nádúrtha	ADJ	Adj	Degree=Pos	16	amod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	16	punct	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark:prt	_	_
@@ -1123,13 +1123,13 @@
 10	alt	alt	NOUN	Noun	Gender=Masc|Number=Sing	9	obj	_	_
 11	taighde	taighde	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	bhFrainc	Frainc	PROPN	Noun	Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
+13	bhFrainc	Frainc	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
 14	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	teideal	teideal	NOUN	Noun	Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+15	teideal	teideal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	'	'	PUNCT	Punct	_	18	punct	_	SpaceAfter=No
 18	Monsieur	Monsieur	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	15	appos	_	NamedEntity=Yes
-19	Dupont	Dupont	PROPN	Noun	Gender=Masc|Number=Sing	18	flat	_	NamedEntity=Yes|SpaceAfter=No
+19	Dupont	Dupont	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	flat	_	NamedEntity=Yes|SpaceAfter=No
 20	'	'	PUNCT	Punct	_	18	punct	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	9	punct	_	_
 
@@ -1148,27 +1148,27 @@
 1	Déantar	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	ar	ar	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	gcaoi	caoi	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+4	gcaoi	caoi	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 5	sin	sin	DET	Det	PronType=Dem	4	det	_	_
 6	den	de	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	fhéar	féar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
+7	fhéar	féar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
 8	suaithinseach	suaithinseach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	paiste	paiste	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
+10	paiste	paiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 11	slán	slán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 12	i	i	ADP	Cmpd	PrepForm=Cmpd	15	case	_	_
 13	lár	lár	ADP	Cmpd	PrepForm=Cmpd	12	fixed	_	_
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-15	ndriseacha	dris	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	1	obl	_	_
+15	ndriseacha	dris	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	1	obl	_	_
 16	agus	agus	CCONJ	Coord	_	18	cc	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	bhfiailí	fiaile	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	15	conj	_	_
+18	bhfiailí	fiaile	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	15	conj	_	_
 19	inar	i	PART	Rel	PronType=Rel	20	obl	_	_
 20	luigh	luigh	VERB	VI	Mood=Ind|Tense=Past	15	acl:relcl	_	_
 21	slán	slán	ADJ	Adj	Degree=Pos	20	amod	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 23	'	'	PUNCT	Punct	_	24	punct	_	SpaceAfter=No
-24	abhlainn	abhlann	NOUN	Noun	Gender=Fem|Number=Sing	20	obj	_	_
+24	abhlainn	abhlann	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
 25	bheannaithe	beannaithe	ADJ	Adj	Degree=Pos|Form=Len	24	amod	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	nsubj	_	_
 27	thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
@@ -1178,18 +1178,18 @@
 31	,	,	PUNCT	Punct	_	32	punct	_	_
 32	siombail	siombail	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	appos	_	_
 33	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
-34	glaineachta	glaineacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	32	nmod	_	_
+34	glaineachta	glaineacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	32	nmod	_	_
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
 36	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	37	det	_	_
 37	neamhurchóide	neamhurchóid	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	34	conj	_	_
 38	agus	agus	CCONJ	Coord	_	40	cc	_	_
 39	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	40	det	_	_
-40	bhearna	bearna	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	34	conj	_	_
+40	bhearna	bearna	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	34	conj	_	_
 41	trína	trí	PART	Rel	PronType=Rel	42	obl	_	_
 42	dtiocfar	tar	VERB	VI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	40	acl:relcl	_	_
 43	ar	ar	ADP	Simp	_	45	case	_	_
 44	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	45	det	_	_
-45	mbeatha	beatha	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	42	obl	_	_
+45	mbeatha	beatha	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	42	obl	_	_
 46	spioradálta	spioradálta	ADJ	Adj	Gender=Fem|Number=Sing	45	amod	_	_
 47	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	45	acl:relcl	_	_
 48	ionann	ionann	ADJ	Adj	Degree=Pos	47	xcomp:pred	_	_
@@ -1204,7 +1204,7 @@
 57	ar	is	AUX	Cop	Tense=Pres|VerbForm=Cop	60	cop	_	_
 58	mar	mar	ADP	Simp	_	60	case	_	_
 59	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	60	nmod:poss	_	_
-60	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	42	ccomp	_	_
+60	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	42	ccomp	_	_
 61	iad	iad	PRON	Pers	Number=Plur|Person=3	60	nsubj	_	_
 62	agus	agus	CCONJ	Coord	_	64	cc	_	_
 63	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	64	det	_	_
@@ -1213,7 +1213,7 @@
 66	de	de	ADP	Simp	_	67	case	_	_
 67	nádúr	nádúr	NOUN	Noun	Gender=Masc|Number=Sing	64	nmod	_	_
 68	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	69	det	_	_
-69	duine	duine	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	67	nmod	_	SpaceAfter=No
+69	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	67	nmod	_	SpaceAfter=No
 70	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 506
@@ -1223,7 +1223,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	Ríordánach	Ríordáin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	dán	dán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	_
+6	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	Teitheadh	teitheadh	NOUN	Noun	VerbForm=Inf	6	appos	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	10	cop	_	_
@@ -1250,7 +1250,7 @@
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
 32	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	33	case	_	_
-33	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	obl	_	SpaceAfter=No
+33	réir	réir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	26	obl	_	SpaceAfter=No
 34	:	:	PUNCT	Punct	_	36	punct	_	_
 35	Do	do	PART	Vb	PartType=Vb	36	mark:prt	_	_
 36	rugas	beir	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Past	1	parataxis	_	_
@@ -1258,7 +1258,7 @@
 38	don	do	ADP	Art	Number=Sing|PronType=Art	39	case	_	_
 39	eaglais	eaglais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	36	obl	_	_
 40	Mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	41	nmod:poss	_	_
-41	chnuasach	cnuasach	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	36	obj	_	_
+41	chnuasach	cnuasach	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	obj	_	_
 42	nuapheacaí	nuapheaca	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	41	nmod	_	SpaceAfter=No
 43	,	,	PUNCT	Punct	_	44	punct	_	_
 44	Do	do	PART	Vb	PartType=Vb	45	mark:prt	_	_
@@ -1267,7 +1267,7 @@
 47	in	i	ADP	Simp	_	48	case	_	_
 48	eagar	eagar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	obl	_	_
 49	Don	do	ADP	Art	Number=Sing|PronType=Art	50	case	_	_
-50	fhoilsitheoir	foilsitheoir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	45	obl	_	_
+50	fhoilsitheoir	foilsitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	45	obl	_	_
 51	a	a	PART	Vb	PartType=Vb|PronType=Rel	52	nsubj	_	_
 52	bhíonn	bí	VERB	PresImp	Aspect=Hab|Form=Len|Mood=Ind|Tense=Pres	50	acl:relcl	_	_
 53	Ag	ag	ADP	Simp	_	54	case	_	_
@@ -1297,7 +1297,7 @@
 3	uaisle	uasal	ADJ	Adj	Number=Plur|PartType=Voc	2	amod	_	_
 4	agus	agus	CCONJ	Coord	_	6	cc	_	_
 5	a	a	PART	Voc	PartType=Voc	6	case:voc	_	_
-6	uaisle	uasal	NOUN	Noun	Case=Voc|Gender=Masc|Number=Plur	2	conj	_	_
+6	uaisle	uasal	NOUN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Plur	2	conj	_	_
 7	go	go	PART	Ad	PartType=Ad	8	mark:prt	_	_
 8	léir	léir	ADJ	Adj	Degree=Pos	6	amod	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -1319,7 +1319,7 @@
 25	seo	seo	DET	Det	PronType=Dem	24	det	_	SpaceAfter=No
 26	...	...	PUNCT	Punct	_	27	punct	_	_
 27	dhein	dein	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	10	parataxis	_	_
-28	Bricriú	Bricriú	PROPN	Noun	Gender=Masc|Number=Sing	27	nsubj	_	_
+28	Bricriú	Bricriú	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
 29	iarracht	iarracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	27	obj	_	_
 30	bob	bob	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	32	obj	_	_
 31	a	a	PART	Inf	PartType=Inf	32	mark	_	_
@@ -1337,7 +1337,7 @@
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 2	Eaglais	Eaglais	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	Naomh	naomh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
-4	Odhran	Odhran	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
+4	Odhran	Odhran	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
 5	anseo	anseo	ADV	Loc	_	1	advmod	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	eaglais	eaglais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
@@ -1345,7 +1345,7 @@
 9	thóg	tóg	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	acl:relcl	_	_
 10	Tiarnaí	tiarna	NOUN	Noun	Gender=Masc|Number=Plur	9	nsubj	_	NamedEntity=Yes
 11	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	12	det	_	NamedEntity=Yes
-12	nEilean	eilean	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	10	nmod	_	NamedEntity=Yes
+12	nEilean	eilean	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	10	nmod	_	NamedEntity=Yes
 13	agus	agus	CCONJ	Coord	_	14	mark	_	_
 14	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	advcl	_	_
 15	deisithe	deisithe	ADJ	Adj	VerbForm=Part	14	xcomp:pred	_	_
@@ -1356,7 +1356,7 @@
 # text = Féadfar an ráiteas sin a fhorlíonadh le measúnú sonrach ar gach mór-réimse de ghníomhaíocht an Chomhphobail.
 1	Féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	ráiteas	ráiteas	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
+3	ráiteas	ráiteas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	sin	sin	DET	Det	PronType=Dem	3	det	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
 6	fhorlíonadh	forlíonadh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
@@ -1365,7 +1365,7 @@
 9	sonrach	sonrach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
-12	mór-réimse	mór-réimse	NOUN	Noun	Gender=Masc|Number=Sing	8	nmod	_	_
+12	mór-réimse	mór-réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 13	de	de	ADP	Simp	_	14	case	_	_
 14	ghníomhaíocht	gníomhaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -1406,19 +1406,19 @@
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
 7	Aire	aire	NOUN	Noun	Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
-8	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
+8	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	againn	ag	ADP	Prep	Number=Plur|Person=1	5	obl:prep	_	_
 10	anseo	anseo	ADV	Loc	_	5	advmod	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
-12	nGaillimh	Gaillimh	PROPN	Noun	Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	_
+12	nGaillimh	Gaillimh	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	nsubj	_	_
 14	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	6	acl:relcl	_	_
 15	peann	peann	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
 16	le	le	ADP	Simp	_	17	case	_	_
 17	pár	pár	NOUN	Noun	Gender=Masc|Number=Sing	14	obl	_	_
 18	-	-	PUNCT	Punct	_	19	punct	_	_
-19	Máire	Máire	PROPN	Noun	Gender=Fem|Number=Sing	5	parataxis	_	NamedEntity=Yes
-20	Geoghegan-Quinn	Geoghegan-Quinn	PROPN	Noun	Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	parataxis	_	NamedEntity=Yes
+20	Geoghegan-Quinn	Geoghegan-Quinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	23	punct	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	nsubj	_	_
 23	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	19	acl:relcl	_	_
@@ -1427,10 +1427,10 @@
 26	Diamond	Diamond	X	Foreign	Foreign=Yes	24	flat:foreign	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
 28	agus	agus	CCONJ	Coord	_	29	cc	_	_
-29	Michael	Michael	PROPN	Noun	Gender=Masc|Number=Sing	19	conj	_	NamedEntity=Yes
+29	Michael	Michael	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	conj	_	NamedEntity=Yes
 30	D.	D.	PROPN	Abr	Abbr=Yes	29	flat:name	_	NamedEntity=Yes
 31	Ó	ó	PART	Pat	PartType=Pat	29	flat:name	_	NamedEntity=Yes
-32	hUiginn	Uiginn	PROPN	Noun	Form=HPref|Gender=Masc|Number=Sing	29	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+32	hUiginn	Uiginn	PROPN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Sing	29	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 33	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 513
@@ -1455,15 +1455,15 @@
 6	freastal	freastal	NOUN	Noun	VerbForm=Vnoun	3	xcomp	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	mbunscoil	bunscoil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	3	obl	_	_
+9	mbunscoil	bunscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	3	obl	_	_
 10	nua	nua	ADJ	Adj	Degree=Pos	9	amod	_	_
 11	nuair	nuair	SCONJ	Subord	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	osclaíonn	oscail	VERB	VTI	Mood=Ind|Tense=Pres	3	advcl	_	_
 14	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	nsubj	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
-16	Meán	Meán	PROPN	Noun	Gender=Masc|Number=Sing	13	obl:tmod	_	NamedEntity=Yes
-17	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+16	Meán	Meán	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	obl:tmod	_	NamedEntity=Yes
+17	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	seo	seo	PRON	Dem	PronType=Dem	16	det	_	_
 19	chugainn	chuig	ADP	Prep	Number=Plur|Person=1	18	fixed	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	23	punct	_	_
@@ -1475,11 +1475,11 @@
 26	déag	déag	NOUN	Subst	Case=NomAcc|Number=Sing	24	nmod	_	_
 27	eile	eile	DET	Det	PronType=Dem	25	det	_	_
 28	sa	i	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
-29	scoil	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	obl	_	_
+29	scoil	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	obl	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	23	obl:tmod	_	_
 32	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	33	case	_	_
-33	dhiaidh	diaidh	NOUN	Subst	Form=Len|Number=Sing	31	nmod	_	_
+33	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	31	nmod	_	_
 34	sin	sin	PRON	Dem	PronType=Dem	33	det	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1497,19 +1497,19 @@
 10	cheoltóirí	ceoltóir	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	6	obl	_	_
 11	óga	óg	ADJ	Adj	NounType=Slender|Number=Plur	10	amod	_	_
 12	Scoil	scoil	NOUN	Noun	Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
-13	Francis	Francis	PROPN	Noun	_	12	nmod	_	NamedEntity=Yes
-14	McPeake	McPeake	PROPN	Noun	Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
+13	Francis	Francis	PROPN	Noun	Definite=Def	12	nmod	_	NamedEntity=Yes
+14	McPeake	McPeake	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	16	cc	_	_
 16	chan	can	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	6	conj	_	_
 17	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	18	det	_	_
 18	páistí	páiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	16	nsubj	_	_
 19	ón	ó	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
 20	dara	dara	NUM	Num	NumType=Ord	21	amod	_	_
-21	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	obl	_	_
+21	bliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	obl	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
 23	mbunscoil	bunscoil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	NamedEntity=Yes
 24	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	23	flat	_	NamedEntity=Yes
-25	Reachtain	Reachtain	PROPN	Noun	Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
+25	Reachtain	Reachtain	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
 26	amhrán	amhrán	NOUN	Noun	Gender=Masc|Number=Sing	16	obj	_	_
 27	breá	breá	ADJ	Adj	Gender=Masc|Number=Sing	26	amod	_	_
 28	faoi	faoi	ADP	Simp	_	29	case	_	_
@@ -1517,7 +1517,7 @@
 30	chun	chun	ADP	Simp	_	31	case	_	_
 31	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	_
 32	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
-33	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	29	nmod	_	SpaceAfter=No
+33	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	29	nmod	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 516
@@ -1525,7 +1525,7 @@
 1	Ó	ó	INTJ	Itj	_	9	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	Punct	_	1	punct	_	_
 3	a	a	PART	Voc	PartType=Voc	4	case:voc	_	_
-4	mhac	mac	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	9	vocative	_	_
+4	mhac	mac	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	vocative	_	_
 5	go	go	ADP	Simp	_	9	advmod	_	_
 6	deo	deo	NOUN	Subst	Number=Sing	5	fixed	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	5	punct	_	_
@@ -1546,20 +1546,20 @@
 22	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
 23	hoíche	oíche	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	19	nmod	_	_
 24	i	i	ADP	Simp	_	25	case	_	_
-25	Meiriceá	Meiriceá	PROPN	Noun	Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
+25	Meiriceá	Meiriceá	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	28	punct	_	_
 27	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	28	nmod:poss	_	_
-28	cholainn	colainn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	parataxis	_	_
+28	cholainn	colainn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	parataxis	_	_
 29	is	agus	CCONJ	Coord	_	31	cc	_	_
 30	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	31	nmod:poss	_	_
-31	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	conj	_	_
+31	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	conj	_	_
 32	caite	caite	ADJ	Adj	VerbForm=Part	28	xcomp:pred	_	_
 33	gan	gan	ADP	Simp	_	34	case	_	_
 34	ord	ord	NOUN	Noun	Gender=Masc|Number=Sing	28	nmod	_	_
 35	ná	ná	CCONJ	Coord	_	36	cc	_	_
 36	eagar	eagar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	conj	_	_
 37	sa	i	ADP	Art	Number=Sing|PronType=Art	38	case	_	_
-38	phuiteach	puiteach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
+38	phuiteach	puiteach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 39	,	,	PUNCT	Punct	_	40	punct	_	_
 40	francaigh	francach	NOUN	Noun	Gender=Masc|Number=Plur	9	parataxis	_	_
 41	ag	ag	ADP	Simp	_	42	case	_	_
@@ -1578,7 +1578,7 @@
 1	Thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	siad	siad	PRON	Pers	Number=Plur|Person=3	1	nsubj	_	_
 3	faoina	faoi	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+4	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 5	go	go	PART	Ad	PartType=Ad	6	mark:prt	_	_
 6	crua	crua	ADJ	Adj	Degree=Pos	1	advmod	_	_
 7	dána	dána	ADJ	Adj	Degree=Pos	1	advmod	_	SpaceAfter=No
@@ -1591,7 +1591,7 @@
 3	go	go	PART	Vb	PartType=Cmpl	4	mark:prt	_	_
 4	bhfuil	bí	VERB	VI	Form=Ecl|Mood=Ind|Tense=Pres	2	csubj:cop	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
+6	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	lán	lán	ADJ	Adj	Degree=Pos	6	xcomp:pred	_	_
 8	de	de	ADP	Simp	_	9	case	_	_
 9	sheanmháthaireacha	seanmháthair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	7	obl	_	SpaceAfter=No
@@ -1624,14 +1624,14 @@
 # sent_id = 519
 # text = Tá Seán ag caint sa chistin le mo mhuintir.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	Seán	Seán	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Seán	Seán	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	caint	caint	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
 6	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	le	le	ADP	Simp	_	9	case	_	_
 8	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	9	nmod:poss	_	_
-9	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
+9	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 520
@@ -1692,12 +1692,12 @@
 20	i	i	ADP	Simp	_	21	case	_	_
 21	gcearnóg	cearnóg	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	bhaile	baile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
+23	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
 25	canadh	canadh	NOUN	Noun	VerbForm=Vnoun	17	xcomp	_	_
 26	ceoil	ceol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	obj	_	_
 27	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	28	nmod:poss	_	_
-28	gcuideachta	cuideachta	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
+28	gcuideachta	cuideachta	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 522
@@ -1706,7 +1706,7 @@
 2	colún	colún	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
 3	rialta	rialta	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
-5	Máire	Máire	PROPN	Noun	Gender=Fem|Number=Sing	1	obl	_	_
+5	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 6	dar	dar	ADP	Simp	_	7	case	_	_
 7	theideal	teideal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 8	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
@@ -1718,7 +1718,7 @@
 14	Irish	Irish	X	_	Foreign=Yes	1	obl	_	_
 15	Independent	Independent	X	_	Foreign=Yes	14	flat:foreign	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
-17	blianta	bliain	NOUN	Noun	Gender=Fem|Number=Plur	1	obl:tmod	_	_
+17	blianta	bliain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	1	obl:tmod	_	_
 18	1927	1927	NUM	Num	_	17	nmod	_	_
 19	agus	agus	CCONJ	Coord	_	20	cc	_	_
 20	1928	1928	NUM	Num	_	18	conj	_	SpaceAfter=No
@@ -1737,10 +1737,10 @@
 # sent_id = 524
 # text = A bhó chairdiúil A bhó chairdiúil, buí is bán, Le grá di, tá mo chroíse lán, Tugann sí uachtar go flaithiúil, Le n-ithe le mo thoirtín úll.
 1	A	a	PART	Voc	PartType=Voc	2	case:voc	_	_
-2	bhó	bó	NOUN	Noun	Case=Voc|Form=Len|Gender=Fem|Number=Sing	16	vocative	_	_
+2	bhó	bó	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	vocative	_	_
 3	chairdiúil	cairdiúil	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing|PartType=Voc	2	amod	_	_
 4	A	a	PART	Voc	PartType=Voc	5	case:voc	_	_
-5	bhó	bó	NOUN	Noun	Case=Voc|Form=Len|Gender=Fem|Number=Sing	16	vocative	_	_
+5	bhó	bó	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	vocative	_	_
 6	chairdiúil	cairdiúil	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing|PartType=Voc	5	amod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	buí	buí	ADJ	Adj	Degree=Pos	5	amod	_	_
@@ -1753,7 +1753,7 @@
 15	,	,	PUNCT	Punct	_	13	punct	_	_
 16	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 17	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	18	nmod:poss	_	_
-18	chroíse	croí	NOUN	Noun	Form=Emp,Len|Gender=Masc|Number=Sing	16	nsubj	_	_
+18	chroíse	croí	NOUN	Noun	Definite=Def|Form=Emp,Len|Gender=Masc|Number=Sing	16	nsubj	_	_
 19	lán	lán	ADJ	Adj	Degree=Pos	16	xcomp:pred	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Tugann	tabhair	VERB	PresInd	Mood=Ind|Tense=Pres	16	parataxis	_	_
@@ -1766,7 +1766,7 @@
 28	n-ithe	ith	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	obl	_	_
 29	le	le	ADP	Simp	_	31	case	_	_
 30	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	31	nmod:poss	_	_
-31	thoirtín	toirtín	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	28	obl	_	_
+31	thoirtín	toirtín	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	obl	_	_
 32	úll	úll	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	31	nmod	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	16	punct	_	_
 
@@ -1805,12 +1805,12 @@
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	obj	_	_
 27	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	23	acl:relcl	_	_
 28	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
-29	bhean	bean	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	27	nsubj	_	_
+29	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	27	nsubj	_	_
 30	anall	anall	ADV	Dir	_	27	advmod	_	_
 31	ón	ó	ADP	Art	Number=Sing|PronType=Art	32	case	_	_
-32	Chill	Cill	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	27	obl	_	_
+32	Chill	Cill	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	27	obl	_	_
 33	san	i	ADP	Art	Number=Sing|PronType=Art	34	case	_	_
-34	Cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	27	obl	_	NamedEntity=Yes
+34	Cheann	ceann	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	obl	_	NamedEntity=Yes
 35	Deas	deas	ADJ	Adj	Gender=Masc|Number=Sing	34	amod	_	NamedEntity=Yes|SpaceAfter=No
 36	.	.	PUNCT	.	_	9	punct	_	_
 
@@ -1826,13 +1826,13 @@
 8	ar	ar	ADP	Simp	_	11	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 10	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	11	amod	_	_
-11	leathanach	leathanach	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+11	leathanach	leathanach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 12	:	:	PUNCT	Punct	_	14	punct	_	_
 13	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	14	cop	_	_
 14	óg	óg	ADJ	Adj	Degree=Pos	1	parataxis	_	_
 15	i	i	ADP	Simp	_	17	case	_	_
 16	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	17	nmod:poss	_	_
-17	shaol	saol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
+17	shaol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	mark:prt	_	_
 19	chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	14	csubj:cleft	_	_
 20	mé	mé	PRON	Pers	Number=Sing|Person=1	19	nsubj	_	_
@@ -1846,7 +1846,7 @@
 28	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	25	acl:relcl	_	_
 29	le	le	ADP	Simp	_	31	case	_	_
 30	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	31	nmod:poss	_	_
-31	mhian	mian	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	obl	_	SpaceAfter=No
+31	mhian	mian	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	28	obl	_	SpaceAfter=No
 32	...	...	PUNCT	...	_	1	punct	_	_
 
 # sent_id = 528
@@ -1867,7 +1867,7 @@
 14	ag	ag	ADP	Simp	_	15	case	_	_
 15	ullmhú	ullmhú	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
 16	don	do	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
-17	fhoilsiú	foilsiú	NOUN	Noun	Form=Len|VerbForm=Inf	15	obl	_	_
+17	fhoilsiú	foilsiú	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	15	obl	_	_
 18	deiridh	deireadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1877,26 +1877,26 @@
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
 3	Oileán	oileán	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
-5	Deargánaigh	Deargánach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+5	Deargánaigh	Deargánach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 7	chéad	céad	NUM	Num	Form=Len|NumType=Ord	8	amod	_	_
-8	fhaiche	faiche	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
+8	fhaiche	faiche	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 9	phoiblí	poiblí	ADJ	Adj	Degree=Pos|Form=Len	8	amod	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	mBéal	Béal	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
-14	Feirste	Feirste	PROPN	Noun	Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
+13	mBéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
+14	Feirste	Feirste	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	17	cc	_	_
 16	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	17	cop	_	SpaceAfter=No
 17	fhada	fada	ADJ	Adj	Degree=Pos|Form=Len	3	conj	_	_
 18	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	ionad	ionad	NOUN	Noun	Gender=Masc|Number=Sing	17	nsubj	_	_
+19	ionad	ionad	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	_
 20	caitheamh	caitheamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nmod	_	_
 21	aimsire	aimsir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
 22	ag	ag	ADP	Simp	_	24	case	_	_
 23	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	24	nmod:poss	_	_
-24	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	17	obl	_	_
+24	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	obl	_	_
 25	saoránach	saoránach	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	24	nmod	_	_
 26	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nmod	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	3	punct	_	_
@@ -1941,7 +1941,7 @@
 13	teipeann	teip	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 14	ar	ar	ADP	Simp	_	16	case	_	_
 15	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	13	obl	_	_
+16	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	13	obl	_	_
 17	solúbthachta	solúbthacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	20	cop	_	_
@@ -1977,7 +1977,7 @@
 22	de	de	ADP	Simp	_	23	case	_	_
 23	dhánaíocht	dánaíocht	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	21	xcomp:pred	_	_
 24	san	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	fhear	fear	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
+25	fhear	fear	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
 26	chéanna	céanna	ADJ	Adj	Degree=Pos|Form=Len	25	amod	_	_
 27	sin	sin	DET	Det	PronType=Dem	25	det	_	_
 28	a	a	PART	Inf	PartType=Inf	29	mark	_	_
@@ -1990,7 +1990,7 @@
 35	dul	dul	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	nmod	_	_
 36	le	le	ADP	Simp	_	37	case	_	_
 37	Naomh	Naomh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	nmod	_	NamedEntity=Yes
-38	Pól	Pól	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	37	flat	_	NamedEntity=Yes
+38	Pól	Pól	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	37	flat	_	NamedEntity=Yes
 39	-	-	PUNCT	Punct	_	42	punct	_	_
 40	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	42	cop	_	_
 41	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	42	nmod	_	_
@@ -2008,13 +2008,13 @@
 # text = Bheadh an scoil éisc faoi lán siúil faoin uisce agus an t-iascaire ag iarraidh é a locadh chun líon trom a chaitheamh timpeall air.
 1	Bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	scoil	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+3	scoil	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	éisc	iasc	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	faoi	faoi	ADP	Simp	_	6	case	_	_
 6	lán	lán	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
 7	siúil	siúl	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	uisce	uisce	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+9	uisce	uisce	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 10	agus	agus	SCONJ	Subord	_	12	mark	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	t-iascaire	iascaire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	advcl	_	_
@@ -2036,7 +2036,7 @@
 # text = Cothú sa Duine Tá cúig chéim i gceist le cothú sa duine: Daoibhse atá ar bheagán Shakespeare, nó daoibhse a d'fhág cúrsaí staidéir níos mó ná cúpla lá ó shin, seo é, go gonta, scéal traigéideach marfach Phrionsa na Danmhairge.
 1	Cothú	cothú	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 2	sa	i	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	Duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	1	nmod	_	_
+3	Duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 4	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 5	cúig	cúig	NUM	Num	NumType=Card	6	nummod	_	_
 6	chéim	céim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	nsubj	_	_
@@ -2045,13 +2045,13 @@
 9	le	le	ADP	Simp	_	10	case	_	_
 10	cothú	cothú	NOUN	Noun	Gender=Masc|Number=Sing	4	xcomp	_	_
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
+12	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
 13	:	:	PUNCT	Punct	_	14	punct	_	_
 14	Daoibhse	do	ADP	Prep	Number=Plur|Person=2|PronType=Emp	1	parataxis	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	14	acl:relcl	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
 17	bheagán	beagán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
-18	Shakespeare	Shakespeare	PROPN	Noun	Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
+18	Shakespeare	Shakespeare	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
 21	daoibhse	do	ADP	Prep	Number=Plur|Person=2|PronType=Emp	14	conj	_	_
@@ -2079,7 +2079,7 @@
 43	marfach	marfach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	41	amod	_	_
 44	Phrionsa	prionsa	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	41	nmod	_	_
 45	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	46	det	_	_
-46	Danmhairge	Danmhairg	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	44	nmod	_	SpaceAfter=No
+46	Danmhairge	Danmhairg	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	44	nmod	_	SpaceAfter=No
 47	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 536
@@ -2120,7 +2120,7 @@
 7	sin	sin	DET	Det	PronType=Dem	5	det	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	mhéid	méid	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+10	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 11	nach	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 12	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	ccomp	_	_
 13	amháin	amháin	ADJ	Adj	Degree=Pos	2	amod	_	_
@@ -2129,7 +2129,7 @@
 16	in	i	ADP	Simp	_	17	case	_	_
 17	onóir	onóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nmod	_	_
 18	do	do	ADP	Simp	_	19	case	_	_
-19	Mhuire	Muire	PROPN	Noun	Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
+19	Mhuire	Muire	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
 20	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	15	nsubj	_	SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
 22	ach	ach	SCONJ	Subord	_	24	mark	_	_
@@ -2163,16 +2163,16 @@
 3	gcoimhlint	coimhlint	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	0	root	_	_
 4	leis	le	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Lucht	Lucht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+6	Lucht	Lucht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 7	Oibre	Oibre	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	le	le	ADP	Simp	_	10	case	_	_
-10	Sinn	Sinn	PROPN	Noun	Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
-11	Féin	Féin	PROPN	Noun	Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
+10	Sinn	Sinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
+11	Féin	Féin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
 12	agus	agus	CCONJ	Coord	_	15	cc	_	_
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	15	det	_	_
-15	Glasaigh	Glasach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	_
+15	Glasaigh	Glasach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 16	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	3	csubj:cleft	_	_
 17	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	16	nsubj	_	_
 18	ar	ar	ADP	Simp	_	19	case	_	_
@@ -2180,11 +2180,11 @@
 20	,	,	PUNCT	Punct	_	23	punct	_	_
 21	seachas	seachas	ADP	Simp	_	23	case	_	_
 22	le	le	ADP	Simp	_	23	case	_	_
-23	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	16	obl	_	NamedEntity=Yes
-24	Fáil	Fál	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
+23	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	16	obl	_	NamedEntity=Yes
+24	Fáil	Fál	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	agus	agus	CCONJ	Coord	_	27	cc	_	_
 26	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	27	det	_	_
-27	Daonlathaigh	daonlathach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	23	conj	_	SpaceAfter=No
+27	Daonlathaigh	daonlathach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	23	conj	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 541
@@ -2231,10 +2231,10 @@
 7	CAM	cam	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	6	amod	_	_
 8	dochar	dochar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	fheachtas	feachtas	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+10	fheachtas	feachtas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
 12	bhfabhar	fabhar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
-13	Nice	Nice	PROPN	Noun	Number=Sing	12	nmod	_	SpaceAfter=No
+13	Nice	Nice	PROPN	Noun	Definite=Def|Number=Sing	12	nmod	_	SpaceAfter=No
 14	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 543
@@ -2251,7 +2251,7 @@
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	páirtí	páirtí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	stát	stát	NOUN	Noun	Gender=Masc|Number=Sing	9	obl	_	_
+13	stát	stát	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 14	seo	seo	DET	Det	PronType=Dem	13	det	_	_
 15	gafa	gafa	ADJ	Adj	VerbForm=Part	9	xcomp:pred	_	_
 16	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
@@ -2278,12 +2278,12 @@
 4	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	oileán	oileán	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+7	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 8	:	:	PUNCT	Punct	_	11	punct	_	_
 9	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
 10	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	11	cop	_	_
 11	Aifreann	Aifreann	NOUN	Noun	Gender=Masc|Number=Sing	1	parataxis	_	NamedEntity=Yes
-12	Domhnaigh	Domhnach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+12	Domhnaigh	Domhnach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	níor	níor	PART	Vb	PartType=Vb|Tense=Past	14	advmod	_	_
 14	éist	éist	VERB	VTI	Mood=Ind|Tense=Past	11	ccomp	_	_
 15	mé	mé	PRON	Pers	Number=Sing|Person=1	14	nsubj	_	_
@@ -2309,7 +2309,7 @@
 15	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	nsubj	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	Mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	obl	_	NamedEntity=Yes
-18	Dé	Dia	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+18	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	go	go	PART	Vb	PartType=Cmpl	20	mark:prt	_	_
 20	bhfaca	feic	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	13	ccomp	_	_
 21	mise	mise	PRON	Pers	Number=Sing|Person=1|PronType=Emp	20	nsubj	_	_
@@ -2321,7 +2321,7 @@
 1	Nuair	nuair	SCONJ	Subord	_	3	mark	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	8	advcl	_	_
-4	Éamonn	Éamonn	PROPN	Noun	Gender=Masc|Number=Sing	3	nsubj	_	_
+4	Éamonn	Éamonn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	i	i	ADP	Cmpd	PrepForm=Cmpd	7	case	_	_
 6	mbun	bun	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	5	fixed	_	_
 7	oibre	obair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	3	obl	_	_
@@ -2362,7 +2362,7 @@
 13	,	,	PUNCT	Punct	_	4	punct	_	_
 14	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 15	gach	gach	DET	Det	Definite=Def	16	det	_	_
-16	seans	seans	NOUN	Noun	Gender=Masc|Number=Sing	14	nsubj	_	_
+16	seans	seans	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 17	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	14	xcomp:pred	_	_
 18	go	go	PART	Vb	PartType=Cmpl	19	mark:prt	_	_
 19	n-éireoidh	éirigh	VERB	VI	Form=Ecl|Mood=Ind|Tense=Fut	14	ccomp	_	_
@@ -2375,15 +2375,15 @@
 26	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
 27	amach	amach	ADV	Dir	_	26	advmod	_	_
 28	i	i	ADP	Simp	_	29	case	_	_
-29	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	26	nmod	_	NamedEntity=Yes
+29	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	26	nmod	_	NamedEntity=Yes
 30	Thiar	thiar	ADV	Dir	_	29	amod	_	NamedEntity=Yes
 31	(	(	PUNCT	Punct	_	32	punct	_	SpaceAfter=No
 32	slán	slán	NOUN	Noun	Gender=Masc|Number=Sing	14	parataxis	_	_
 33	leat	le	ADP	Prep	Number=Sing|Person=2	32	obl:prep	_	SpaceAfter=No
 34	,	,	PUNCT	Punct	_	36	punct	_	_
 35	a	a	PART	Voc	PartType=Voc	36	case:voc	_	_
-36	Bhobby	Bobby	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	32	vocative	_	NamedEntity=Yes
-37	Molloy	Molloy	PROPN	Noun	Gender=Masc|Number=Sing	36	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+36	Bhobby	Bobby	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	32	vocative	_	NamedEntity=Yes
+37	Molloy	Molloy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 38	?	?	PUNCT	?	_	14	punct	_	_
 
 # sent_id = 549
@@ -2397,26 +2397,26 @@
 7	is	agus	CCONJ	Coord	_	8	cc	_	_
 8	thángas-sa	tar	VERB	VI	Form=Emp,Len|Mood=Ind|Number=Sing|Person=1|Tense=Past	1	conj	_	_
 9	go	go	ADP	Simp	_	10	case	_	_
-10	Port	Port	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	NamedEntity=Yes
-11	Láirge	Láirge	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+10	Port	Port	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	NamedEntity=Yes
+11	Láirge	Láirge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	cosa-in-airde	cosa-in-airde	NOUN	Noun	Gender=Fem|Number=Sing	8	obl	_	_
 14	im	i_mo	ADP	_	Number=Sing|Person=1|Poss=Yes	15	case	_	_
-15	aonar	aonar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
+15	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 550
 # text = Campa samhraidh Óg-Eagras, Ionad Mosney, Co. na Mí.
 1	Campa	campa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	samhraidh	samhradh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-3	Óg-Eagras	Óg-Eagras	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	flat	_	NamedEntity=Yes|SpaceAfter=No
+3	Óg-Eagras	Óg-Eagras	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	flat	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	Ionad	ionad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-6	Mosney	Mosney	PROPN	Noun	Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes|SpaceAfter=No
+6	Mosney	Mosney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	Co.	contae	NOUN	Abr	Abbr=Yes	1	nmod	_	NamedEntity=Yes
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
-10	Mí	Mí	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
+10	Mí	Mí	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 551
@@ -2424,7 +2424,7 @@
 1	Ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 2	féidir	féidir	NOUN	Subst	Number=Sing	0	root	_	_
 3	gach	gach	DET	Det	Definite=Def	4	det	_	_
-4	gearán	gearán	NOUN	Noun	Gender=Masc|Number=Sing	6	obj	_	_
+4	gearán	gearán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
 6	shocrú	socrú	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 7	go	go	PART	Ad	PartType=Ad	8	mark:prt	_	_
@@ -2436,7 +2436,7 @@
 13	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	11	csubj:cop	_	_
 14	foráil	foráil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nsubj	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	chóras	córas	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+16	chóras	córas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 17	gearán	gearán	NOUN	Noun	Gender=Masc|Number=Sing	16	nmod	_	_
 18	inmheánach	inmheánach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	17	amod	_	_
 19	faoina	faoi	PART	Rel	PronType=Rel	20	obl	_	_
@@ -2447,7 +2447,7 @@
 24	faoi	faoi	ADP	Cmpd	PrepForm=Cmpd	27	case	_	_
 25	bhráid	bhráid	ADP	Cmpd	PrepForm=Cmpd	24	fixed	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	Ombudsman	Ombudsman	NOUN	Noun	Gender=Masc|Number=Sing	23	obl	_	_
+27	Ombudsman	Ombudsman	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
 28	nuair	nuair	SCONJ	Subord	_	30	mark	_	_
 29	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	30	cop	_	_
 30	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	13	advcl	_	_
@@ -2501,7 +2501,7 @@
 # sent_id = 554
 # text = An teachtaireacht a thagann ar ais ná gur fhág agus soicindí níos déanaí, tá Cruise ag gabháil an dúnmharfóra le bheith agus é ar tí a bhean is a leannán a shá chun báis le siosúr.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	teachtaireacht	teachtaireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
+2	teachtaireacht	teachtaireacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
 4	thagann	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Pres	2	csubj:cleft	_	_
 5	ar	ar	ADV	Dir	_	4	advmod	_	_
@@ -2515,11 +2515,11 @@
 13	déanaí	déanach	ADJ	Adj	Degree=Cmp,Sup	11	amod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	11	punct	_	_
 15	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	9	conj	_	_
-16	Cruise	Cruise	PROPN	Noun	Gender=Masc|Number=Sing	15	nsubj	_	_
+16	Cruise	Cruise	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
 18	gabháil	gabháil	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	dúnmharfóra	dúnmharfóir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	obj	_	_
+20	dúnmharfóra	dúnmharfóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	obj	_	_
 21	le	le	ADP	Simp	_	22	case	_	_
 22	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	18	xcomp	_	_
 23	agus	agus	CCONJ	Coord	_	24	mark	_	_
@@ -2527,10 +2527,10 @@
 25	ar	ar	ADP	Simp	_	26	case	_	_
 26	tí	tí	NOUN	Noun	Gender=Fem|Number=Sing	24	xcomp	_	_
 27	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	nmod:poss	_	_
-28	bhean	bean	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	33	obj	_	_
+28	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	33	obj	_	_
 29	is	agus	CCONJ	Coord	_	33	cc	_	_
 30	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	nmod:poss	_	_
-31	leannán	leannán	NOUN	Noun	Gender=Masc|Number=Sing	28	conj	_	_
+31	leannán	leannán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	conj	_	_
 32	a	a	PART	Inf	PartType=Inf	33	mark	_	_
 33	shá	sá	NOUN	Noun	Form=Len|VerbForm=Inf	24	xcomp	_	_
 34	chun	chun	ADP	Simp	_	35	case	_	_
@@ -2543,7 +2543,7 @@
 # text = Ar an dtaobh lastuaidh de tá carraig ard mar a bheadh oileán beag go nglaoitear Boilg an Chruaidh air.
 1	Ar	ar	ADP	Simp	_	3	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
+3	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
 4	lastuaidh	lastuaidh	ADJ	Adj	Degree=Pos	3	amod	_	_
 5	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	3	obl:prep	_	_
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -2558,7 +2558,7 @@
 15	nglaoitear	glaoigh	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	11	ccomp	_	_
 16	Boilg	boilg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	NamedEntity=Yes
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
-18	Chruaidh	cruaidh	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Chruaidh	cruaidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -2571,15 +2571,15 @@
 # sent_id = 557
 # text = Rug Antaine ar an Independant a bhí ar bhinse Charoline is scuab an chuid eile amach chun a saoirse.
 1	Rug	beir	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-2	Antaine	Antaine	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Antaine	Antaine	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ar	ar	ADP	Simp	_	5	case	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	Independant	Independant	PROPN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+5	Independant	Independant	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 6	a	a	PART	Inf	PartType=Inf	7	nsubj	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	acl:relcl	_	_
 8	ar	ar	ADP	Simp	_	9	case	_	_
 9	bhinse	binse	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
-10	Charoline	Caroline	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
+10	Charoline	Caroline	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 11	is	agus	CCONJ	Coord	_	12	cc	_	_
 12	scuab	scuab	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
@@ -2588,7 +2588,7 @@
 16	amach	amach	ADV	Dir	_	12	advmod	_	_
 17	chun	chun	ADP	Simp	_	19	case	_	_
 18	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	saoirse	saoirse	NOUN	Noun	Gender=Fem|Number=Sing	12	obl	_	SpaceAfter=No
+19	saoirse	saoirse	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	obl	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 558
@@ -2596,7 +2596,7 @@
 1	Ach	ach	SCONJ	Subord	_	8	mark	_	SpaceAfter=No
 2	,	,	PUNCT	Punct	_	1	punct	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	dhiaidh	diaidh	NOUN	Subst	Form=Len|Number=Sing	8	obl	_	_
+4	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	8	obl	_	_
 5	sin	sin	DET	Det	PronType=Dem	4	det	_	_
 6	féin	féin	PRON	Ref	Reflex=Yes	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	4	punct	_	_
@@ -2619,7 +2619,7 @@
 24	sláinte	sláinte	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	22	nmod	_	_
 25	ag	ag	ADP	Simp	_	27	case	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
+27	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 559
@@ -2629,8 +2629,8 @@
 3	díograiseach	díograiseach	ADJ	Adj	Case=NomAcc|NounType=Weak|Number=Sing	1	amod	_	_
 4	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	6	cop	_	_
 5	ea	ea	PRON	Pers	Number=Sing|Person=3	6	nmod	_	_
-6	Colm	Colm	PROPN	Noun	_	1	csubj:cleft	_	NamedEntity=Yes
-7	Cille	Cille	PROPN	Noun	_	6	flat:name	_	NamedEntity=Yes
+6	Colm	Colm	PROPN	Noun	Definite=Def	1	csubj:cleft	_	NamedEntity=Yes
+7	Cille	Cille	PROPN	Noun	Definite=Def	6	flat:name	_	NamedEntity=Yes
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 10	dúil	dúil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	nsubj	_	_
@@ -2660,7 +2660,7 @@
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	t-allas	allas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 17	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	léine	léine	NOUN	Noun	Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
+18	léine	léine	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 561
@@ -2669,7 +2669,7 @@
 2	mhaith	maith	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	1	amod	_	_
 3	de	de	ADP	Simp	_	5	case	_	SpaceAfter=No
 4	'n	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	teangaidh	teanga	NOUN	Noun	Gender=Fem|Number=Sing	1	nmod	_	_
+5	teangaidh	teanga	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	obl	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 8	in	i	ADP	Simp	_	9	case	_	_
@@ -2696,17 +2696,17 @@
 29	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	28	obl:prep	_	_
 30	as	as	ADP	Simp	_	32	case	_	_
 31	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
-32	siopa	siopa	NOUN	Noun	Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
+32	siopa	siopa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	36	punct	_	_
 34	nó	nó	CCONJ	Coord	_	36	cc	_	_
 35	go	go	PART	Vb	PartType=Cmpl	36	mark:prt	_	_
 36	gcuirfeadh	cuir	VERB	VTI	Form=Ecl|Mood=Cnd	1	conj	_	_
 37	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	36	nsubj	_	_
 38	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	39	det	_	_
-39	póilíos	póilín	NOUN	Noun	Gender=Masc|Number=Plur	36	obj	_	_
+39	póilíos	póilín	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	36	obj	_	_
 40	in	i	ADP	Simp	_	42	case	_	_
 41	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	42	nmod:poss	_	_
-42	dhiaidh	diaidh	NOUN	Subst	Form=Len|Number=Sing	36	obl	_	SpaceAfter=No
+42	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	36	obl	_	SpaceAfter=No
 43	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 562
@@ -2722,7 +2722,7 @@
 9	Fásann	fás	VERB	VTI	Mood=Ind|Tense=Pres	2	parataxis	_	_
 10	siad	siad	PRON	Pers	Number=Plur|Person=3	9	nsubj	_	_
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	cheo	ceo	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+12	cheo	ceo	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	Is	is	PART	Sup	PartType=Sup	15	mark:prt	_	_
 15	airde	ard	ADJ	Adj	Degree=Cmp,Sup	10	amod	_	_
@@ -2745,7 +2745,7 @@
 9	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	obl:prep	_	_
 10	te	te	ADJ	Adj	Degree=Pos	9	amod	_	_
 11	ón	ó	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	oigheann	oigheann	NOUN	Noun	Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
+12	oigheann	oigheann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	15	cop	_	_
 15	fearr	maith	ADJ	Adj	Degree=Cmp,Sup	1	parataxis	_	_
@@ -2766,7 +2766,7 @@
 2	ciúin	ciúin	ADJ	Adj	Gender=Masc|Number=Sing	1	amod	_	_
 3	ab	is	AUX	Cop	Form=VF|PronType=Rel|Tense=Past|VerbForm=Cop	5	cop	_	_
 4	ea	ea	PRON	Pers	Number=Sing|Person=3	5	nmod	_	_
-5	Donncha	Donncha	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+5	Donncha	Donncha	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 6	-	-	PUNCT	Punct	_	7	punct	_	_
 7	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	5	appos	_	_
 8	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	9	mark:prt	_	_
@@ -2780,7 +2780,7 @@
 16	taobh	taobh	ADV	Loc	_	9	advmod	_	_
 17	amuigh	amuigh	ADV	Loc	_	9	advmod	_	_
 18	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
+19	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 20	tí	teach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2793,7 +2793,7 @@
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
 6	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	case	_	_
-8	choimeád	coimeád	NOUN	Noun	Form=Len|VerbForm=Inf	2	xcomp	_	_
+8	choimeád	coimeád	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	2	xcomp	_	_
 9	siar	siar	ADV	Dir	_	8	advmod	_	_
 10	toisc	toisc	SCONJ	Subord	_	11	mark	_	_
 11	easpa	easpa	NOUN	Noun	Gender=Fem|Number=Sing	2	obl	_	_
@@ -2804,11 +2804,11 @@
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 18	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	19	case	_	_
-19	infheistiú	infheistiú	NOUN	Noun	VerbForm=Inf	8	conj	_	_
+19	infheistiú	infheistiú	NOUN	Noun	Definite=Def|VerbForm=Inf	8	conj	_	_
 20	(	(	PUNCT	Punct	_	23	punct	_	SpaceAfter=No
 21	is	agus	CCONJ	Coord	_	23	cc	_	_
 22	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	23	case	_	_
-23	chailliúnt	cailliúint	NOUN	Noun	Form=Len|Typo=Yes|VerbForm=Inf	19	conj	_	SpaceAfter=No
+23	chailliúnt	cailliúint	NOUN	Noun	Definite=Def|Form=Len|Typo=Yes|VerbForm=Inf	19	conj	_	SpaceAfter=No
 24	)	)	PUNCT	Punct	_	23	punct	_	_
 25	ar	ar	ADP	Simp	_	26	case	_	_
 26	scairmhargaí	scairmhargadh	NOUN	Noun	Gender=Masc|Number=Plur	19	obl	_	_
@@ -2816,7 +2816,7 @@
 28	lear	lear	NOUN	Noun	Gender=Masc|Number=Sing	27	fixed	_	_
 29	ag	ag	ADP	Simp	_	31	case	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
-31	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	_
+31	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	_
 32	céanna	céanna	ADJ	Adj	Degree=Pos	31	amod	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	2	punct	_	_
 34	ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	35	cop	_	_
@@ -2833,7 +2833,7 @@
 3	Cheathrú	ceathrú	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	NamedEntity=Yes
 4	Uain	uan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chaoi	caoi	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+6	chaoi	caoi	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	go	go	PART	Vb	PartType=Cmpl	8	mark:prt	_	_
 8	mbíonn	bí	VERB	PresImp	Aspect=Hab|Form=Ecl|Mood=Ind|Tense=Pres	1	ccomp	_	_
 9	teacht	teacht	NOUN	Noun	VerbForm=Inf	8	nsubj	_	_
@@ -2841,7 +2841,7 @@
 11	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	12	det	_	_
 12	duilleoga	duilleog	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	9	nmod	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	gheimhreadh	geimhreadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
+14	gheimhreadh	geimhreadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 567
@@ -2850,12 +2850,12 @@
 2	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	amháin	amháin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	den	de	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	tseimineár	seimineár	NOUN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+5	tseimineár	seimineár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 6	seo	seo	DET	Det	PronType=Dem	2	det	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
 8	fhorbairt	forbairt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
+10	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
 12	SCÉAL	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	appos	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	18	punct	_	_
@@ -2866,8 +2866,8 @@
 18	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	NamedEntity=Yes
-21	Marial	Marial	PROPN	Noun	Gender=Masc|Number=Sing	20	appos	_	NamedEntity=Yes
-22	Hannon	Hannon	PROPN	Noun	Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+21	Marial	Marial	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	appos	_	NamedEntity=Yes
+22	Hannon	Hannon	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 23	,	,	PUNCT	Punct	_	25	punct	_	_
 24	a	a	PART	Vb	PartType=Vb|PronType=Rel	25	nsubj	_	_
 25	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
@@ -2877,15 +2877,15 @@
 29	agus	agus	CCONJ	Coord	_	30	cc	_	_
 30	todhchaí	todhchaí	NOUN	Noun	Gender=Fem|Number=Sing	28	conj	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
-32	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
+32	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	35	det	_	_
 35	léiritheoir	léiritheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	conj	_	_
 36	teilifíse	teilifís	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	35	nmod	_	SpaceAfter=No
 37	,	,	PUNCT	Punct	_	38	punct	_	_
-38	Concubhar	Concubhar	PROPN	Noun	Gender=Masc|Number=Sing	35	appos	_	NamedEntity=Yes
+38	Concubhar	Concubhar	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	35	appos	_	NamedEntity=Yes
 39	Ó	ó	PART	Pat	PartType=Pat	38	flat:name	_	NamedEntity=Yes
-40	Liatháin	Liatháin	PROPN	Noun	Gender=Masc|Number=Sing	38	flat:name	_	NamedEntity=Yes
+40	Liatháin	Liatháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	38	flat:name	_	NamedEntity=Yes
 41	a	a	PART	Vb	PartType=Vb|PronType=Rel	42	nsubj	_	_
 42	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	38	acl:relcl	_	_
 43	mar	mar	SCONJ	Subord	_	45	mark	_	_
@@ -2903,17 +2903,17 @@
 55	agus	agus	CCONJ	Coord	_	57	cc	_	_
 56	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
 57	Dr.	dochtúir	NOUN	Abr	Abbr=Yes	20	conj	_	NamedEntity=Yes
-58	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	57	flat	_	NamedEntity=Yes
+58	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat	_	NamedEntity=Yes
 59	Ó	ó	PART	Pat	PartType=Pat	57	flat:name	_	NamedEntity=Yes
-60	Criomhthainn	Criomhthainn	PROPN	Noun	Gender=Masc|Number=Sing	57	flat:name	_	NamedEntity=Yes
+60	Criomhthainn	Criomhthainn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat:name	_	NamedEntity=Yes
 61	ó	ó	ADP	Simp	_	62	case	_	_
 62	Choláiste	coláiste	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
 63	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	64	det	_	NamedEntity=Yes
 64	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	62	nmod	_	NamedEntity=Yes|SpaceAfter=No
 65	,	,	PUNCT	Punct	_	66	punct	_	_
-66	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	62	nmod	_	NamedEntity=Yes
-67	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	66	nmod	_	NamedEntity=Yes
-68	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	67	nmod	_	NamedEntity=Yes|SpaceAfter=No
+66	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	62	nmod	_	NamedEntity=Yes
+67	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	66	nmod	_	NamedEntity=Yes
+68	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	67	nmod	_	NamedEntity=Yes|SpaceAfter=No
 69	,	,	PUNCT	Punct	_	71	punct	_	_
 70	a	a	PART	Vb	PartType=Vb|PronType=Rel	71	nsubj	_	_
 71	mhínigh	mínigh	VERB	VT	Form=Len|Mood=Ind|Tense=Past	57	acl:relcl	_	_
@@ -2940,7 +2940,7 @@
 92	ar	ar	ADP	Cmpd	PrepForm=Cmpd	95	case	_	_
 93	fud	fud	ADP	Cmpd	PrepForm=Cmpd	92	fixed	_	_
 94	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	95	det	_	_
-95	domhain	domhan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	91	obl	_	SpaceAfter=No
+95	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	91	obl	_	SpaceAfter=No
 96	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 568
@@ -2951,8 +2951,8 @@
 4	de	de	ADP	Simp	_	5	case	_	_
 5	$100m	$100m	NUM	Num	_	3	nmod	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
-7	Merrill	Merrill	PROPN	Noun	Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-8	Lynch	Lynch	PROPN	Noun	Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
+7	Merrill	Merrill	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+8	Lynch	Lynch	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
 9	mí	mí	NOUN	Noun	Gender=Fem|Number=Sing	1	obl:tmod	_	_
 10	ó	ó	ADP	Simp	_	11	case	_	_
 11	shin	sin	PRON	Dem	Form=Len|PronType=Dem	9	nmod	_	_
@@ -2965,7 +2965,7 @@
 18	scaireanna	scair	NOUN	Noun	Gender=Fem|Number=Plur	17	nmod	_	_
 19	comhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	obj	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
-21	Winstar	Winstar	PROPN	Noun	Gender=Masc|Number=Sing	19	appos	_	SpaceAfter=No
+21	Winstar	Winstar	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	appos	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	19	punct	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	cheannach	ceannach	NOUN	Noun	Form=Len|VerbForm=Inf	14	xcomp	_	_
@@ -2999,9 +2999,9 @@
 4	umhlaíocht	umhlaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	fhíornaofa	fíornaofa	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	7	nmod:poss	_	_
-7	dTiarna	tiarna	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-8	Íosa	Íosa	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	appos	_	NamedEntity=Yes
-9	Críost	Críost	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
+7	dTiarna	tiarna	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+8	Íosa	Íosa	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	appos	_	NamedEntity=Yes
+9	Críost	Críost	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 570
@@ -3029,7 +3029,7 @@
 13	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	3	advcl	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	Bhreatain	Breatain	PROPN	Noun	Form=Len|Gender=Fem|Number=Sing	13	obl	_	NamedEntity=Yes
+16	Bhreatain	Breatain	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	obl	_	NamedEntity=Yes
 17	Mhór	Mór	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	16	amod	_	NamedEntity=Yes|SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3040,19 +3040,19 @@
 3	seo	seo	PRON	Dem	PronType=Dem	1	ccomp	_	_
 4	ceann	ceann	NOUN	Noun	Gender=Masc|Number=Sing	3	nmod	_	_
 5	dena	de_na	ADP	Art	Number=Plur|PronType=Art	6	case	_	_
-6	fadhbanna	fadhb	NOUN	Noun	Gender=Fem|Number=Plur	4	nmod	_	_
+6	fadhbanna	fadhb	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	_
 7	is	is	PART	Sup	PartType=Sup	8	mark:prt	_	_
 8	mó	mór	ADJ	Adj	Degree=Cmp,Sup	6	amod	_	_
 9	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	6	acl:relcl	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	cheantar	ceantar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+11	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 573
 # text = Fás na nGaelscoileanna.
 1	Fás	fás	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 2	na	na	DET	Art	PronType=Art	3	det	_	_
-3	nGaelscoileanna	Gaelscoil	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
+3	nGaelscoileanna	Gaelscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 574
@@ -3067,7 +3067,7 @@
 8	i	i	ADP	Simp	_	9	case	_	_
 9	dtimpiste	timpiste	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	4	obl	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	Londain	Londain	PROPN	Noun	Gender=Fem|Number=Sing	4	obl	_	_
+11	Londain	Londain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 12	is	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	14	cop	_	_
 13	ea	ea	PRON	Pers	Number=Sing|Person=3	14	nmod	_	_
 14	príomhcharachtar	príomhcharachtar	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
@@ -3121,14 +3121,14 @@
 17	seo	seo	PRON	Dem	PronType=Dem	9	obl	_	SpaceAfter=No
 18	:	:	PUNCT	Punct	_	19	punct	_	_
 19	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	parataxis	_	_
-20	Edward	Edward	PROPN	Noun	Gender=Masc|Number=Sing	19	nsubj	_	NamedEntity=Yes
-21	Sapir	Sapir	PROPN	Noun	Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
+20	Edward	Edward	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	NamedEntity=Yes
+21	Sapir	Sapir	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
 22	(	(	PUNCT	Punct	_	23	punct	_	SpaceAfter=No
 23	1887-1939	1887-1939	NUM	Num	_	20	nmod	_	SpaceAfter=No
 24	)	)	PUNCT	Punct	_	23	punct	_	_
 25	ar	ar	ADP	Simp	_	27	case	_	_
 26	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	27	det	_	_
-27	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	20	nmod	_	_
+27	daoine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	_
 28	a	a	PART	Vb	PartType=Vb|PronType=Rel	29	nsubj	_	_
 29	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	27	acl:relcl	_	_
 30	bonn	bonn	NOUN	Noun	Gender=Masc|Number=Sing	29	obj	_	_
@@ -3197,7 +3197,7 @@
 10	drochrud	drochrud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
 11	éinteacht	éinteacht	ADJ	Adj	Gender=Masc|Number=Sing	10	amod	_	_
 12	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	13	case	_	_
-13	mhnaoi	bean	NOUN	Noun	Case=Dat|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
+13	mhnaoi	bean	NOUN	Noun	Case=Dat|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
 14	ó	ó	SCONJ	Subord	_	15	mark	_	_
 15	bhuail	buail	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	9	advcl	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
@@ -3215,12 +3215,12 @@
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	dreapadóir	dreapadóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
-9	Paul	Paul	PROPN	Noun	Gender=Masc|Number=Sing	8	appos	_	NamedEntity=Yes
-10	Pritchard	Pritchard	PROPN	Noun	Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+9	Paul	Paul	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	appos	_	NamedEntity=Yes
+10	Pritchard	Pritchard	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	ar	ar	ADP	Simp	_	12	case	_	_
 12	pháipéar	páipéar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	Teastais	teastas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+14	Teastais	teastas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 15	Shóisearaigh	sóisearach	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	14	amod	_	NamedEntity=Yes
 16	gnáthleibhéal	gnáthleibhéal	NOUN	Noun	Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
@@ -3235,7 +3235,7 @@
 6	Alliance	Alliance	PROPN	Noun	Foreign=Yes|Number=Sing	5	flat:foreign	_	_
 7	Chase	Chase	PROPN	Noun	Foreign=Yes|Number=Sing	5	flat:foreign	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
-9	Cheltenham	Cheltenham	PROPN	Noun	Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
+9	Cheltenham	Cheltenham	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	5	punct	_	_
 11	ag	ag	ADP	Simp	_	12	case	_	_
 12	seo	seo	PRON	Dem	PronType=Dem	0	root	_	_
@@ -3244,7 +3244,7 @@
 15	ante-post	ante-post	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	14	nmod	_	_
 16	-	-	PUNCT	Punct	_	17	punct	_	_
 17	Mr.	Mr.	NOUN	Abr	Abbr=Yes	12	parataxis	_	NamedEntity=Yes
-18	Mulligan	Mulligan	PROPN	Noun	Gender=Masc|Number=Sing	17	flat	_	NamedEntity=Yes
+18	Mulligan	Mulligan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat	_	NamedEntity=Yes
 19	(	(	PUNCT	Punct	_	21	punct	_	SpaceAfter=No
 20	5	5	NUM	Num	_	21	nummod	_	_
 21	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
@@ -3268,8 +3268,8 @@
 39	)	)	PUNCT	Punct	_	34	punct	_	SpaceAfter=No
 40	;	;	PUNCT	Punct	_	41	punct	_	_
 41	agus	agus	CCONJ	Coord	_	42	cc	_	_
-42	Nahthen	Nahthen	PROPN	Noun	Number=Sing	17	conj	_	NamedEntity=Yes
-43	Lad	Lad	PROPN	Noun	Number=Sing	42	flat:name	_	NamedEntity=Yes
+42	Nahthen	Nahthen	PROPN	Noun	Definite=Def|Number=Sing	17	conj	_	NamedEntity=Yes
+43	Lad	Lad	PROPN	Noun	Definite=Def|Number=Sing	42	flat:name	_	NamedEntity=Yes
 44	(	(	PUNCT	Punct	_	46	punct	_	SpaceAfter=No
 45	2	2	NUM	Num	_	46	nummod	_	_
 46	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	42	nmod	_	SpaceAfter=No
@@ -3313,7 +3313,7 @@
 28	siopaí	siopa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	26	obl	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 30	chéad	céad	NUM	Num	Form=Len|NumType=Ord	31	amod	_	_
-31	mhí	mí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	26	obl:tmod	_	_
+31	mhí	mí	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl:tmod	_	_
 32	eile	eile	DET	Det	PronType=Dem	31	det	_	SpaceAfter=No
 33	...	...	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	1	punct	_	_
@@ -3344,7 +3344,7 @@
 13	réir	réir	ADP	Cmpd	PrepForm=Cmpd	12	fixed	_	_
 14	thoil	toil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 15	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	máistrí	máistir	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	14	nmod	_	SpaceAfter=No
+16	máistrí	máistir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 585
@@ -3373,7 +3373,7 @@
 22	SAM	SAM	PROPN	Abr	Abbr=Yes	21	nmod	_	_
 23	ag	ag	ADP	Simp	_	25	case	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
-25	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obl:tmod	_	SpaceAfter=No
+25	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obl:tmod	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 586
@@ -3387,13 +3387,13 @@
 7	mór	mór	ADJ	Adj	Degree=Pos	1	advmod	_	_
 8	san	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
 9	Fhichiú	fichiú	NUM	_	Form=Len|NumType=Ord	10	amod	_	_
-10	hAois	aois	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	1	obl:tmod	_	_
+10	hAois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	1	obl:tmod	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
 12	bhrí	brí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 13	gur	gur	PART	Vb	PartType=Vb|Tense=Past	14	mark:prt	_	_
 14	glacadh	glac	VERB	VT	Mood=Ind|Person=0|Tense=Past	1	ccomp	_	_
 15	lena	le	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	16	case	_	_
-16	hathréimiú	athréimiú	NOUN	Noun	Form=HPref|VerbForm=Inf	14	obl	_	_
+16	hathréimiú	athréimiú	NOUN	Noun	Definite=Def|Form=HPref|VerbForm=Inf	14	obl	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
 18	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 19	d'	de	ADP	Simp	_	20	case	_	SpaceAfter=No
@@ -3408,7 +3408,7 @@
 2	scanraithe	scanraithe	ADJ	Adj	VerbForm=Part	1	amod	_	_
 3	agus	agus	CCONJ	Coord	_	5	cc	_	_
 4	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	nmod:poss	_	_
-5	lámha	lámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	conj	_	_
+5	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	conj	_	_
 6	cáidheach	cáidheach	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
 8	roidealach	roidealach	NOUN	Noun	Gender=Masc|Number=Sing	5	nmod	_	_
@@ -3431,7 +3431,7 @@
 2	dtuigtear	tuig	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 3	fós	fós	ADV	Gn	_	2	advmod	_	_
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obl	_	_
+5	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obl	_	_
 6	seo	seo	DET	Det	PronType=Dem	5	det	_	_
 7	cé	cé	SCONJ	Subord	PronType=Int	9	advmod	_	_
 8	chomh	chomh	ADV	Its	_	7	fixed	_	_
@@ -3456,7 +3456,7 @@
 8	go	go	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
 9	dtí	dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	8	fixed	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Tuaisceart	tuaisceart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	_
+11	Tuaisceart	tuaisceart	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 12	i	i	ADP	Simp	_	11	nmod	_	_
 13	gcoitinne	coitinne	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	12	fixed	_	_
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
@@ -3464,7 +3464,7 @@
 16	i	i	ADP	Simp	_	17	case	_	_
 17	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 18	chathair	cathair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	_
-19	Dhoire	Doire	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+19	Dhoire	Doire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
 21	1995	1995	NUM	Num	_	1	obl	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
@@ -3473,7 +3473,7 @@
 25	de	de	ADP	Simp	_	26	case	_	_
 26	bhrabach	brabach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	síochána	síocháin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	26	nmod	_	SpaceAfter=No
+28	síochána	síocháin	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	26	nmod	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 591
@@ -3482,7 +3482,7 @@
 2	Sea	is	AUX	Cop	Tense=Pres|VerbForm=Cop	0	root	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	5	punct	_	_
 4	a	a	PART	Voc	PartType=Voc	5	case:voc	_	_
-5	Dhaid	Daid	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc	2	vocative	_	SpaceAfter=No
+5	Dhaid	Daid	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	2	vocative	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	8	punct	_	_
 7	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	8	cop	_	_
 8	shona	sona	ADJ	Adj	Degree=Pos|Form=Len	2	csubj:cleft	_	SpaceAfter=No
@@ -3498,7 +3498,7 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	rothar	rothar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
-5	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+5	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 593
@@ -3515,7 +3515,7 @@
 10	bheitheá	bí	VERB	Cond	Form=Len|Mood=Cnd|Number=Sing|Person=2	1	advcl	_	_
 11	in	i	ADP	Simp	_	13	case	_	_
 12	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	13	det	_	_
-13	sheasamh	seasamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
+13	sheasamh	seasamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 14	ar	ar	ADP	Simp	_	15	case	_	_
 15	scraith	scraith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obl	_	_
 16	ghlogair	glogar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
@@ -3523,7 +3523,7 @@
 18	nach	nach	PART	Vb	PartType=Cmpl	19	mark:prt	_	_
 19	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	10	conj	_	_
 20	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	21	det	_	_
-21	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	nsubj	_	_
+21	fhios	fios	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nsubj	_	_
 22	agat	ag	ADP	Prep	Number=Sing|Person=2	19	obl:prep	_	_
 23	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	obj	_	_
 24	agus	agus	SCONJ	Subord	_	25	mark	_	_
@@ -3540,7 +3540,7 @@
 6	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 7	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	xcomp:pred	_	_
 8	don	do	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obl	_	_
+9	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 10	úd	úd	DET	Det	PronType=Dem	9	det	_	_
 11	-	-	PUNCT	Punct	_	12	punct	_	_
 12	phléigh	pléigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
@@ -3573,15 +3573,15 @@
 14	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	9	conj	_	_
 15	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	14	nsubj	_	_
 16	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	17	nmod:poss	_	_
-17	cóta	cóta	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
+17	cóta	cóta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
 18	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	béal	béal	NOUN	Noun	Gender=Masc|Number=Sing	14	obl	_	_
+19	béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
 21	íochtar	íochtar	NOUN	Noun	Gender=Masc|Number=Sing	14	conj	_	_
 22	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	cóta	cóta	NOUN	Noun	Gender=Masc|Number=Sing	21	nmod	_	_
+23	cóta	cóta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	25	case	_	_
-25	béal	béal	NOUN	Noun	Gender=Masc|Number=Sing	21	obl	_	_
+25	béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	_
 26	agus	agus	CCONJ	Coord	_	27	cc	_	_
 27	rith	rith	VERB	VTI	Mood=Ind|Tense=Past	14	conj	_	_
 28	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	27	nsubj	_	_
@@ -3608,11 +3608,11 @@
 11	a	a	PART	Inf	PartType=Inf	12	mark	_	_
 12	thógáil	tógáil	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	cheantar	ceantar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+14	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	14	acl:relcl	_	_
 16	léirithe	léirithe	ADJ	Adj	VerbForm=Part	15	xcomp:pred	_	_
 17	sa	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	ghrianghraf	grianghraf	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
+18	ghrianghraf	grianghraf	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 597
@@ -3621,7 +3621,7 @@
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	an-chóngarach	an-chóngarach	ADJ	Adj	Degree=Pos	1	advmod	_	_
 4	don	do	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	bhaile	baile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+5	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 8	mé	mé	PRON	Pers	Number=Sing|Person=1	7	nsubj	_	_
@@ -3644,7 +3644,7 @@
 8	sin	sin	DET	Det	PronType=Dem	7	det	_	_
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	chéidh	céidh	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+11	chéidh	céidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	nDeisceart	deisceart	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
@@ -3653,14 +3653,14 @@
 17	a	a	PART	Vb	PartType=Vb	18	mark:prt	_	_
 18	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nsubj	_	_
+20	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 21	maith	maith	ADJ	Adj	Degree=Pos	18	xcomp:pred	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 599
 # text = Rinne Íosa iarracht ar shólás a thabhairt dóibh: 'Chuir mé amach sa saol sibh gan sparán, ná mála, ná bróga - an raibh aon rud de dhíth oraibh?
 1	Rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-2	Íosa	Íosa	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Íosa	Íosa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	iarracht	iarracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	shólás	sólás	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	3	nmod	_	_
@@ -3709,7 +3709,7 @@
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	osclaíodh	oscail	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 14	don	do	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	phobal	pobal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+15	phobal	pobal	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 16	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	obj	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
 18	1864	1864	NUM	Num	_	13	obl:tmod	_	SpaceAfter=No
@@ -3723,7 +3723,7 @@
 4	trasna	trasna	PART	Inf	PartType=Inf	3	amod	_	_
 5	uathu	ó	ADP	Prep	Number=Plur|Person=3	1	obl:prep	_	_
 6	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	7	nmod:poss	_	_
-7	bhféachaint	féachaint	NOUN	Noun	Form=Ecl|VerbForm=Inf	1	obl	_	_
+7	bhféachaint	féachaint	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	1	obl	_	_
 8	nóiméad	nóiméad	NOUN	Noun	Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3749,20 +3749,20 @@
 7	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	10	cop	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	advcl	_	_
 9	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
-10	mhian	mian	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	8	nmod	_	_
+10	mhian	mian	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	8	nmod	_	_
 11	a	a	PART	Inf	PartType=Inf	12	mark	_	_
 12	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	fulaingt	fulaingt	NOUN	Noun	VerbForm=Vnoun	12	xcomp	_	_
 15	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	case	_	_
-16	chodladh	codladh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
+16	chodladh	codladh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
 17	fém	fém	NOUN	Noun	Gender=Fem|Number=Sing	16	nmod	_	_
 18	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	obl:prep	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	sin	sin	PRON	Dem	PronType=Dem	1	conj	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	nsubj	_	SpaceAfter=No
+23	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	nsubj	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	28	punct	_	_
 25	de	de	ADP	Cmpd	PrepForm=Cmpd	28	case	_	_
 26	réir	réir	ADP	Cmpd	PrepForm=Cmpd	25	fixed	_	_
@@ -3775,7 +3775,7 @@
 33	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	32	nsubj	_	_
 34	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	32	obj	_	_
 35	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
-36	uillinneacha	uillinn	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Strong|Number=Plur	34	nmod	_	_
+36	uillinneacha	uillinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Strong|Number=Plur	34	nmod	_	_
 37	sa	i	ADP	Art	Number=Sing|PronType=Art	38	case	_	_
 38	chloch	cloch	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	32	obl	_	SpaceAfter=No
 39	.	.	PUNCT	.	_	1	punct	_	_
@@ -3804,9 +3804,9 @@
 13	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	_
 14	faoi	faoi	ADP	Simp	_	16	case	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	jabanna	jab	NOUN	Noun	Gender=Masc|Number=Plur	10	nmod	_	_
+16	jabanna	jab	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
-18	gCorcaigh	Corcaigh	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Fem|Number=Plur	16	nmod	_	SpaceAfter=No
+18	gCorcaigh	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	16	nmod	_	SpaceAfter=No
 19	;	;	PUNCT	Punct	_	21	punct	_	_
 20	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	21	advmod	_	_
 21	fheadar	feadair	VERB	_	Form=Len|Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	2	parataxis	_	SpaceAfter=No
@@ -3817,7 +3817,7 @@
 26	gcloisfimis	clois	VERB	VTI	Form=Ecl|Mood=Cnd,Int|Number=Plur|Person=1	21	ccomp	_	_
 27	puinn	puinn	NOUN	Subst	Case=NomAcc|Number=Sing	26	nsubj	_	_
 28	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	29	case	_	_
-29	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	26	obl	_	_
+29	thaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	obl	_	_
 30	mura	mura	SCONJ	Subord	_	31	mark	_	_
 31	labhródh	labhair	VERB	VTI	Mood=Cnd	26	advcl	_	_
 32	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	33	det	_	_
@@ -3859,12 +3859,12 @@
 # sent_id = 607
 # text = Deir Diarmaid gurb é a rinne Tadhg ná bheith ag dul 'ó thír go tír, ó thuaith go tuaith, ó thriúcha go triúcha, ó bhaile go baile, ó thigh go tigh, ó bhothán go bothán, agus ó phosta go piléar, i leith a bheith 'na mháistir scoile, ag milleadh, ag míchorú 's ag maslú Béarla agus Gaeilge, in aghaidh ceartdhlí na bhfáidhe agus na bhfíorollún, agus contrárdha do rialacha léinn agus lán fhoghlamtha chúirte na naoi mbéithe agus Apolló.
 1	Deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-2	Diarmaid	Diarmaid	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Diarmaid	Diarmaid	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	9	cop	_	_
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	9	nsubj	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	mark:prt	_	_
 6	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	4	acl:relcl	_	_
-7	Tadhg	Tadhg	PROPN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
+7	Tadhg	Tadhg	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	ná	ná	CCONJ	Coord	_	9	mark:prt	_	_
 9	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	1	ccomp	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
@@ -3911,7 +3911,7 @@
 51	a	a	PART	Vb	PartType=Vb|PronType=Rel	52	nsubj	_	_
 52	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	11	xcomp	_	_
 53	'na	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	54	case	_	_
-54	mháistir	máistir	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	52	xcomp:pred	_	_
+54	mháistir	máistir	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	52	xcomp:pred	_	_
 55	scoile	scoil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	54	nmod	_	SpaceAfter=No
 56	,	,	PUNCT	Punct	_	57	punct	_	_
 57	ag	ag	ADP	Simp	_	58	case	_	_
@@ -3922,18 +3922,18 @@
 62	's	agus	CCONJ	Coord	_	64	cc	_	_
 63	ag	ag	ADP	Simp	_	64	case	_	_
 64	maslú	maslú	NOUN	Noun	VerbForm=Vnoun	58	conj	_	_
-65	Béarla	Béarla	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	64	obj	_	_
+65	Béarla	Béarla	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	64	obj	_	_
 66	agus	agus	CCONJ	Coord	_	67	cc	_	_
-67	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	65	conj	_	SpaceAfter=No
+67	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	65	conj	_	SpaceAfter=No
 68	,	,	PUNCT	Punct	_	71	punct	_	_
 69	in	in	ADP	Cmpd	PrepForm=Cmpd	71	case	_	_
 70	aghaidh	aghaidh	ADP	Cmpd	PrepForm=Cmpd	69	fixed	_	_
 71	ceartdhlí	ceartdlí	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	52	nmod	_	_
 72	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	73	det	_	_
-73	bhfáidhe	fáidh	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	71	nmod	_	_
+73	bhfáidhe	fáidh	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	71	nmod	_	_
 74	agus	agus	CCONJ	Coord	_	76	cc	_	_
 75	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	76	det	_	_
-76	bhfíorollún	fíorollamh	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	73	conj	_	SpaceAfter=No
+76	bhfíorollún	fíorollamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	73	conj	_	SpaceAfter=No
 77	,	,	PUNCT	Punct	_	78	punct	_	_
 78	agus	agus	CCONJ	Coord	_	79	cc	_	_
 79	contrárdha	contrárdha	ADJ	Adj	Degree=Pos	71	conj	_	_
@@ -3946,9 +3946,9 @@
 86	chúirte	cúirt	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	81	nmod	_	_
 87	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	89	det	_	_
 88	naoi	naoi	NUM	Num	NumType=Card	89	nummod	_	_
-89	mbéithe	bé	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	81	nmod	_	_
+89	mbéithe	bé	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	81	nmod	_	_
 90	agus	agus	CCONJ	Coord	_	91	cc	_	_
-91	Apolló	Apolló	PROPN	Noun	Gender=Masc|Number=Sing	81	conj	_	SpaceAfter=No
+91	Apolló	Apolló	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	81	conj	_	SpaceAfter=No
 92	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 608
@@ -3956,10 +3956,10 @@
 1	Le	le	ADP	Simp	_	2	case	_	_
 2	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	imshruthaithe	imshruthú	NOUN	Noun	Case=Gen|VerbForm=Inf	2	nmod	_	_
+4	imshruthaithe	imshruthú	NOUN	Noun	Case=Gen|Definite=Def|VerbForm=Inf	2	nmod	_	_
 5	tugann	tabhair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	ocsahaemaglóibin	ocsahaemaglóibin	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
+7	ocsahaemaglóibin	ocsahaemaglóibin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	ocsaigin	ocsaigin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obj	_	_
 10	do	do	ADP	Simp	_	12	case	_	_
@@ -3972,7 +3972,7 @@
 1	Buailimid	buail	VERB	PresInd	Mood=Ind|Number=Plur|Person=1|Tense=Pres	0	root	_	_
 2	leis	le	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	bhfeiniméan	feiniméan	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+4	bhfeiniméan	feiniméan	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 5	céanna	céanna	ADJ	Adj	Gender=Masc|Number=Sing	4	amod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	8	punct	_	_
 7	'	'	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
@@ -3986,20 +3986,20 @@
 15	croise	cros	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	_
 16	leis	le	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	síol	síol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
+18	síol	síol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 19	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	18	acl:relcl	_	_
 20	á	do	ADP	Poss	Person=3|PronType=Prs	21	case	_	_
 21	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
 22	san	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	earrach	earrach	NOUN	Noun	Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
+23	earrach	earrach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
 25	i	i	ADP	Simp	_	26	case	_	_
 26	gcuntas	cuntas	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 27	suntasach	suntasach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	26	amod	_	_
 28	ó	ó	ADP	Simp	_	29	case	_	_
 29	Chontae	contae	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
-30	Loch	Loch	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
-31	Garman	Garman	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes|SpaceAfter=No
+30	Loch	Loch	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
+31	Garman	Garman	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes|SpaceAfter=No
 32	:	:	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4010,7 +4010,7 @@
 3	imréitigh	imréiteach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
 4	cánach	cáin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
 5	arna	ar	ADP	Poss	Number=Plur|Person=3|Poss=Yes	6	case	_	_
-6	eisiúint	eisiúint	NOUN	Noun	VerbForm=Inf	2	nmod	_	_
+6	eisiúint	eisiúint	NOUN	Noun	Definite=Def|VerbForm=Inf	2	nmod	_	_
 7	ag	ag	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	Coimisinéirí	coimisinéir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	obl	_	NamedEntity=Yes
@@ -4041,8 +4041,8 @@
 4	chuig	chuig	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	obair	obair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
-7	Dé	Dé	PROPN	Subst	Number=Sing	6	obl:tmod	_	NamedEntity=Yes
-8	Sathairn	Satharn	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Dé	Dé	PROPN	Subst	Definite=Def|Number=Sing	6	obl:tmod	_	NamedEntity=Yes
+8	Sathairn	Satharn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	chomh	chomh	ADV	Its	_	2	advmod	_	_
 10	maith	maith	ADJ	Adj	Degree=Pos	9	fixed	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	_	_
@@ -4072,16 +4072,16 @@
 # sent_id = 615
 # text = Thuig Mary Harney é seo go breá, agus Charlie McCreevy.
 1	Thuig	tuig	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Mary	Mary	PROPN	Noun	Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Harney	Harney	PROPN	Noun	Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+2	Mary	Mary	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Harney	Harney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	obj	_	_
 5	seo	seo	PRON	Dem	PronType=Dem	2	det	_	_
 6	go	go	PART	Ad	PartType=Ad	7	mark:prt	_	_
 7	breá	breá	ADJ	Adj	Degree=Pos	1	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
-10	Charlie	Charlie	PROPN	Noun	Gender=Masc|Number=Sing	2	conj	_	NamedEntity=Yes
-11	McCreevy	McCreevy	PROPN	Noun	Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+10	Charlie	Charlie	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	conj	_	NamedEntity=Yes
+11	McCreevy	McCreevy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 616
@@ -4089,20 +4089,20 @@
 1	Tharla	tarlaigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	maolú	maolú	NOUN	Noun	VerbForm=Inf	1	nsubj	_	_
 3	dá	de	ADP	Poss	Poss=Yes	4	case	_	_
-4	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+4	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl:tmod	_	_
+6	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl:tmod	_	_
 7	1241	1241	NUM	Num	_	6	nmod	_	_
 8	nuair	nuair	SCONJ	Subord	_	10	mark	_	_
 9	a	a	PART	Vb	PartType=Vb|PronType=Rel	10	mark:prt	_	_
 10	fuair	faigh	VERB	PastInd	Mood=Ind|Tense=Past	1	advcl	_	_
-11	Ogedei	Ogedei	PROPN	Noun	Gender=Fem|Number=Sing	10	nsubj	_	_
+11	Ogedei	Ogedei	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nsubj	_	_
 12	bás	bás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obj	_	_
 13	(	(	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
 14	mac	mac	NOUN	Noun	Gender=Masc|Number=Sing	11	appos	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
-16	Geingeas	Geingeas	PROPN	Noun	Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
-17	Cán	Cán	PROPN	Noun	Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
+16	Geingeas	Geingeas	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+17	Cán	Cán	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	nsubj	_	_
 19	tháinig	tar	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	16	acl:relcl	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
@@ -4116,9 +4116,9 @@
 1	É	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	0	root	_	_
 2	fein	féin	PRON	Ref	Reflex=Yes|Typo=Yes	1	nmod	_	_
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
-4	Tomás	Tomás	PROPN	Noun	Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
+4	Tomás	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
 5	Ó	ó	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Concheanainn	Concheanainn	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+6	Concheanainn	Concheanainn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 7	(	(	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
 8	1870-1961	1870-1961	NUM	Num	_	4	nmod	_	SpaceAfter=No
 9	)	)	PUNCT	Punct	_	8	punct	_	_
@@ -4175,9 +4175,9 @@
 31	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	26	xcomp	_	_
 32	chuig	chuig	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	gCúirt	cúirt	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
+34	gCúirt	cúirt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
 35	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	case	_	_
-36	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	31	nmod	_	_
+36	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	31	nmod	_	_
 37	faoi	faoi	ADP	Simp	_	38	case	_	_
 38	deara	deara	NOUN	Subst	Number=Sing	31	nmod	_	_
 39	oibriú	oibriú	NOUN	Noun	VerbForm=Inf	43	obj	_	_
@@ -4215,7 +4215,7 @@
 71	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	72	det	_	_
 72	fhógra	fógra	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	70	nmod	_	_
 73	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	74	case	_	_
-74	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	69	obl	_	_
+74	réir	réir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	69	obl	_	_
 75	sin	sin	PRON	Dem	PronType=Dem	74	det	_	SpaceAfter=No
 76	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -4223,11 +4223,11 @@
 # text = (Ó Floinn, agus Mac Cana, 1956, 214) I gCath Almhaine is léir gur Naomh Críostaí é Colm Cille.
 1	(	(	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Ó	ó	PART	Pat	PartType=Pat	17	parataxis	_	NamedEntity=Yes
-3	Floinn	Floinn	PROPN	Noun	Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+3	Floinn	Floinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	6	punct	_	_
 5	agus	agus	CCONJ	Coord	_	6	cc	_	_
 6	Mac	mac	PART	Pat	PartType=Pat	2	conj	_	NamedEntity=Yes
-7	Cana	Cana	PROPN	Noun	Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+7	Cana	Cana	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	1956	1956	NUM	Num	_	6	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
@@ -4235,26 +4235,26 @@
 12	)	)	PUNCT	Punct	_	2	punct	_	_
 13	I	i	ADP	Simp	_	14	case	_	_
 14	gCath	cath	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	NamedEntity=Yes
-15	Almhaine	Almhain	PROPN	Noun	Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
+15	Almhaine	Almhain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	17	cop	_	_
 17	léir	léir	ADJ	Adj	Degree=Pos	0	root	_	_
 18	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	19	cop	_	_
 19	Naomh	naomh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	csubj:cop	_	NamedEntity=Yes
 20	Críostaí	Críostaí	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	19	amod	_	NamedEntity=Yes
 21	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nmod	_	_
-22	Colm	Colm	PROPN	Noun	Gender=Masc|Number=Sing	21	nsubj	_	NamedEntity=Yes
-23	Cille	Cille	PROPN	Noun	_	22	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+22	Colm	Colm	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	NamedEntity=Yes
+23	Cille	Cille	PROPN	Noun	Definite=Def	22	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 24	.	.	PUNCT	.	_	17	punct	_	_
 
 # sent_id = 621
 # text = TOMÁS: Cé bhí, a stór?
-1	TOMÁS	Tomás	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+1	TOMÁS	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	4	punct	_	_
 3	Cé	cé	PRON	Q	PronType=Int	4	nsubj	_	_
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	7	punct	_	_
 6	a	a	PART	Voc	PartType=Voc	7	case:voc	_	_
-7	stór	stór	NOUN	Noun	Case=Voc|Gender=Masc|Number=Sing	4	vocative	_	SpaceAfter=No
+7	stór	stór	NOUN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	4	vocative	_	SpaceAfter=No
 8	?	?	PUNCT	?	_	1	punct	_	_
 
 # sent_id = 622
@@ -4268,7 +4268,7 @@
 7	seo	seo	PRON	Dem	PronType=Dem	6	det	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	a	a	PART	Voc	PartType=Voc	10	case:voc	_	_
-10	Tom	Tom	PROPN	Noun	Case=Voc|Gender=Masc|Number=Sing	1	vocative	_	SpaceAfter=No
+10	Tom	Tom	PROPN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	1	vocative	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 623
@@ -4285,7 +4285,7 @@
 2	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
 3	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	tí	teach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	obj	_	_
+5	tí	teach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 6	chugam	chuig	ADP	Prep	Number=Sing|Person=1	1	obl:prep	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4308,7 +4308,7 @@
 15	,	,	PUNCT	Punct	_	12	punct	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
 17	páipéir	páipéar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
-18	Bhéarla	Béarla	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
+18	Bhéarla	Béarla	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
 21	tseachtain	seachtain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl:tmod	_	_
@@ -4322,14 +4322,14 @@
 29	Aire	aire	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
 30	Oideachais	oideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes|SpaceAfter=No
 31	,	,	PUNCT	Punct	_	32	punct	_	_
-32	Máirtín	Máirtín	PROPN	Noun	Case=Gen|Gender=Masc	29	appos	_	NamedEntity=Yes
+32	Máirtín	Máirtín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	29	appos	_	NamedEntity=Yes
 33	Mac	mac	PART	Pat	PartType=Pat	32	flat:name	_	NamedEntity=Yes
-34	Aonghusa	Aonghus	PROPN	Noun	Case=Gen|Gender=Masc	33	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+34	Aonghusa	Aonghus	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	33	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 35	,	,	PUNCT	Punct	_	37	punct	_	_
 36	nach	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	37	cop	_	_
 37	leor	leor	ADJ	Adj	Degree=Pos	25	ccomp	_	_
 38	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	39	det	_	_
-39	rogha	rogha	NOUN	Noun	Gender=Fem|Number=Sing	37	nsubj	_	_
+39	rogha	rogha	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	37	nsubj	_	_
 40	a	a	PART	Inf	PartType=Inf	41	mark	_	_
 41	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	37	csubj:cop	_	_
 42	ag	ag	ADP	Simp	_	43	case	_	_
@@ -4340,7 +4340,7 @@
 47	a	a	PART	Vb	PartType=Vb|PronType=Rel	48	obl	_	_
 48	rachaidh	téigh	VERB	VTI	Mood=Ind|Tense=Fut	46	acl:relcl	_	_
 49	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	50	nmod:poss	_	_
-50	bpáistí	páiste	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	48	nsubj	_	_
+50	bpáistí	páiste	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	48	nsubj	_	_
 51	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	48	obl:prep	_	SpaceAfter=No
 52	.	.	PUNCT	.	_	25	punct	_	_
 
@@ -4359,13 +4359,13 @@
 3	aon	aon	DET	Det	PronType=Ind	4	det	_	_
 4	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	nsubj	_	_
 5	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	case	_	_
-6	íoc	íoc	NOUN	Noun	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
+6	íoc	íoc	NOUN	Noun	Definite=Def|VerbForm=Inf	2	xcomp	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 628
 # text = An bháine idir dhúch na bhfocal mar a bheadh an t-aer ag trilsiú trí fholt na gcrann.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	bháine	báine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
+2	bháine	báine	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 3	idir	idir	ADP	Simp	_	4	case	_	_
 4	dhúch	dúch	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
@@ -4390,11 +4390,11 @@
 3	mháthair	máthair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	suite	suite	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	gclúid	clúid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+6	gclúid	clúid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	cniotáil	cniotáil	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 9	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	_
+10	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
 11	seo	seo	DET	Det	PronType=Dem	10	det	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4411,18 +4411,18 @@
 9	fógraíodh	fógair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	7	acl:relcl	_	_
 10	seo	seo	PRON	Dem	PronType=Dem	9	obj	_	_
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
-12	Mary	Mary	PROPN	Noun	Gender=Fem|Number=Sing	9	nsubj	_	NamedEntity=Yes
-13	Gavin	Gavin	PROPN	Noun	Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
+12	Mary	Mary	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	9	nsubj	_	NamedEntity=Yes
+13	Gavin	Gavin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
 14	agus	agus	CCONJ	Coord	_	15	cc	_	_
-15	Johanna	Johanna	PROPN	Noun	Gender=Fem|Number=Sing	12	conj	_	NamedEntity=Yes
-16	McInerney	McInerney	PROPN	Noun	Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+15	Johanna	Johanna	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	conj	_	NamedEntity=Yes
+16	McInerney	McInerney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 17	,	,	PUNCT	Punct	_	18	punct	_	_
 18	Teach	teach	NOUN	Noun	Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
-19	Cheeverstown	Cheeverstown	PROPN	Noun	Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
+19	Cheeverstown	Cheeverstown	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
-21	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-22	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
-23	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes|SpaceAfter=No
+21	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+22	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
+23	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes|SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 631
@@ -4430,7 +4430,7 @@
 1	Dá	dá	SCONJ	Subord	_	2	mark	_	_
 2	dtosuigheadh	tosaigh	VERB	VTI	Form=Ecl|Mood=Cnd	19	advcl	_	_
 3	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	hinghean	inghean	NOUN	Noun	Form=HPref|Gender=Fem|Number=Sing	2	nsubj	_	_
+4	hinghean	inghean	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	ag	ag	ADP	Simp	_	6	case	_	_
 6	séideadh	séideadh	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 7	fúithe	faoi	ADP	Prep	Gender=Fem|Number=Sing|Person=3	6	obl:prep	_	_
@@ -4448,7 +4448,7 @@
 19	bheag	beag	ADJ	Adj	Degree=Pos|Form=Len	0	root	_	_
 20	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	22	nmod	_	_
 21	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	22	nmod:poss	_	_
-22	hacmhuinn	acmhainn	NOUN	Noun	Form=HPref|Gender=Fem|Number=Sing	19	nsubj	_	_
+22	hacmhuinn	acmhainn	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Sing	19	nsubj	_	_
 23	thar	thar	ADP	Simp	_	22	advmod	_	_
 24	agus	agus	CCONJ	Coord	_	23	fixed	_	_
 25	ariamh	ariamh	ADV	Gn	_	23	fixed	_	SpaceAfter=No
@@ -4460,14 +4460,14 @@
 2	léir	léir	ADJ	Adj	Degree=Pos	0	root	_	_
 3	don	do	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
 4	dá	dó	NUM	Num	Definite=Def|NumType=Card	5	nummod	_	_
-5	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+5	thaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 6	nach	nach	PART	Vb	PartType=Cmpl	7	obl	_	_
 7	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	csubj:cop	_	_
 8	spéis	spéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nsubj	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	bunáite	bunáite	NOUN	Noun	Gender=Fem|Number=Sing	7	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	vótóirí	vótóir	NOUN	Noun	Gender=Masc|Number=Plur	10	nmod	_	_
+12	vótóirí	vótóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
 14	mionfhorálacha	mionfhoráil	NOUN	Noun	Gender=Fem|Number=Plur	7	obl	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -4485,7 +4485,7 @@
 7	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	10	cop	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	10	nmod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	gath	gath	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+10	gath	gath	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 11	ba	is	PART	Sup	PartType=Sup|Tense=Past|VerbForm=Cop	19	mark:prt	_	_
 12	ghile	geal	ADJ	Adj	Degree=Cmp,Sup|Form=Len	10	amod	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
@@ -4530,7 +4530,7 @@
 20	a	a	PART	Vb	PartType=Vb	21	mark:prt	_	_
 21	thaispeáin	taispeáin	VERB	VT	Form=Len|Mood=Ind|Tense=Past	10	advcl	_	_
 22	suirbhé	suirbhé	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nsubj	_	_
-23	Nielson	Nielson	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	_
+23	Nielson	Nielson	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	_
 24	ach	ach	SCONJ	Subord	_	26	mark	_	_
 25	ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	26	cop	_	_
 26	leor	leor	ADJ	Adj	Degree=Pos	2	advcl	_	_
@@ -4541,7 +4541,7 @@
 # text = I gceantar Anagaire mar shampla tá ar a laghad deich mbaile fearainn nach dtugtar aitheantas díobhtha i seoladh an vótóra rud a chiallaíonn go mbíonn an seoladh poist céanna ag na vótóirí uilig.
 1	I	I	ADP	Simp	_	2	case	_	_
 2	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
-3	Anagaire	Anagaire	PROPN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+3	Anagaire	Anagaire	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 4	mar	mar	ADP	Simp	_	5	case	_	_
 5	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -4558,7 +4558,7 @@
 17	i	i	ADP	Simp	_	18	case	_	_
 18	seoladh	seoladh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	vótóra	vótóir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	_
+20	vótóra	vótóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	_
 21	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	parataxis	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	nsubj	_	_
 23	chiallaíonn	ciallaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	21	acl:relcl	_	_
@@ -4570,7 +4570,7 @@
 29	céanna	céanna	ADJ	Adj	Degree=Pos	27	amod	_	_
 30	ag	ag	ADP	Simp	_	32	case	_	_
 31	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	32	det	_	_
-32	vótóirí	vótóir	NOUN	Noun	Gender=Fem|Number=Plur	25	obl	_	_
+32	vótóirí	vótóir	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	25	obl	_	_
 33	uilig	uile	DET	Det	_	32	det	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -4655,13 +4655,13 @@
 # text = Go bhfága Dia a leanbh féin agus a bheithíoch féin ag chuile chréatúr!
 1	Go	go	PART	Vb	PartType=Cmpl	2	mark:prt	_	_
 2	bhfága	fág	VERB	VTI	Form=Ecl|Mood=Sub|Tense=Pres	0	root	_	_
-3	Dia	Dia	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+3	Dia	Dia	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	nmod:poss	_	_
-5	leanbh	leanbh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
+5	leanbh	leanbh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 6	féin	féin	PRON	Ref	Reflex=Yes	5	nmod	_	_
 7	agus	agus	CCONJ	Coord	_	9	cc	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	nmod:poss	_	_
-9	bheithíoch	beithíoch	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
+9	bheithíoch	beithíoch	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
 10	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 11	ag	ag	ADP	Simp	_	13	case	_	_
 12	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	13	det	_	_
@@ -4680,16 +4680,16 @@
 # sent_id = 640
 # text = 'Dia dhuit, a Mhíchíl,' a deir Sándra leis, 'tá áthas orm bualadh leat.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Dia	Dia	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	parataxis	_	_
+2	Dia	Dia	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	parataxis	_	_
 3	dhuit	do	ADP	Prep	Form=Len|Number=Sing|Person=2	2	obl:prep	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	a	a	PART	Voc	PartType=Voc	6	case:voc	_	_
-6	Mhíchíl	Mícheál	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	10	vocative	_	SpaceAfter=No
+6	Mhíchíl	Mícheál	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	vocative	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
 8	'	'	PUNCT	Punct	_	6	punct	_	_
 9	a	a	PART	Vb	PartType=Vb|PronType=Rel	10	mark:prt	_	_
 10	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-11	Sándra	Sándra	PROPN	Noun	Gender=Masc|Number=Sing	10	nsubj	_	_
+11	Sándra	Sándra	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
 12	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	10	obl:prep	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	'	'	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
@@ -4705,7 +4705,7 @@
 1	Táimid	bí	VERB	PresInd	Mood=Ind|Number=Plur|Person=1|Tense=Pres	0	root	_	_
 2	uilig	uile	ADJ	Adj	Degree=Pos	1	amod	_	_
 3	sa	i	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
-4	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+4	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 5	seo	seo	DET	Det	PronType=Dem	4	det	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	thuaidh	thuaidh	ADV	Dir	_	1	advmod	_	_
@@ -4721,7 +4721,7 @@
 17	cailleadh	cailleadh	NOUN	Noun	VerbForm=Inf	16	obj	_	_
 18	acmhainní	acmhainn	NOUN	Noun	Case=Gen|Gender=Fem|Number=Plur	17	nmod	_	_
 19	den	de	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	chineál	cineál	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
+20	chineál	cineál	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
 21	seo	seo	DET	Det	PronType=Dem	20	det	_	_
 22	do	do	ADP	Simp	_	23	case	_	_
 23	mheanma	meanma	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	16	obl	_	_
@@ -4749,36 +4749,36 @@
 17	shioc	sioc	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	6	conj	_	_
 18	fuil	fuil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	nsubj	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	chuairteora	cuairteoir	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+20	chuairteora	cuairteoir	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	aonair	aonar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	_
 22	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
-23	chuislí	cuisle	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	17	obl	_	SpaceAfter=No
+23	chuislí	cuisle	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	17	obl	_	SpaceAfter=No
 24	:	:	PUNCT	Punct	_	25	punct	_	_
 25	cloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	parataxis	_	_
 26	gearrtha	gearrtha	ADJ	Adj	VerbForm=Part	25	amod	_	_
-27	Eoin	Eoin	PROPN	Noun	Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
-28	Baiste	baiste	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	27	flat:name	_	NamedEntity=Yes
+27	Eoin	Eoin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
+28	Baiste	baiste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	flat:name	_	NamedEntity=Yes
 29	a	a	PART	Vb	PartType=Vb|PronType=Rel	30	nsubj	_	_
 30	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	25	csubj:cleft	_	_
-31	Héaród	Héaród	PROPN	Noun	Gender=Masc|Number=Sing	30	nsubj	_	_
+31	Héaród	Héaród	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	30	nsubj	_	_
 32	nó	nó	CCONJ	Coord	_	33	cc	_	_
 33	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	31	conj	_	_
 34	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	33	amod	_	_
 35	a	a	ADP	Simp	_	36	case	_	_
 36	iompar	iompar	NOUN	Noun	VerbForm=Inf	30	xcomp	_	_
 37	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	38	case	_	_
-38	lámha	lámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	36	obl	_	SpaceAfter=No
+38	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	36	obl	_	SpaceAfter=No
 39	,	,	PUNCT	Punct	_	42	punct	_	_
 40	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	42	cop	_	_
 41	iad	iad	PRON	Pers	Number=Plur|Person=3	42	nmod	_	_
 42	ceannaithe	ceannaghaidh	NOUN	Noun	Gender=Fem|Number=Plur	25	parataxis	_	_
 43	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	44	nmod:poss	_	_
-44	thiarna	tiarna	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	42	nsubj	_	_
+44	thiarna	tiarna	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	42	nsubj	_	_
 45	féin	féin	PRON	Ref	Reflex=Yes	44	nmod	_	SpaceAfter=No
 46	,	,	PUNCT	Punct	_	47	punct	_	_
-47	Ulrik	Ulrik	PROPN	Noun	Gender=Masc|Number=Sing	44	appos	_	NamedEntity=Yes
+47	Ulrik	Ulrik	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	44	appos	_	NamedEntity=Yes
 48	de	de	PART	Pat	PartType=Pat	47	flat:name	_	NamedEntity=Yes
-49	Celje	Celje	PROPN	Noun	Gender=Masc|Number=Sing	47	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+49	Celje	Celje	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	47	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 50	,	,	PUNCT	Punct	_	47	punct	_	_
 51	a	a	PART	Vb	PartType=Vb|PronType=Rel	52	mark:prt	_	_
 52	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	42	csubj:cleft	_	_
@@ -4830,7 +4830,7 @@
 18	úsáid	úsáid	NOUN	Noun	VerbForm=Inf	14	conj	_	_
 19	fhéinmhuiníneach	féinmhuiníneach	ADJ	Adj	Degree=Pos|Form=Len	18	amod	_	_
 20	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	21	det	_	_
-21	matamaitice	matamaitic	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	_
+21	matamaitice	matamaitic	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	18	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
 23	réimsí	réimse	NOUN	Noun	Gender=Masc|Number=Plur	11	obl	_	_
 24	eile	eile	DET	Det	PronType=Dem	26	det	_	_
@@ -4838,7 +4838,7 @@
 26	churaclaim	curaclam	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	agus	agus	CCONJ	Coord	_	29	cc	_	_
 28	sa	i	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
-29	ghnáthshaol	gnáthshaol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	conj	_	SpaceAfter=No
+29	ghnáthshaol	gnáthshaol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	conj	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 644
@@ -4868,14 +4868,14 @@
 15	ar	ar	ADP	Simp	_	16	case	_	_
 16	fáil	fáil	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
 17	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	18	case	_	_
-18	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
+18	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
 19	agus	agus	CCONJ	Coord	_	20	cc	_	_
 20	comhoibreoidh	comhoibrigh	VERB	VI	Mood=Ind|Tense=Fut	8	conj	_	_
 21	siad	siad	PRON	Pers	Number=Plur|Person=3	20	nsubj	_	_
 22	le	le	ADP	Simp	_	23	case	_	_
 23	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	20	obl	_	_
 24	trína	trí	ADP	Poss	Number=Plur|Person=3|Poss=Yes	25	case	_	_
-25	riaracháin	riarachán	NOUN	Noun	Gender=Masc|Number=Plur	20	obl	_	_
+25	riaracháin	riarachán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	obl	_	_
 26	chustaim	custam	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
 27	d'	de	ADP	Simp	_	28	case	_	SpaceAfter=No
 28	fhonn	fonn	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
@@ -4935,13 +4935,13 @@
 20	ar	ar	ADP	Simp	_	23	case	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	26ú	26	NUM	Num	NumType=Ord	10	obl:tmod	_	NamedEntity=Yes
-23	Márta	Márta	PROPN	Noun	Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes|SpaceAfter=No
+23	Márta	Márta	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes|SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 647
 # text = I Márta bhí beagnach 700 i bpríosún, dar le de h-Íde, a d'iarr ar John Quinn cur ar son saor-Éireann sna Stáit.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	Márta	Márta	PROPN	Noun	Gender=Masc|Number=Sing	3	obl:tmod	_	_
+2	Márta	Márta	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	obl:tmod	_	_
 3	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 4	beagnach	beagnach	ADV	Gn	_	3	advmod	_	_
 5	700	700	NUM	Num	_	3	nsubj	_	_
@@ -4951,20 +4951,20 @@
 9	dar	dar	VERB	PresInd	Mood=Ind|Tense=Pres	3	parataxis	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	de	de	PART	Pat	PartType=Pat	9	obl	_	NamedEntity=Yes
-12	h-Íde	Íde	PROPN	Noun	Form=HPref|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+12	h-Íde	Íde	PROPN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	obj	_	_
 15	d'	do	PART	Vb	PartType=Vb	16	mark:prt	_	SpaceAfter=No
 16	iarr	iarr	VERB	VT	Mood=Ind|Tense=Past	11	acl:relcl	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
-18	John	John	PROPN	Noun	Gender=Masc|Number=Sing	16	obl	_	NamedEntity=Yes
-19	Quinn	Quinn	PROPN	Noun	Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
+18	John	John	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	obl	_	NamedEntity=Yes
+19	Quinn	Quinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
 20	cur	cur	NOUN	Noun	VerbForm=Inf	16	xcomp	_	_
 21	ar	ar	ADP	Cmpd	PrepForm=Cmpd	23	case	_	_
 22	son	son	ADP	Cmpd	PrepForm=Cmpd	21	fixed	_	_
-23	saor-Éireann	saor-Éire	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	obl	_	_
+23	saor-Éireann	saor-Éire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 24	sna	i	ADP	Art	Number=Plur|PronType=Art	25	case	_	_
-25	Stáit	stát	NOUN	Noun	Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
+25	Stáit	stát	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 648
@@ -4972,7 +4972,7 @@
 1	D'	do	PART	Vb	PartType=Vb	2	mark:prt	_	SpaceAfter=No
 2	éirigh	éirigh	VERB	VI	Mood=Ind|Tense=Past	0	root	_	_
 3	sa	i	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
-4	scrúdú	scrúdú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
+4	scrúdú	scrúdú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 5	leis	le	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	mac	mac	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
@@ -4983,7 +4983,7 @@
 # text = Cuirfidh gach imreoir fáilte roimh na gnéithe nua seo ach níl aon amhras ann ach nach mbeadh na hathruithe seo tarlaithe murach an brú a chuir an GPA orthu, agus go mbeidh a thuilleadh ag teacht.
 1	Cuirfidh	cuir	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 2	gach	gach	DET	Det	Definite=Def	3	det	_	_
-3	imreoir	imreoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	imreoir	imreoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	fáilte	fáilte	NOUN	Noun	Gender=Fem|Number=Sing	1	obj	_	_
 5	roimh	roimh	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
@@ -5036,7 +5036,7 @@
 12	teacht	teacht	NOUN	Noun	VerbForm=Inf	11	obj	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	15	det	_	_
-15	haltraí	altra	NOUN	Noun	Form=HPref|Gender=Masc|Number=Plur	12	obl	_	_
+15	haltraí	altra	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	12	obl	_	_
 16	rollaithe	rollaithe	ADJ	Adj	VerbForm=Part	15	amod	_	_
 17	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	15	acl:relcl	_	_
 18	ag	ag	ADP	Simp	_	19	case	_	_
@@ -5070,12 +5070,12 @@
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
 2	crochadh	croch	VERB	PastInd	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	tUrramhach	urramach	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	2	obj	_	NamedEntity=Yes
-5	James	James	PROPN	Noun	_	4	flat	_	NamedEntity=Yes
-6	Porter	Porter	PROPN	Noun	_	5	flat:name	_	NamedEntity=Yes
+4	tUrramhach	urramach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	2	obj	_	NamedEntity=Yes
+5	James	James	PROPN	Noun	Definite=Def	4	flat	_	NamedEntity=Yes
+6	Porter	Porter	PROPN	Noun	Definite=Def	5	flat:name	_	NamedEntity=Yes
 7	láimh	lámh	NOUN	Noun	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
 8	lena	le	ADP	Poss	Poss=Yes	9	case	_	_
-9	theach	teach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+9	theach	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 10	pobail	pobal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
 11	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
@@ -5139,7 +5139,7 @@
 5	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	6	cop	_	_
 6	eisean	eisean	PRON	Pers	Gender=Masc|Number=Sing|Person=3|PronType=Emp	0	root	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	Briotanach	Briotanach	NOUN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
+8	Briotanach	Briotanach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	is	is	PART	Sup	PartType=Sup|Tense=Pres|VerbForm=Cop	19	mark:prt	_	_
 10	fearr	maith	ADJ	Adj	Degree=Cmp,Sup	8	amod	_	_
 11	ar	ar	ADP	Simp	_	10	nmod	_	_
@@ -5185,9 +5185,9 @@
 22	seo	seo	DET	Det	PronType=Dem	21	det	_	_
 23	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	obj	_	_
 24	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	21	acl:relcl	_	_
-25	Séamus	Séamus	PROPN	Noun	Gender=Masc|Number=Sing	24	nsubj	_	NamedEntity=Yes
+25	Séamus	Séamus	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	NamedEntity=Yes
 26	Ó	ó	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
-27	Grianna	Grianna	PROPN	Noun	Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
+27	Grianna	Grianna	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
 28	agus	agus	CCONJ	Coord	_	30	cc	_	_
 29	cé	cé	PRON	Q	PronType=Int	17	conj	_	_
 30	eile	eile	DET	Det	PronType=Dem	29	det	_	_
@@ -5207,7 +5207,7 @@
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	brionglóidigh	brionglóideach	NOUN	Noun	Case=Dat|Gender=Fem|Number=Sing	1	xcomp	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	oíche	oíche	NOUN	Noun	Gender=Fem|Number=Sing	1	obl	_	_
+6	oíche	oíche	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 7	go	go	PART	Vb	PartType=Cmpl	8	mark:prt	_	_
 8	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 9	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nsubj	_	_
@@ -5220,7 +5220,7 @@
 16	síobadh	síobadh	NOUN	Noun	VerbForm=Vnoun	14	xcomp:pred	_	_
 17	mara	muir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	obj	_	_
 18	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	bord	bord	NOUN	Noun	Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
+19	bord	bord	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 658
@@ -5228,18 +5228,18 @@
 1	Tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	chluiche	cluiche	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+4	chluiche	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	ceannais	ceannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
 6	in	in	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 7	aghaidh	aghaidh	ADP	Cmpd	PrepForm=Cmpd	6	fixed	_	_
 8	Thír	Tír	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
-9	Eoghain	Eoghan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+9	Eoghain	Eoghan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	agus	agus	CCONJ	Coord	_	12	cc	_	_
 11	d'	do	PART	Vb	PartType=Vb	12	mark:prt	_	SpaceAfter=No
 12	éirigh	éirigh	VERB	VI	Mood=Ind|Tense=Past	1	conj	_	_
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	PronType=Art	15	det	_	_
-15	Laighnigh	Laighneach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
+15	Laighnigh	Laighneach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 16	cúl	cúl	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
 17	cinniúnach	cinniúnach	ADJ	Adj	Degree=Pos	16	amod	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
@@ -5247,7 +5247,7 @@
 20	-	-	PUNCT	Punct	_	21	punct	_	_
 21	scór	scór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	parataxis	_	_
 22	na	na	DET	Art	PronType=Art	23	det	_	_
-23	bua	bua	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
+23	bua	bua	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
 25	gan	gan	ADP	Simp	_	26	case	_	_
 26	amhras	amhras	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
@@ -5279,7 +5279,7 @@
 # text = Ar an ábhar sin, ba chóir bheith ag smaoineamh ar straitéisí nua maidir le múineadh na teanga.
 1	Ar	ar	ADP	Simp	_	3	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	ábhar	ábhar	NOUN	Noun	Gender=Masc|Number=Sing	7	obl	_	_
+3	ábhar	ábhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 4	sin	sin	DET	Det	PronType=Dem	3	det	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	3	punct	_	_
 6	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	7	cop	_	_
@@ -5309,12 +5309,12 @@
 8	i	i	ADP	Simp	_	9	case	_	_
 9	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	scoile	scoil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
+11	scoile	scoil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	nGaeltacht	Gaeltacht	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
-14	Dhoire	Doire	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
-15	Bhó	bó	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
-16	Riada	Riada	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
+13	nGaeltacht	Gaeltacht	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+14	Dhoire	Doire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
+15	Bhó	bó	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
+16	Riada	Riada	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 663
@@ -5324,12 +5324,12 @@
 3	mé	mé	PRON	Pers	Number=Sing|Person=1	2	nsubj	_	_
 4	féin	féin	PRON	Ref	Reflex=Yes	3	nmod	_	_
 5	agus	agus	CCONJ	Coord	_	6	cc	_	_
-6	Padaí	Padaí	PROPN	Noun	Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
+6	Padaí	Padaí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
 7	Mór	Mór	ADJ	Adj	Gender=Masc|Number=Sing	6	amod	_	NamedEntity=Yes
 8	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 9	dtigh	teach	NOUN	Noun	Case=Dat|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
-10	Dhónaill	Dónall	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-11	Bhrocaigh	Brocach	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
+10	Dhónaill	Dónall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+11	Bhrocaigh	Brocach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	-	-	PUNCT	Punct	_	13	punct	_	_
 13	cupla	cupla	NOUN	Noun	Gender=Masc|Number=Plur	2	parataxis	_	_
 14	deoch	deoch	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
@@ -5355,7 +5355,7 @@
 11	stánadh	stánadh	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	boilgíní	boilgín	NOUN	Noun	Gender=Masc|Number=Plur	11	obl	_	_
+14	boilgíní	boilgín	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
 16	tsiúl	siúl	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
@@ -5363,7 +5363,7 @@
 19	go	go	PART	Ad	PartType=Ad	20	mark:prt	_	_
 20	hingearach	ingearach	ADJ	Adj	Degree=Pos|Form=HPref	18	advmod	_	_
 21	sa	i	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
-22	ghloine	gloine	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	18	nmod	_	SpaceAfter=No
+22	ghloine	gloine	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 665
@@ -5371,7 +5371,7 @@
 1	Éirigh	éirigh	VERB	VI	Mood=Imp|Number=Sing|Person=2	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	Punct	_	4	punct	_	_
 3	a	a	PART	Voc	PartType=Voc	4	case:voc	_	_
-4	shreamaide	sreamaide	NOUN	Noun	Case=Voc|Form=Len|Gender=Fem|Number=Sing	1	vocative	_	_
+4	shreamaide	sreamaide	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	vocative	_	_
 5	gan	gan	ADP	Simp	_	6	case	_	_
 6	úsáid	úsáid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
@@ -5380,7 +5380,7 @@
 # text = FEIDHMEANNA NA mBAILTE.
 1	FEIDHMEANNA	feidhm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 2	NA	na	DET	Art	PronType=Art	3	det	_	_
-3	mBAILTE	baile	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	1	nmod	_	SpaceAfter=No
+3	mBAILTE	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 667
@@ -5430,7 +5430,7 @@
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	obj	_	_
 7	fhaightear	faigh	VERB	VT	Form=Len|Mood=Ind|Person=0|Tense=Pres	4	acl:relcl	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	Mheánmhuir	Meánmhuir	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	obl	_	SpaceAfter=No
+9	Mheánmhuir	Meánmhuir	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 669
@@ -5447,7 +5447,7 @@
 10	a	a	PART	Inf	PartType=Inf	11	mark	_	_
 11	chaitheamh	caitheamh	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	gCeatharlach	Ceatharlach	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
+13	gCeatharlach	Ceatharlach	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 670
@@ -5457,7 +5457,7 @@
 3	Storm	Storm	PROPN	Noun	Foreign=Yes|Number=Sing	2	nsubj	_	NamedEntity=Yes
 4	Alert	Alert	PROPN	Noun	Foreign=Yes|Number=Sing	3	flat:foreign	_	NamedEntity=Yes
 5	ag	ag	ADP	Simp	_	6	case	_	_
-6	Ascot	Ascot	PROPN	Noun	Number=Sing	2	obl	_	_
+6	Ascot	Ascot	PROPN	Noun	Definite=Def|Number=Sing	2	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	tseachain	seachtain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing|Typo=Yes	2	obl:tmod	_	_
 9	seo	seo	DET	Det	PronType=Dem	8	det	_	_
@@ -5474,7 +5474,7 @@
 6	cur	cur	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 7	dealraimh	dealramh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	obj	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	mhuir	muir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
+9	mhuir	muir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 672
@@ -5504,7 +5504,7 @@
 # sent_id = 673
 # text = Lá Mhaghnuis an Phíce, Lá na ngunnaí mór ar Loch Súilighe, Oídhche na Gaoithe Móire, Lá Ghleann Bheithe, An Lá a cuireadh Butt agus An Lá a d'éag Parnell (Rácáil agus Scuabadh (1955) 27).
 1	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-2	Mhaghnuis	Maghnus	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+2	Mhaghnuis	Maghnus	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	Phíce	píce	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -5514,11 +5514,11 @@
 9	mór	mór	ADJ	Adj	Case=Gen|NounType=Weak|Number=Plur	8	amod	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
 11	Loch	loch	NOUN	Noun	Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
-12	Súilighe	Súilighe	PROPN	Noun	Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
+12	Súilighe	Súilighe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	Oídhche	oídhche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	conj	_	NamedEntity=Yes
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	NamedEntity=Yes
-16	Gaoithe	gaoth	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
+16	Gaoithe	gaoth	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Móire	mór	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
@@ -5526,17 +5526,17 @@
 21	Bheithe	beith	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	Lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
+24	Lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	obl:tmod	_	_
 26	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	24	acl:relcl	_	_
-27	Butt	Butt	PROPN	Noun	Gender=Masc|Number=Sing	26	obj	_	_
+27	Butt	Butt	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
 28	agus	agus	CCONJ	Coord	_	30	cc	_	_
 29	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
-30	Lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
+30	Lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	33	obl:tmod	_	_
 32	d'	do	PART	Vb	PartType=Vb	33	mark:prt	_	SpaceAfter=No
 33	éag	éag	VERB	VI	Mood=Ind|Tense=Past	30	acl:relcl	_	_
-34	Parnell	Parnell	PROPN	Noun	Gender=Masc|Number=Sing	33	nsubj	_	_
+34	Parnell	Parnell	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	33	nsubj	_	_
 35	(	(	PUNCT	Punct	_	36	punct	_	SpaceAfter=No
 36	Rácáil	rácáil	NOUN	Noun	VerbForm=Inf	19	appos	_	_
 37	agus	agus	CCONJ	Coord	_	38	cc	_	_
@@ -5553,13 +5553,13 @@
 2	lár	lár	NOUN	Noun	Gender=Masc|Number=Sing	6	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 4	18ú	18	NUM	Num	NumType=Ord	5	amod	_	_
-5	aois	aois	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nmod	_	_
+5	aois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 6	baineadh	bain	VERB	VTI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 7	úsáid	úsáid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obj	_	_
 8	fhorleathan	forleathan	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	amod	_	_
 9	as	as	ADP	Simp	_	10	case	_	_
 10	inneall	inneall	NOUN	Noun	Gender=Masc|Number=Sing	7	nmod	_	_
-11	Newcomen	Newcomen	PROPN	Noun	Gender=Masc|Number=Sing	10	nmod	_	_
+11	Newcomen	Newcomen	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 12	le	le	ADP	Simp	_	15	case	_	_
 13	huisce	uisce	NOUN	Noun	Form=HPref|Gender=Masc|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
@@ -5595,13 +5595,13 @@
 5	agus	agus	CCONJ	Coord	_	6	cc	_	_
 6	ceapaire	ceapaire	NOUN	Noun	Gender=Masc|Number=Sing	3	conj	_	_
 7	do	do	ADP	Simp	_	8	case	_	_
-8	Niamh	Niamh	PROPN	Noun	Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
+8	Niamh	Niamh	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 677
 # text = An té a fheicfidh, léifidh.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	té	té	PRON	Idf	PronType=Ind	0	root	_	_
+2	té	té	PRON	Idf	Definite=Def|PronType=Ind	0	root	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	nsubj	_	_
 4	fheicfidh	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	2	acl:relcl	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -5615,7 +5615,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	craiceann	craiceann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 5	den	de	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chlóbh	clóbh	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
+6	chlóbh	clóbh	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 7	gairleoige	gairleog	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	mionghearr	mionghearr	VERB	VT	Mood=Imp|Number=Sing|Person=2	2	conj	_	_
@@ -5623,7 +5623,7 @@
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
 12	cuir	cuir	VERB	VTI	Mood=Imp|Number=Sing|Person=2	2	conj	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	chorcán	corcán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+14	chorcán	corcán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 15	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	12	obj	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -5639,8 +5639,8 @@
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	tugadh	tabhair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 10	tí	tí	NOUN	Noun	Gender=Masc|Number=Sing	9	obj	_	_
-11	Tom	Tom	PROPN	Noun	Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
-12	Tommy	Tommy	PROPN	Noun	Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
+11	Tom	Tom	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+12	Tommy	Tommy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
@@ -5655,7 +5655,7 @@
 # text = Beidh gach earra agus seirbhís a fhógrófar faoi réir scrúdaithe tráth ar bith ag na húinéirí.
 1	Beidh	bí	VERB	VI	Mood=Ind|Tense=Fut	0	root	_	_
 2	gach	gach	DET	Det	Definite=Def	3	det	_	_
-3	earra	earra	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+3	earra	earra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	agus	agus	CCONJ	Coord	_	5	cc	_	_
 5	seirbhís	seirbhís	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	conj	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	obj	_	_
@@ -5677,11 +5677,11 @@
 2	ionann	ionann	ADJ	Adj	Degree=Pos	0	root	_	_
 3	tithe	teach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	nsubj	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	gcathracha	cathair	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|Number=Plur	3	nmod	_	_
+5	gcathracha	cathair	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	3	nmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	tithe	teach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	conj	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	mbailte	baile	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	7	nmod	_	_
+9	mbailte	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	7	nmod	_	_
 10	beaga	beag	ADJ	Adj	Case=Gen|Gender=Fem|Number=Plur	9	amod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -5696,7 +5696,7 @@
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	biogóideacht	biogóideacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
 9	san	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	aer	aer	NOUN	Noun	Gender=Masc|Number=Sing	5	obl	_	_
+10	aer	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 11	mar	mar	ADP	Simp	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	5	advcl	_	_
@@ -5717,14 +5717,14 @@
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	deirtear	abair	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	Bhéarla	Béarla	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+5	Bhéarla	Béarla	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 684
 # text = Agus sa chás sin, beidh sé le feiscint an mbeidh ballraíocht i gcumann The Week in Politics ar fáil acu chomh saoráideach is atá sé ag Brian Hayes?
 1	Agus	agus	CCONJ	Coord	_	6	cc	_	_
 2	sa	i	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	chás	cás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	obl	_	_
+3	chás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	obl	_	_
 4	sin	sin	DET	Det	PronType=Dem	3	det	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	3	punct	_	_
 6	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
@@ -5749,8 +5749,8 @@
 25	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	11	advcl	_	_
 26	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	25	nsubj	_	_
 27	ag	ag	ADP	Simp	_	28	case	_	_
-28	Brian	Brian	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
-29	Hayes	Hayes	PROPN	Noun	_	28	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+28	Brian	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
+29	Hayes	Hayes	PROPN	Noun	Definite=Def	28	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 30	?	?	PUNCT	?	_	6	punct	_	_
 
 # sent_id = 685
@@ -5775,7 +5775,7 @@
 18	ghaoth	gaoth	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	nsubj	_	_
 19	ar	ar	ADP	Simp	_	21	case	_	_
 20	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	21	nmod:poss	_	_
-21	leataobh	leataobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
+21	leataobh	leataobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	_
 22	agus	agus	CCONJ	Coord	_	23	mark	_	_
 23	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	16	advcl	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
@@ -5790,7 +5790,7 @@
 33	imeacht	imeacht	NOUN	Noun	VerbForm=Vnoun	30	xcomp	_	_
 34	ar	ar	ADP	Simp	_	36	case	_	_
 35	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
-36	leataobh	leataobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	obl	_	SpaceAfter=No
+36	leataobh	leataobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 686
@@ -5800,16 +5800,16 @@
 3	siad	siad	PRON	Pers	Number=Plur|Person=3	2	nsubj	_	_
 4	gur	gur	PART	Vb	PartType=Vb|Tense=Past	5	mark:prt	_	_
 5	bhuaigh	buaigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	ccomp	_	_
-6	Fine	Fine	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
-7	Gael	Gael	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	6	nmod	_	NamedEntity=Yes
+6	Fine	Fine	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
+7	Gael	Gael	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	NamedEntity=Yes
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 9	dara	dara	NUM	Num	NumType=Ord	10	amod	_	_
-10	shuíocán	suíochán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing|Typo=Yes	5	obj	_	_
+10	shuíocán	suíochán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	5	obj	_	_
 11	nuair	nuair	SCONJ	Subord	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	advcl	_	_
 14	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	15	det	_	_
-15	vótaí	vóta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	13	nsubj	_	_
+15	vótaí	vóta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	13	nsubj	_	_
 16	aistrithe	aistrithe	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	15	amod	_	_
 17	go	go	PART	Ad	PartType=Ad	18	mark:prt	_	_
 18	léir	léir	ADJ	Adj	Degree=Pos	15	amod	_	_
@@ -5824,12 +5824,12 @@
 4	gur	gur	PART	Vb	PartType=Vb|Tense=Past	5	mark:prt	_	_
 5	tharla	tarlaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	ccomp	_	_
 6	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
-7	sheirbhís	seirbhís	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	5	nsubj	_	_
+7	sheirbhís	seirbhís	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nsubj	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
 9	gCathaoir	cathaoir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
-10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
+10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	tréimhse	tréimhse	NOUN	Noun	Gender=Fem|Number=Sing	5	obl	_	_
+12	tréimhse	tréimhse	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 13	iar-Chomhairleach	iarchomhairleach	ADJ	Adj	Gender=Fem|Number=Sing	12	amod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	agus	agus	SCONJ	Subord	_	16	mark	_	_
@@ -5838,7 +5838,7 @@
 18	ag	ag	ADP	Simp	_	19	case	_	_
 19	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	16	xcomp	_	_
 20	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
-21	inspioráid	inspioráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	obl	_	_
+21	inspioráid	inspioráid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	19	obl	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	obl	_	_
 23	threoraigh	treoraigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	21	acl:relcl	_	_
 24	Nostra	Nostra	X	_	Foreign=Yes	23	obj	_	NamedEntity=Yes
@@ -5857,10 +5857,10 @@
 8	Níor	is	AUX	Cop	Tense=Past|VerbForm=Cop	9	cop	_	_
 9	leor	leor	ADJ	Adj	Degree=Pos	0	root	_	_
 10	d'	do	ADP	Simp	_	11	case	_	SpaceAfter=No
-11	Éamonn	Éamonn	PROPN	Noun	Gender=Masc|Number=Sing	9	obl	_	_
+11	Éamonn	Éamonn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 12	agus	agus	CCONJ	Coord	_	14	cc	_	_
 13	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	case	_	_
-14	bhean	bean	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	conj	_	_
+14	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	conj	_	_
 15	a	a	PART	Inf	PartType=Inf	16	mark	_	_
 16	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	9	csubj:cop	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
@@ -5883,7 +5883,7 @@
 6	féidir	féidir	NOUN	Subst	Number=Sing	4	acl:relcl	_	_
 7	ainm	ainm	NOUN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	duine	duine	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
+9	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 10	lena	le	PART	Rel	PronType=Rel	11	obl	_	_
 11	mbaineann	bain	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Pres	9	acl:relcl	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
@@ -5896,7 +5896,7 @@
 19	féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 20	fógra	fógra	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
 21	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
-22	Acht	acht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	_
+22	Acht	acht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	_
 23	seo	seo	DET	Det	PronType=Dem	22	det	_	_
 24	a	a	PART	Inf	PartType=Inf	25	mark	_	_
 25	dhíriú	díriú	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
@@ -5936,26 +5936,26 @@
 7	Teachtaí	teachta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	6	nsubj	_	NamedEntity=Yes
 8	Dála	dáil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	ó	ó	ADP	Simp	_	10	case	_	_
-10	Fhianna	Fiann	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	6	obl	_	NamedEntity=Yes
-11	Fáil	Fál	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+10	Fhianna	Fiann	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	6	obl	_	NamedEntity=Yes
+11	Fáil	Fál	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	cois	cois	ADP	Simp	_	13	case	_	_
 13	teorann	teorainn	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	obl	_	_
 14	-	-	PUNCT	Punct	_	15	punct	_	_
 15	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	parataxis	_	_
 16	féin	féin	PRON	Ref	Reflex=Yes	15	nmod	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	18	punct	_	_
-18	Jim	Jim	PROPN	Noun	Gender=Masc|Number=Sing	15	conj	_	NamedEntity=Yes
-19	McDaid	McDaid	PROPN	Noun	Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
+18	Jim	Jim	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	conj	_	NamedEntity=Yes
+19	McDaid	McDaid	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
 20	ó	ó	ADP	Simp	_	21	case	_	_
-21	Dhún	Dún	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+21	Dhún	Dún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 22	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	23	det	_	NamedEntity=Yes
-23	nGall	Gall	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	21	nmod	_	NamedEntity=Yes
+23	nGall	Gall	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	21	nmod	_	NamedEntity=Yes
 24	agus	agus	CCONJ	Coord	_	25	cc	_	_
-25	Rory	Rory	PROPN	Noun	Gender=Masc|Number=Sing	15	conj	_	NamedEntity=Yes
+25	Rory	Rory	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	conj	_	NamedEntity=Yes
 26	O'	o	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
-27	Hanlon	Hanlon	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
+27	Hanlon	Hanlon	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
 28	ó	ó	ADP	Simp	_	29	case	_	_
-29	Mhuineachán	Muineachán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
+29	Mhuineachán	Muineachán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
 30	le	le	ADP	Simp	_	31	case	_	_
 31	hionadaithe	ionadaí	NOUN	Noun	Form=HPref|Gender=Masc|Number=Plur	15	nmod	_	_
 32	ó	ó	ADP	Simp	_	34	case	_	_
@@ -5967,8 +5967,8 @@
 38	páirtithe	páirtí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	31	conj	_	_
 39	Aontachtaíocha	aontachtaíoch	ADJ	Adj	Gender=Masc|Number=Plur	38	amod	_	_
 40	i	i	ADP	Simp	_	41	case	_	_
-41	mBéal	Béal	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	NamedEntity=Yes
-42	Feirste	Feirste	PROPN	Noun	Gender=Masc|Number=Sing	41	nmod	_	NamedEntity=Yes|SpaceAfter=No
+41	mBéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	NamedEntity=Yes
+42	Feirste	Feirste	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	41	nmod	_	NamedEntity=Yes|SpaceAfter=No
 43	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 691
@@ -6001,7 +6001,7 @@
 2	Ag	ag	ADP	Simp	_	3	case	_	_
 3	breathnú	breathnú	NOUN	Noun	VerbForm=Vnoun	0	root	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	mbeithígh	beithíoch	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	3	obj	_	SpaceAfter=No
+5	mbeithígh	beithíoch	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	3	obj	_	SpaceAfter=No
 6	!	!	PUNCT	!	_	3	punct	_	_
 
 # sent_id = 694
@@ -6009,42 +6009,42 @@
 1	Má	má	SCONJ	Subord	_	2	mark	_	_
 2	choinníonn	coinnigh	VERB	VT	Form=Len|Mood=Ind|Tense=Pres	24	advcl	_	_
 3	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	2	obj	_	_
+4	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	2	obj	_	_
 5	urlabhra	urlabhra	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
 6	theoranta	teoranta	ADJ	Adj	Degree=Pos|Form=Len	4	amod	_	_
 7	faoi	faoi	ADP	Simp	_	11	nmod	_	_
 8	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	fixed	_	_
 9	ag	ag	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	gcleacht	cleacht	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
+11	gcleacht	cleacht	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
 12	coitianta	coitianta	ADJ	Adj	Gender=Masc|Number=Sing	11	amod	_	_
 13	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	14	case	_	_
-14	gcomhrá	comhrá	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
+14	gcomhrá	comhrá	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
 16	pearsana	pearsa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	14	nmod	_	_
 17	eile	eile	DET	Det	PronType=Dem	16	det	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	20	case	_	_
-20	machnamh	machnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	conj	_	_
+20	machnamh	machnamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	conj	_	_
 21	comhfhiosach	comhfhiosach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	20	amod	_	_
 22	iad	iad	PRON	Pers	Number=Plur|Person=3	16	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	2	punct	_	_
 24	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 25	mianach	mianach	NOUN	Noun	Gender=Masc|Number=Sing	24	nsubj	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-27	hindibhidiúlachta	indibhidiúlacht	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	25	nmod	_	_
+27	hindibhidiúlachta	indibhidiúlacht	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	25	nmod	_	_
 28	fós	fós	ADV	Gn	_	24	advmod	_	_
 29	iontu	i	ADP	Prep	Number=Plur|Person=3	24	obl:prep	_	_
 30	sa	i	ADP	Art	Number=Sing|PronType=Art	31	case	_	_
 31	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	24	obl	_	_
 32	sin	sin	DET	Det	PronType=Dem	31	det	_	_
 33	dá	de	ADP	Poss	Number=Plur|Person=3|Poss=Yes	34	case	_	_
-34	mbeatha	beatha	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
+34	mbeatha	beatha	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
 35	mhothálach	mothálach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	34	amod	_	_
 36	a	a	PART	Vb	PartType=Vb|PronType=Rel	37	obl	_	_
 37	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	34	acl:relcl	_	_
 38	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	39	nmod:poss	_	_
-39	réim	réim	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	37	nsubj	_	_
+39	réim	réim	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	37	nsubj	_	_
 40	ar	ar	ADP	Simp	_	42	case	_	_
 41	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	42	det	_	_
 42	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	37	obl	_	_
@@ -6110,28 +6110,28 @@
 # sent_id = 698
 # text = Tháinig Geilghéis iníon Mhic Lughach, bean Chaoil mhic Criomhthain na gCuan.
 1	Tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Geilghéis	Geilghéis	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Geilghéis	Geilghéis	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	iníon	iníon	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 4	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	3	flat	_	NamedEntity=Yes
-5	Lughach	Lughach	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+5	Lughach	Lughach	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	bean	bean	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	appos	_	_
-8	Chaoil	caol	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+8	Chaoil	caol	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	mhic	mac	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-10	Criomhthain	Criomhthain	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+10	Criomhthain	Criomhthain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	gCuan	cuan	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	8	nmod	_	SpaceAfter=No
+12	gCuan	cuan	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	8	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 699
 # text = Bhain an gearán seo leis an idirghníomhaíocht idir Oifig s'agam féin, Bord Sláinte Limistéar an Tuaiscirt (BSLT) agus Ospidéal Beaumont.
 1	Bhain	Bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	gearán	gearán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	gearán	gearán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	leis	le	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	idirghníomhaíocht	idirghníomhaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+7	idirghníomhaíocht	idirghníomhaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 8	idir	idir	ADP	Simp	_	9	case	_	_
 9	Oifig	oifig	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nmod	_	_
 10	s'	s	DET	Det	_	9	det	_	SpaceAfter=No
@@ -6142,13 +6142,13 @@
 15	Sláinte	sláinte	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	Limistéar	limistéar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
-18	Tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	(	(	PUNCT	Punct	_	20	punct	_	SpaceAfter=No
 20	BSLT	BSLT	PROPN	Abr	Abbr=Yes	14	appos	_	SpaceAfter=No
 21	)	)	PUNCT	Punct	_	20	punct	_	_
 22	agus	agus	CCONJ	Coord	_	23	cc	_	_
 23	Ospidéal	ospidéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
-24	Beaumont	Beaumont	PROPN	Noun	_	23	nmod	_	SpaceAfter=No
+24	Beaumont	Beaumont	PROPN	Noun	Definite=Def	23	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 700
@@ -6159,13 +6159,13 @@
 4	ndearna	déan	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	2	csubj:cop	_	_
 5	éagóir	éagóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	den	de	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	sórt	sórt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	_
+7	sórt	sórt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	obj	_	_
 9	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	7	acl:relcl	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	Dr	dochtúir	NOUN	Abr	Abbr=Yes	9	nsubj	_	NamedEntity=Yes
 12	O'	o	PART	Pat	PartType=Pat	11	flat	_	NamedEntity=Yes|SpaceAfter=No
-13	Meara	Meara	PROPN	Noun	Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
+13	Meara	Meara	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 14	díobháil	díobháil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
 16	ós	ó	SCONJ	Subord	VerbForm=Cop	18	mark	_	_
@@ -6183,7 +6183,7 @@
 28	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	27	obl:prep	_	SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	agus	agus	CCONJ	Coord	_	31	cc	_	_
-31	Gaeilge	Gaeilge	PROPN	Noun	Gender=Fem|Number=Sing	26	conj	_	SpaceAfter=No
+31	Gaeilge	Gaeilge	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	26	conj	_	SpaceAfter=No
 32	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 701
@@ -6216,11 +6216,11 @@
 4	ag	ag	ADP	Simp	_	5	case	_	_
 5	fiach	fiach	NOUN	Noun	VerbForm=Vnoun	3	xcomp	_	_
 6	Ón	ó	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	dTower	dTower	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	5	obl	_	_
+7	dTower	dTower	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	obl	_	_
 8	soir	soir	ADV	Dir	_	5	advmod	_	_
 9	dtí	go_dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	mbinn	binn	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
+11	mbinn	binn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	Is	agus	SCONJ	Subord	Tense=Pres|VerbForm=Cop	14	mark	_	_
 14	ceol	ceol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	advcl	_	_
@@ -6228,11 +6228,11 @@
 16	Le	le	ADP	Simp	_	17	case	_	_
 17	cloisint	cloisint	NOUN	Noun	VerbForm=Inf	14	xcomp	_	_
 18	im	i_mo	ADP	Det	Number=Sing|Person=1|Poss=Yes	19	case	_	_
-19	thimpeall	timpeall	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
+19	thimpeall	timpeall	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Cluasa	cluas	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	14	parataxis	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	ghiorraí	giorria	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
+23	ghiorraí	giorria	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
 24	Ag	ag	ADP	Simp	_	25	case	_	_
 25	saighdeadh	saighdeadh	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 26	as	as	ADP	Simp	_	27	case	_	_
@@ -6243,7 +6243,7 @@
 31	fiaigh	fiach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	nmod	_	_
 32	Agamsa	ag	ADP	Prep	Number=Sing|Person=1|PronType=Emp	30	obl:prep	_	_
 33	dá	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	34	case	_	_
-34	gríosadh	gríosadh	NOUN	Noun	VerbForm=Inf	23	nmod	_	SpaceAfter=No
+34	gríosadh	gríosadh	NOUN	Noun	Definite=Def|VerbForm=Inf	23	nmod	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 703
@@ -6256,7 +6256,7 @@
 6	ghnách	gnách	ADJ	Adj	Degree=Pos|Form=Len	16	parataxis	_	_
 7	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	obl:prep	_	_
 8	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	case	_	_
-9	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obl	_	_
+9	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	obl	_	_
 10	de	de	ADP	Simp	_	11	case	_	_
 11	chás	cás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
 12	:	:	PUNCT	Punct	_	6	punct	_	_
@@ -6300,7 +6300,7 @@
 20	-	-	PUNCT	Punct	_	22	punct	_	_
 21	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	NamedEntity=Yes
 22	Tiarna	tiarna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	_
-23	Killanin	Killanin	PROPN	Noun	Gender=Masc|Number=Sing	22	flat	_	NamedEntity=Yes|SpaceAfter=No
+23	Killanin	Killanin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	flat	_	NamedEntity=Yes|SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	Uachtarán	uachtarán	NOUN	Noun	Gender=Masc|Number=Sing	22	appos	_	NamedEntity=Yes
 26	Oinigh	oineach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
@@ -6336,7 +6336,7 @@
 5	i	i	ADP	Simp	_	6	case	_	_
 6	bpoll	poll	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	aeir	aer	NOUN	Noun	Gender=Masc|Number=Sing	6	nmod	_	_
+8	aeir	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	dhreapaigh	dreap	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
@@ -6356,14 +6356,14 @@
 4	bhunmhúinteoir	bunmhúinteoir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
 6	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-7	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	6	nmod	_	NamedEntity=Yes
+7	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	6	nmod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
-9	nDroim	droim	PROPN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-10	Conrach	conrach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes|SpaceAfter=No
+9	nDroim	droim	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+10	Conrach	conrach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes|SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
-12	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-13	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
-14	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
+12	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+13	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+14	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	17	punct	_	_
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
 17	chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
@@ -6378,15 +6378,15 @@
 1	Scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	tAthair	athair	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-4	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
-5	Lavelle	Lavelle	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+4	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
+5	Lavelle	Lavelle	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 6	leabhar	leabhar	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
 7	bolscaireachta	bolscaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
 8	The	the	X	_	Foreign=Yes	6	appos	_	NamedEntity=Yes
 9	Irish	Irish	X	_	Foreign=Yes	8	flat:foreign	_	NamedEntity=Yes
 10	Landlord	Landlord	X	_	Foreign=Yes	8	flat:foreign	_	NamedEntity=Yes
 11	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	case	_	_
-12	dhearcadh	dearcadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	obj	_	_
+12	dhearcadh	dearcadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	obj	_	_
 13	san	sin	DET	Det	Dialect=Munster|PronType=Dem	12	det	_	_
 14	ar	ar	ADP	Simp	_	18	case	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
@@ -6404,9 +6404,9 @@
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	aonar	aonar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+4	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	fhásach	fásach	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+6	fhásach	fásach	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 710
@@ -6417,7 +6417,7 @@
 4	sínte	sínte	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	7	nmod:poss	_	_
-7	mbolg	bolg	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+7	mbolg	bolg	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
 9	scaoileadh	scaoileadh	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
@@ -6428,7 +6428,7 @@
 15	tar	tar	ADP	Cmpd	PrepForm=Cmpd	20	case	_	_
 16	éis	éis	ADP	Cmpd	PrepForm=Cmpd	15	fixed	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	abha	abha	NOUN	Noun	Gender=Fem|Number=Sing	20	obj	_	_
+18	abha	abha	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
 20	thrasnú	trasnú	NOUN	Noun	Form=Len|VerbForm=Inf	14	xcomp	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
@@ -6447,7 +6447,7 @@
 2	sin	sin	PRON	Dem	PronType=Dem	1	fixed	_	_
 3	's	agus	CCONJ	Coord	_	5	cc	_	_
 4	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	case	_	_
-5	bhrí	brí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	2	conj	_	_
+5	bhrí	brí	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	conj	_	_
 6	sin	sin	PRON	Dem	PronType=Dem	5	det	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	1	punct	_	_
 8	níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -6462,7 +6462,7 @@
 17	cur	cur	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
 18	preab	preab	NOUN	Noun	Gender=Fem|Number=Sing	17	obj	_	_
 19	san	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	ól	ól	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
+20	ól	ól	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 713
@@ -6487,10 +6487,10 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	tóin	tóin	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nsubj	_	_
+4	tóin	tóin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	as	as	ADP	Simp	_	7	case	_	_
 6	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
-7	mhála	mála	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+7	mhála	mála	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 8	plaisteach	plaisteach	ADJ	Adj	Gender=Masc|Number=Sing	7	amod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
@@ -6506,7 +6506,7 @@
 2	dom	do	ADP	Prep	Number=Sing|Person=1	1	obl:prep	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	5	punct	_	_
 4	san	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+5	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 6	i	i	ADP	Cmpd	PrepForm=Cmpd	7	case	_	_
 7	láthair	láthair	ADP	Cmpd	PrepForm=Cmpd	1	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
@@ -6535,11 +6535,11 @@
 # text = Baineann an riail seo leis an gcomórtas le foirne 11.
 1	Baineann	bain	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	riail	riail	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+3	riail	riail	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	leis	le	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	gcomórtas	comórtas	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+7	gcomórtas	comórtas	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
 9	foirne	foireann	NOUN	Noun	Gender=Fem|Number=Plur	7	nmod	_	_
 10	11	11	NUM	Num	_	9	nmod	_	SpaceAfter=No
@@ -6575,11 +6575,11 @@
 26	cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	24	nmod	_	_
 27	nó	nó	CCONJ	Coord	_	29	cc	_	_
 28	gach	gach	DET	Det	Definite=Def	29	det	_	_
-29	ceann	ceann	NOUN	Noun	Gender=Masc|Number=Sing	26	conj	_	_
+29	ceann	ceann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	conj	_	_
 30	dá	de	ADP	Poss	Number=Plur|Person=3|Poss=Yes	31	case	_	_
-31	bhfeidhmeanna	feidhm	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	29	nmod	_	_
+31	bhfeidhmeanna	feidhm	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	29	nmod	_	_
 32	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
-33	Acht	acht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	nmod	_	_
+33	Acht	acht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	nmod	_	_
 34	seo	seo	DET	Det	PronType=Dem	33	det	_	SpaceAfter=No
 35	,	,	PUNCT	Punct	_	36	punct	_	_
 36	lena	le	PART	Rel	PronType=Rel	6	obl	_	_
@@ -6594,7 +6594,7 @@
 45	nó	nó	CCONJ	Coord	_	46	cc	_	_
 46	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	43	conj	_	_
 47	den	de	ADP	Art	Number=Sing|PronType=Art	48	case	_	_
-48	chaiteachas	caiteachas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	46	nmod	_	_
+48	chaiteachas	caiteachas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	nmod	_	_
 49	a	a	PART	Vb	PartType=Vb|PronType=Rel	50	nsubj	_	_
 50	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	48	acl:relcl	_	_
 51	tabhaithe	tabhaithe	ADJ	Adj	VerbForm=Part	50	xcomp:pred	_	_
@@ -6619,7 +6619,7 @@
 70	agus	agus	CCONJ	Coord	_	71	cc	_	_
 71	oibreacha	obair	NOUN	Noun	Gender=Fem|Number=Plur	58	conj	_	_
 72	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	73	case	_	_
-73	ndéanamh	déanamh	NOUN	Noun	Form=Ecl|VerbForm=Inf	58	xcomp	_	_
+73	ndéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	58	xcomp	_	_
 74	acu	ag	ADP	Prep	Number=Plur|Person=3	73	nmod	_	_
 75	de	de	ADP	Cmpd	PrepForm=Cmpd	78	case	_	_
 76	réir	réir	ADP	Cmpd	PrepForm=Cmpd	75	fixed	_	_
@@ -6638,7 +6638,7 @@
 89	agus	agus	CCONJ	Coord	_	90	cc	_	_
 90	oibreacha	obair	NOUN	Noun	Gender=Fem|Number=Plur	87	conj	_	_
 91	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	92	case	_	_
-92	ndéanamh	déanamh	NOUN	Noun	Form=Ecl|VerbForm=Inf	53	xcomp	_	_
+92	ndéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	53	xcomp	_	_
 93	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	92	obl:prep	_	_
 94	nó	nó	CCONJ	Coord	_	95	cc	_	_
 95	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	93	conj	_	_
@@ -6711,7 +6711,7 @@
 45	nó	nó	CCONJ	Coord	_	57	cc	_	_
 46	chun	chun	ADP	Simp	_	57	case	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
-48	céadtadán	céatadán	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	57	obj	_	_
+48	céadtadán	céatadán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	57	obj	_	_
 49	íseal	íseal	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	48	amod	_	_
 50	rannpáirtíochta	rannpháirtíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing|Typo=Yes	48	nmod	_	_
 51	i	i	ADP	Simp	_	52	case	_	_
@@ -6732,7 +6732,7 @@
 5	gur	gur	PART	Vb	PartType=Vb|Tense=Past	6	mark:prt	_	_
 6	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	csubj:cop	_	_
 7	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	8	nmod:poss	_	_
-8	leannán	leannán	NOUN	Noun	Gender=Masc|Number=Sing	6	nsubj	_	_
+8	leannán	leannán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	fir	fear	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
 10	tú	tú	PRON	Pers	Number=Sing|Person=2	6	obj	_	SpaceAfter=No
 11	?	?	PUNCT	?	_	4	punct	_	_
@@ -6761,14 +6761,14 @@
 # text = Ag an am céanna bhí líon na gcraobhacha den Chonradh ag laghdú go mór, agus bhí an eagraíocht ag dul i bhfiacha.
 1	Ag	ag	ADP	Simp	_	3	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl:tmod	_	_
+3	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl:tmod	_	_
 4	céanna	céanna	ADJ	Adj	Degree=Pos	3	amod	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	gcraobhacha	craobh	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|Number=Plur	6	nmod	_	_
+8	gcraobhacha	craobh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	6	nmod	_	_
 9	den	de	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	Chonradh	conradh	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
+10	Chonradh	conradh	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
 11	ag	ag	ADP	Simp	_	12	case	_	_
 12	laghdú	laghdú	NOUN	Noun	VerbForm=Vnoun	5	xcomp	_	_
 13	go	go	PART	Ad	PartType=Ad	14	mark:prt	_	_
@@ -6789,17 +6789,17 @@
 1	Ó	ó	ADP	Simp	_	2	case	_	_
 2	thaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	polaitíochta	polaitíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+4	polaitíochta	polaitíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 5	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	case	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	2	punct	_	_
 7	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
+9	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 10	seo	seo	DET	Det	PronType=Dem	9	det	_	_
 11	chun	chun	ADP	Simp	_	12	case	_	_
 12	tairbhe	tairbhe	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
-13	Shinn	Sinn	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
-14	Fein	Féin	PROPN	Noun	Gender=Masc|Number=Sing|Typo=Yes	13	flat	_	NamedEntity=Yes|SpaceAfter=No
+13	Shinn	Sinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+14	Fein	Féin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	13	flat	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
 16	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	13	acl:relcl	_	_
 17	tar	tar	ADP	Cmpd	PrepForm=Cmpd	19	case	_	_
@@ -6809,15 +6809,15 @@
 21	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	16	xcomp	_	_
 22	ar	ar	ADP	Simp	_	24	case	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	bhord	bord	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
+24	bhord	bord	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
 25	póilíneachta	póilíneacht	NOUN	Noun	VerbForm=Part	24	nmod	_	_
 26	úr	úr	ADJ	Adj	Degree=Pos	24	amod	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 724
 # text = Maigh Eo.
-1	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-2	Eo	Eo	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes|SpaceAfter=No
+1	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+2	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes|SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 725
@@ -6830,7 +6830,7 @@
 6	nó	nó	CCONJ	Coord	_	9	cc	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	ghuthán	guthán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
+9	ghuthán	guthán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	hamazon	amazon	X	Foreign	Foreign=Yes|Form=HPref	9	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
@@ -6839,7 +6839,7 @@
 15	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	14	fixed	_	_
 16	eile	eile	DET	Det	PronType=Dem	14	det	_	_
 17	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	case	_	_
-18	shórt	sórt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
+18	shórt	sórt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
 19	-	-	PUNCT	Punct	_	24	punct	_	_
 20	ach	ach	SCONJ	Subord	_	24	mark	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
@@ -6861,7 +6861,7 @@
 7	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	_
 8	rófhada	rófhada	ADJ	Adj	Gender=Masc|Number=Sing	6	xcomp:pred	_	_
 9	san	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	ospidéal	ospidéal	NOUN	Noun	Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
+10	ospidéal	ospidéal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 727
@@ -6877,14 +6877,14 @@
 9	léi	le	ADP	Prep	Gender=Fem|Number=Sing|Person=3	7	obl:prep	_	_
 10	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	7	obj	_	_
 11	óna	ó	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	12	case	_	_
-12	seanmháthair	seanmháthair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obl	_	_
+12	seanmháthair	seanmháthair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
 13	agus	agus	CCONJ	Coord	_	15	cc	_	_
 14	d'	do	PART	Vb	PartType=Vb	15	mark:prt	_	SpaceAfter=No
 15	fhoghlaim	foghlaim	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	conj	_	_
 16	sise	sise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	15	nsubj	_	_
 17	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	15	obj	_	_
 18	óna	ó	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	hathair	athair	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	15	obl	_	_
+19	hathair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Sing	15	obl	_	_
 20	siúd	siúd	DET	Det	PronType=Dem	19	det	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -6907,7 +6907,7 @@
 # text = Os a choinne sin b'fhurasta cás a dhéanamh ar son litríocht na n-aosánach a choinneáil ar deighilt ar fad ó litríocht mhór an tsaoil.
 1	Os	os	ADP	Simp	_	3	case	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
-3	choinne	coinne	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	6	obl	_	_
+3	choinne	coinne	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	obl	_	_
 4	sin	sin	PRON	Dem	PronType=Dem	3	det	_	_
 5	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	6	cop	_	SpaceAfter=No
 6	fhurasta	furasta	ADJ	Adj	Degree=Pos|Form=Len	0	root	_	_
@@ -6988,7 +6988,7 @@
 3	soiléir	soiléir	ADJ	Adj	Gender=Masc|Number=Sing	2	amod	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	gcáineadh	cáineadh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	nmod	_	_
+6	gcáineadh	cáineadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	nmod	_	_
 7	sin	sin	DET	Det	PronType=Dem	6	det	_	_
 8	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 9	triúr	triúr	NOUN	Noun	Gender=Masc|Number=Sing	8	nsubj	_	_
@@ -6997,13 +6997,13 @@
 12	ceapadh	ceapadh	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	mBord	bord	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
+15	mBord	bord	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
 17	Mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	NamedEntity=Yes
-18	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
+18	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
-20	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-21	Noone	Noone	PROPN	Noun	Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
+20	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+21	Noone	Noone	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
 22	ón	ó	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	SELC	SELC	PROPN	Abr	Abbr=Yes	20	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
@@ -7013,15 +7013,15 @@
 28	turasóireacht	turasóireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	obl	_	_
 29	i	i	ADP	Simp	_	30	case	_	_
 30	gceantar	ceantar	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	28	nmod	_	_
-31	Iorrais	Iorras	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
+31	Iorrais	Iorras	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
-33	Joe	Joe	PROPN	Noun	Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
-34	Kennedy	Kennedy	PROPN	Noun	Gender=Masc|Number=Sing	33	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+33	Joe	Joe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
+34	Kennedy	Kennedy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	33	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 35	,	,	PUNCT	Punct	_	36	punct	_	_
-36	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
-37	Eo	Eo	PROPN	Noun	Gender=Masc|Number=Sing	36	nmod	_	NamedEntity=Yes
+36	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
+37	Eo	Eo	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	NamedEntity=Yes
 38	agus	agus	CCONJ	Coord	_	39	cc	_	_
-39	Manchain	Manchain	PROPN	Noun	Gender=Fem|Number=Sing	36	conj	_	SpaceAfter=No
+39	Manchain	Manchain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	36	conj	_	SpaceAfter=No
 40	,	,	PUNCT	Punct	_	41	punct	_	_
 41	tógálaí	tógálaí	NOUN	Noun	Gender=Masc|Number=Sing	33	nmod	_	_
 42	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	41	amod	_	_
@@ -7032,12 +7032,12 @@
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
 48	tÓstóir	óstóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	conj	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
-50	Brian	Brian	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	48	appos	_	NamedEntity=Yes
-51	McEniff	McEniff	PROPN	Noun	Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
+50	Brian	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	appos	_	NamedEntity=Yes
+51	McEniff	McEniff	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
 52	as	as	ADP	Simp	_	53	case	_	_
-53	Dún	Dún	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	50	nmod	_	NamedEntity=Yes
+53	Dún	Dún	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	50	nmod	_	NamedEntity=Yes
 54	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	55	det	_	NamedEntity=Yes
-55	nGall	Gall	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	53	nmod	_	NamedEntity=Yes|SpaceAfter=No
+55	nGall	Gall	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	53	nmod	_	NamedEntity=Yes|SpaceAfter=No
 56	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 734
@@ -7046,19 +7046,19 @@
 2	ionad	ionad	NOUN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
 3	scríbhneoirí	scríbhneoir	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
 4	den	de	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	chineál	cineál	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+5	chineál	cineál	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 6	céanna	céanna	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-9	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-10	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+8	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+9	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+10	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	ach	ach	SCONJ	Subord	_	15	mark	_	_
 12	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	13	cop	_	_
 13	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	advcl	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	ceann	ceann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	15	nmod	_	_
+17	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	15	nmod	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
 19	t-aon	aon	DET	Det	PronType=Ind	20	det	_	_
 20	cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
@@ -7102,7 +7102,7 @@
 6	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 7	leis	le	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	tairiscint	tairiscint	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
+9	tairiscint	tairiscint	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 737
@@ -7134,7 +7134,7 @@
 4	file	file	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	advcl	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	7	nmod:poss	_	_
-7	bhealach	bealach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
+7	bhealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 8	siar	siar	ADV	Dir	_	7	advmod	_	_
 9	chuig	chuig	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
@@ -7150,11 +7150,11 @@
 20	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	19	obl:prep	_	_
 21	ar	ar	ADP	Simp	_	23	case	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	slioscharr	slioscharr	NOUN	Noun	Gender=Masc|Number=Sing	19	nmod	_	_
+23	slioscharr	slioscharr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
 24	sea	is	AUX	Cop	Tense=Pres|VerbForm=Cop	25	cop	_	_
 25	tharla	tarlaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	timpiste	timpiste	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	25	nsubj	_	_
+27	timpiste	timpiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	25	nsubj	_	_
 28	seo	seo	DET	Det	PronType=Dem	27	det	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	25	punct	_	_
 
@@ -7171,8 +7171,8 @@
 # sent_id = 740
 # text = Thug David Trimble an t-eiteachas d'iarratais go gcuirfí buíon neamhspleách i mbun an fhiosraithe.
 1	Thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	David	David	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Trimble	Trimble	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+2	David	David	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Trimble	Trimble	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 5	t-eiteachas	eiteachas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 6	d'	de	ADP	Simp	_	7	case	_	SpaceAfter=No
@@ -7184,7 +7184,7 @@
 12	i	i	ADP	Cmpd	PrepForm=Cmpd	15	case	_	_
 13	mbun	bun	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	12	fixed	_	_
 14	an	an	DET	Art	PronType=Art	15	det	_	_
-15	fhiosraithe	fiosrú	NOUN	Noun	Case=Gen|Form=Len|VerbForm=Vnoun	9	obl	_	SpaceAfter=No
+15	fhiosraithe	fiosrú	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|VerbForm=Vnoun	9	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 741
@@ -7194,10 +7194,10 @@
 3	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	trá	trá	NOUN	Noun	Gender=Fem|Number=Sing	1	obl	_	_
+6	trá	trá	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 7	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl:tmod	_	_
 8	arna	ar	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	case	_	_
-9	mhárach	márach	NOUN	Subst	Form=Len|Number=Sing	7	nmod	_	SpaceAfter=No
+9	mhárach	márach	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	7	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 742
@@ -7206,7 +7206,7 @@
 2	borradh	borradh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	breise	breis	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
 4	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	iarracht	iarracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+5	iarracht	iarracht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 6	de	de	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 7	dheasca	dheasca	ADP	Cmpd	PrepForm=Cmpd	6	fixed	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
@@ -7227,7 +7227,7 @@
 23	heisiach	eisiach	ADJ	Adj	Degree=Pos|Form=HPref	20	advmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
 25	ar	ar	ADP	Simp	_	26	case	_	_
-26	ANOIS	ANOIS	PROPN	Noun	Gender=Masc|Number=Sing	20	obl	_	_
+26	ANOIS	ANOIS	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	obl:tmod	_	_
 29	seachtaine	seachtain	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	28	compound	_	_
@@ -7248,7 +7248,7 @@
 9	,	,	PUNCT	Punct	_	2	punct	_	_
 10	breofaidh	breoigh	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	meascán	meascán	NOUN	Noun	Gender=Masc|Number=Sing	10	nsubj	_	SpaceAfter=No
+12	meascán	meascán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	10	punct	_	_
 
 # sent_id = 744
@@ -7264,14 +7264,14 @@
 9	deora	deoir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	6	conj	_	_
 10	i	i	ADP	Simp	_	12	case	_	_
 11	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	12	nmod:poss	_	_
-12	shúile	súil	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	9	nmod	_	SpaceAfter=No
+12	shúile	súil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	9	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 745
 # text = Cosnófar a leithéid de chógais anois trí bheith curtha i dtaisceadáin ar a bhfuil glais mhoill ama ar leith nach féidir le baill foirne a shárú.
 1	Cosnófar	cosain	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
-3	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
+3	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
 5	chógais	cógas	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	3	nmod	_	_
 6	anois	anois	ADV	Gn	_	1	advmod	_	_
@@ -7302,11 +7302,11 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 3	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	4	nmod:poss	_	_
-4	léiritheoir	léiritheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	léiritheoir	léiritheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	sraithe	sraith	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
-6	Trevor	Trevor	PROPN	Noun	Gender=Masc|Number=Sing	4	appos	_	NamedEntity=Yes
+6	Trevor	Trevor	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	appos	_	NamedEntity=Yes
 7	Ó	ó	PART	Pat	PartType=Pat	6	flat:name	_	NamedEntity=Yes
-8	Clochartaigh	Clochartaigh	PROPN	Noun	Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
+8	Clochartaigh	Clochartaigh	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	obair	obair	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 11	le	le	ADP	Simp	_	12	case	_	_
@@ -7318,7 +7318,7 @@
 17	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	16	obl:prep	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	bhfoireann	foireann	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	nmod	_	_
+20	bhfoireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	16	nmod	_	_
 21	ar	ar	ADP	Simp	_	22	case	_	_
 22	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	26	punct	_	_
@@ -7330,13 +7330,13 @@
 29	mba	is	AUX	Cop	Form=Ecl|Tense=Past|VerbForm=Cop	30	cop	_	_
 30	dheas	deas	ADJ	Adj	Degree=Pos|Form=Len	26	ccomp	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
-32	smaoineamh	smaoineamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	nsubj	_	_
+32	smaoineamh	smaoineamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	30	nsubj	_	_
 33	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	32	nmod	_	_
 34	dá	dá	SCONJ	Subord	_	35	mark	_	_
 35	dtiocfadh	tar	VERB	VI	Form=Ecl|Mood=Cnd	30	advcl	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
 37	dá	dó	NUM	Num	Definite=Def|NumType=Card	38	nummod	_	_
-38	dhream	dream	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	35	nsubj	_	_
+38	dhream	dream	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	nsubj	_	_
 39	le	le	ADP	Simp	_	40	case	_	_
 40	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	35	obl	_	_
 41	chun	chun	ADP	Simp	_	45	case	_	_
@@ -7357,9 +7357,9 @@
 1	Nuair	nuair	SCONJ	Subord	_	3	mark	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	33	advcl	_	_
-4	Tomás	Tomás	PROPN	Noun	Gender=Masc|Number=Sing	3	nsubj	_	NamedEntity=Yes
+4	Tomás	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	NamedEntity=Yes
 5	de	de	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Bhaldraithe	Baldraithe	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+6	Bhaldraithe	Baldraithe	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	9	mark:prt	_	_
 9	maireann	mair	VERB	VTI	Mood=Ind|Tense=Pres	4	acl:relcl	_	SpaceAfter=No
@@ -7374,10 +7374,10 @@
 18	Erris	Erris	X	Foreign	Foreign=Yes|Gender=Masc|Number=Sing	15	flat:foreign	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
 20	le	le	ADP	Simp	_	21	case	_	_
-21	Eamonn	Eamonn	PROPN	Noun	Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+21	Eamonn	Eamonn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 22	Mhac	mac	PART	Pat	Form=Len|Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes
 23	an	an	PART	Pat	Definite=Def|Number=Sing|PronType=Art	21	flat:name	_	NamedEntity=Yes
-24	Fheisligh	Feisleach	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes
+24	Fheisligh	Feisleach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes
 25	in	i	ADP	Simp	_	26	case	_	_
 26	Studica	Studica	X	Foreign	Foreign=Yes|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 27	Celtica	Celtica	X	Foreign	Foreign=Yes|Gender=Masc|Number=Sing	26	flat:foreign	_	NamedEntity=Yes
@@ -7395,7 +7395,7 @@
 
 # sent_id = 748
 # text = TREASA (léi féin): An rud ceannann céanna gach maidin Sathairn.
-1	TREASA	Treasa	PROPN	Noun	Gender=Fem|Number=Sing	0	root	_	_
+1	TREASA	Treasa	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 2	(	(	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 3	léi	le	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	_
 4	féin	féin	PRON	Ref	Reflex=Yes	3	nmod	_	SpaceAfter=No
@@ -7406,15 +7406,15 @@
 9	ceannann	ceannann	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
 10	céanna	céanna	ADJ	Adj	Gender=Masc|Number=Sing	8	amod	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
-12	maidin	maidin	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nmod	_	_
-13	Sathairn	Satharn	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
+12	maidin	maidin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	_
+13	Sathairn	Satharn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 749
 # text = Arbh é Seán a bhí ann?
 1	Arbh	is	AUX	Cop	Form=VF|Mood=Int|Tense=Past|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+3	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	mark:prt	_	_
 5	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 6	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	xcomp:pred	_	SpaceAfter=No
@@ -7429,7 +7429,7 @@
 5	raibh	bí	VERB	VI	Mood=Ind|Tense=Past	3	acl:relcl	_	_
 6	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	_
 7	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	8	case	_	_
-8	chónaí	cónaí	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp:pred	_	_
+8	chónaí	cónaí	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	5	xcomp:pred	_	_
 9	ann	ann	ADV	Loc	_	5	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -7449,26 +7449,26 @@
 3	Áras	áras	NOUN	Noun	_	0	root	_	NamedEntity=Yes
 4	Chumann	cumann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	Ríoga	ríoga	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	4	amod	_	NamedEntity=Yes
-6	Bhaile	Baile	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-7	Átha	Átha	PROPN	Noun	_	6	nmod	_	NamedEntity=Yes
-8	Cliath	Cliath	PROPN	Noun	_	7	nmod	_	NamedEntity=Yes
+6	Bhaile	Baile	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+7	Átha	Átha	PROPN	Noun	Definite=Def	6	nmod	_	NamedEntity=Yes
+8	Cliath	Cliath	PROPN	Noun	Definite=Def	7	nmod	_	NamedEntity=Yes
 9	i	i	ADP	Simp	_	10	case	_	_
-10	nDroichead	droichead	PROPN	Noun	Form=Ecl	3	nmod	_	NamedEntity=Yes
+10	nDroichead	droichead	PROPN	Noun	Definite=Def|Form=Ecl	3	nmod	_	NamedEntity=Yes
 11	na	na	DET	Art	PronType=Art	12	det	_	NamedEntity=Yes
-12	Dothra	Dothra	PROPN	Noun	_	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
+12	Dothra	Dothra	PROPN	Noun	Definite=Def	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
-15	Átha	Átha	PROPN	Noun	_	14	nmod	_	NamedEntity=Yes
-16	Cliath	Cliath	PROPN	Noun	_	15	nmod	_	NamedEntity=Yes
+14	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+15	Átha	Átha	PROPN	Noun	Definite=Def	14	nmod	_	NamedEntity=Yes
+16	Cliath	Cliath	PROPN	Noun	Definite=Def	15	nmod	_	NamedEntity=Yes
 17	4	4	NUM	Num	_	14	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	a	a	PART	Vb	PartType=Vb	20	mark:prt	_	_
 20	bheidh	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Fut	3	csubj:cleft	_	_
 21	an	an	DET	Art	PronType=Art	22	det	_	_
-22	spórt	spórt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nsubj	_	_
+22	spórt	spórt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
 23	seo	seo	DET	Det	_	22	det	_	_
 24	á	do	ADP	Poss	Poss=Yes	25	case	_	_
-25	imirt	imirt	NOUN	Noun	VerbForm=Inf	20	xcomp	_	SpaceAfter=No
+25	imirt	imirt	NOUN	Noun	Definite=Def|VerbForm=Inf	20	xcomp	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 753
@@ -7503,7 +7503,7 @@
 2	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 3	fuipeanna	fuip	NOUN	Noun	Gender=Fem|Number=Plur	2	nsubj	_	_
 4	dhá	do	ADP	Poss	Form=Len|Number=Plur|Person=3|Poss=Yes	5	case	_	_
-5	n-úsáid	úsáid	NOUN	Noun	Form=Ecl|VerbForm=Inf	2	xcomp	_	_
+5	n-úsáid	úsáid	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	2	xcomp	_	_
 6	ó	ó	ADP	Simp	_	7	case	_	_
 7	thús	tús	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
@@ -7519,7 +7519,7 @@
 4	clár	clár	NOUN	Noun	Gender=Masc|Number=Sing	3	nsubj	_	_
 5	teilifíse	teilifís	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
 6	sa	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	Bhreatain	Breatain	PROPN	Noun	Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
+7	Bhreatain	Breatain	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
 9	fios	fios	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
@@ -7530,7 +7530,7 @@
 15	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	amod	_	_
 16	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	xcomp:pred	_	_
 17	sna	i	ADP	Art	Number=Plur|PronType=Art	18	case	_	_
-18	hospidéil	ospidéal	NOUN	Noun	Form=HPref|Gender=Masc|Number=Plur	13	obl	_	_
+18	hospidéil	ospidéal	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	13	obl	_	_
 19	maidir	maidir	ADP	CmpdNoGen	_	22	case	_	_
 20	le	le	ADP	CmpdNoGen	_	19	fixed	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
@@ -7566,7 +7566,7 @@
 15	dtithe	teach	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	13	obl	_	_
 16	eile	eile	DET	Det	PronType=Dem	15	det	_	_
 17	Chillín	Cillín	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
-18	Chaoimhín	Caoimhín	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	17	nmod	_	NamedEntity=Yes
+18	Chaoimhín	Caoimhín	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	17	nmod	_	NamedEntity=Yes
 19	ach	ach	SCONJ	Subord	_	20	mark	_	_
 20	oiread	oiread	NOUN	Subst	Number=Sing	10	advcl	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	_	_
@@ -7606,8 +7606,8 @@
 # sent_id = 759
 # text = Tá New Bedford, anois, ionad iascaireachta traidisiúnta le 350 bliain anuas, Cháin sé go dian, freisin, an truailliú atá á dhéanamh don dúlra ag na comhlachtaí ollmhóra ilnáisiúnacha.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	New	New	PROPN	Noun	Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Bedford	Bedford	PROPN	Noun	Number=Sing	2	flat	_	NamedEntity=Yes|SpaceAfter=No
+2	New	New	PROPN	Noun	Definite=Def|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Bedford	Bedford	PROPN	Noun	Definite=Def|Number=Sing	2	flat	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	anois	anois	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
@@ -7630,7 +7630,7 @@
 23	truailliú	truailliú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obj	_	_
 24	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	23	acl:relcl	_	_
 25	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	26	case	_	_
-26	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	24	xcomp	_	_
+26	dhéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	24	xcomp	_	_
 27	don	do	ADP	Art	Number=Sing|PronType=Art	28	case	_	_
 28	dúlra	dúlra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
 29	ag	ag	ADP	Simp	_	31	case	_	_
@@ -7681,13 +7681,13 @@
 26	a	a	PART	Inf	PartType=Inf	27	mark	_	_
 27	fhagháil	fáil	NOUN	Noun	Form=Len|VerbForm=Inf	21	csubj:cop	_	SpaceAfter=No
 28	,	,	PUNCT	Punct	_	31	punct	_	_
-29	ag	ag	ADP	Simp	_	32	case	_	_
+29	ag	ag	ADP	Simp	_	31	case	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	haon	aon	NUM	Num	Form=HPref|NumType=Card	27	obl:tmod	_	_
 32	déag	déag	NOUN	Subst	Case=NomAcc|Number=Sing	31	nmod	_	_
-33	gach	gach	DET	Det	Definite=Def	32	det	_	_
-34	uile	uile	DET	Det	PronType=Ind	32	det	_	_
-35	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	obl:tmod	_	_
+33	gach	gach	DET	Det	Definite=Def	35	det	_	_
+34	uile	uile	DET	Det	PronType=Ind	35	det	_	_
+35	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	obl:tmod	_	_
 36	i	i	ADP	Simp	_	37	case	_	_
 37	gcaitheamh	caitheamh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	obl:tmod	_	_
 38	deich	deich	NUM	Num	NumType=Card	39	nummod	_	_
@@ -7698,8 +7698,8 @@
 # text = Ba í Garry Hynes - Druid agus iar-stiúrthóir ealaíne conspóideach na hAmharclainne Náisiúnta - a léirigh an oíche go sár-ábalta mar is dual di.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	3	nmod	_	_
-3	Garry	Garry	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-4	Hynes	Hynes	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
+3	Garry	Garry	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+4	Hynes	Hynes	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 5	-	-	PUNCT	Punct	_	6	punct	_	_
 6	Druid	druid	NOUN	Noun	Foreign=Yes|Number=Sing	3	appos	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
@@ -7743,7 +7743,7 @@
 9	uaireanta	uaireanta	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	teoraic	teoiric	NOUN	Noun	Gender=Fem|Number=Sing	1	obj	_	_
+12	teoraic	teoiric	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 13	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
 14	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 15	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -7781,7 +7781,7 @@
 2	ansin	ansin	ADV	Loc	_	1	advmod	_	_
 3	ach	ach	SCONJ	Subord	_	1	mark:prt	_	_
 4	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	thuairim	tuairim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	nsubj	_	_
+5	thuairim	tuairim	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	nsubj	_	_
 6	phearsanta	pearsanta	ADJ	Adj	Degree=Pos|Form=Len	5	amod	_	_
 7	féin	féin	PRON	Ref	Reflex=Yes	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
@@ -7798,32 +7798,32 @@
 # sent_id = 767
 # text = Tá Brian Friel i ndiaidh cead a thabhairt don chomhlacht drámaíochta Aisling Ghéar an chéad leagan Gaeilge dá mhórshaothar Dancing at Lughnasa a chur ar an ardán.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	Brian	Brian	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Friel	Friel	PROPN	Noun	Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+2	Brian	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Friel	Friel	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	i	i	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 5	ndiaidh	ndiaidh	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	4	fixed	_	_
 6	cead	cead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obj	_	_
 7	a	a	PART	Inf	PartType=Inf	8	mark	_	_
 8	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	chomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+10	chomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 11	drámaíochta	drámaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	_
-12	Aisling	Aisling	PROPN	Noun	Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+12	Aisling	Aisling	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 13	Ghéar	géar	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	12	amod	_	NamedEntity=Yes
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 15	chéad	céad	NUM	Num	Form=Len|NumType=Ord	16	amod	_	_
-16	leagan	leagan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	obj	_	_
-17	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
+16	leagan	leagan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
+17	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 18	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	mhórshaothar	mórshaothar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
+19	mhórshaothar	mórshaothar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 20	Dancing	Dancing	X	_	Foreign=Yes	19	nmod	_	_
 21	at	at	X	_	Foreign=Yes	20	flat:foreign	_	_
-22	Lughnasa	Lughnasa	PROPN	Noun	Gender=Masc|Number=Sing	20	flat:foreign	_	_
+22	Lughnasa	Lughnasa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:foreign	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
 25	ar	ar	ADP	Simp	_	27	case	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	ardán	ardán	NOUN	Noun	Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
+27	ardán	ardán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 768
@@ -7839,9 +7839,9 @@
 9	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	7	obl:prep	_	_
 10	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
-12	Höskuld	Höskuld	PROPN	Noun	Gender=Masc|Number=Sing	9	conj	_	_
+12	Höskuld	Höskuld	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
 13	-	-	PUNCT	Punct	_	14	punct	_	_
-14	Ólaf	Ólaf	PROPN	Noun	Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
+14	Ólaf	Ólaf	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 769
@@ -7873,7 +7873,7 @@
 25	taobh	taobh	ADV	Loc	_	22	advmod	_	_
 26	amuigh	amuigh	ADV	Loc	_	25	advmod	_	_
 27	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	case	_	_
-28	fhiúntas	fiúntas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
+28	fhiúntas	fiúntas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
 29	liteartha	liteartha	ADJ	Adj	Gender=Masc|Number=Sing	28	amod	_	_
 30	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	2	parataxis	_	_
 31	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	30	nsubj	_	_
@@ -7927,7 +7927,7 @@
 22	agus	agus	CCONJ	_	_	23	cc	_	NamedEntity=Yes
 23	Eolaslainne	eolaslann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	21	conj	_	NamedEntity=Yes
 24	san	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	áireamh	áireamh	NOUN	Noun	Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
+25	áireamh	áireamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 772
@@ -7954,7 +7954,7 @@
 2	scaoileas	scaoil	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Past	0	root	_	_
 3	siar	siar	ADV	Dir	_	2	advmod	_	_
 4	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	shuíochán	suíochán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
+5	shuíochán	suíochán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
 6	féin	féin	PRON	Ref	Reflex=Yes	5	nmod	_	_
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	fada	fada	ADJ	Adj	Degree=Pos	2	amod	_	_
@@ -8010,15 +8010,15 @@
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	obj	_	_
 15	dtugadh	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Tense=Past	13	acl:relcl	_	_
 16	siad	siad	PRON	Pers	Number=Plur|Person=3	15	nsubj	_	_
-17	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	15	obj	_	NamedEntity=Yes
-18	Seoighe	Seoighe	PROPN	Noun	Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
+17	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	obj	_	NamedEntity=Yes
+18	Seoighe	Seoighe	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	_
 20	acu	ag	ADP	Prep	Number=Plur|Person=3	15	obl:prep	_	_
 21	fá	fá	ADP	Simp	Dialect=Ulster|PrepForm=Cmpd	23	case	_	_
 22	choinne	choinne	ADP	Simp	Dialect=Ulster|PrepForm=Cmpd	21	fixed	_	_
 23	obair	obair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	obj	_	_
 24	den	de	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	chineál	cineál	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+25	chineál	cineál	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 26	seo	seo	DET	Det	PronType=Dem	25	det	_	_
 27	a	a	PART	Inf	PartType=Inf	28	mark	_	_
 28	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	15	xcomp	_	SpaceAfter=No
@@ -8029,15 +8029,15 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	leas	leas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	tomhaltóra	tomhaltóir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+4	tomhaltóra	tomhaltóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	gach	gach	DET	Det	Definite=Def	6	det	_	_
-6	pioc	pioc	NOUN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+6	pioc	pioc	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	tábhachtach	tábhachtach	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 9	le	le	ADP	Simp	_	10	case	_	_
 10	leas	leas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	táirgtheora	táirgtheoir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
+12	táirgtheora	táirgtheoir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 778
@@ -8052,11 +8052,11 @@
 8	AN	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	DR	dochtúir	NOUN	Abr	Abbr=Yes	7	nmod	_	NamedEntity=Yes
 10	UÍ	uí	PART	Pat	PartType=Pat	9	flat	_	NamedEntity=Yes
-11	SHÚILLEABHÁIN	Súilleabháin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+11	SHÚILLEABHÁIN	Súilleabháin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	:	:	PUNCT	Punct	_	13	punct	_	_
 13	Agus	agus	CCONJ	Coord	_	14	cc	_	_
 14	cén	cé	PRON	Q	Number=Sing|PronType=Int	2	parataxis	_	_
-15	chaoi	caoi	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	14	nsubj	_	_
+15	chaoi	caoi	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nsubj	_	_
 16	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	15	acl:relcl	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	t-othar	othar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
@@ -8069,10 +8069,10 @@
 3	focalspárálach	focalspárálach	ADJ	Adj	Gender=Masc|Number=Sing	1	amod	_	_
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nmod	_	_
 5	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
-6	Mháire	Máire	PROPN	Noun	Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+6	Mháire	Máire	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	Mhac	mac	PART	Pat	Form=Len|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
 8	an	an	PART	Pat	Definite=Def|Number=Sing|PronType=Art	6	flat:name	_	NamedEntity=Yes
-9	tSaoi	Saoi	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	tSaoi	Saoi	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 10	,	,	PUNCT	Punct	_	13	punct	_	_
 11	'	'	PUNCT	Punct	_	13	punct	_	SpaceAfter=No
 12	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
@@ -8120,7 +8120,7 @@
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 2	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
 3	ardchaighdeán	ardchaighdeán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
-4	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
+4	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
 6	idir	idir	ADP	Simp	_	7	case	_	_
 7	scríofa	scríofa	ADJ	Adj	VerbForm=Part	3	xcomp:pred	_	_
@@ -8145,7 +8145,7 @@
 26	,	,	PUNCT	Punct	_	29	punct	_	_
 27	ar	ar	ADP	Simp	_	29	case	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
-29	gCaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	23	conj	_	_
+29	gCaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	23	conj	_	_
 30	Oifigiúil	oifigiúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	29	amod	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	_
 32	ar	ar	ADP	Simp	_	33	case	_	_
@@ -8160,18 +8160,18 @@
 2	ar	ar	ADP	Simp	_	3	case	_	_
 3	bhonn	bonn	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	hargóna	argóint	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	3	nmod	_	_
+5	hargóna	argóint	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	3	nmod	_	_
 6	sin	sin	DET	Det	PronType=Dem	5	det	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	mark:prt	_	_
 8	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 9	de	de	PART	Pat	PartType=Pat	8	nsubj	_	NamedEntity=Yes
-10	Valera	Valera	PROPN	Noun	Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+10	Valera	Valera	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	i	i	ADP	Simp	_	12	case	_	_
 12	gceannas	ceannas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	Sinn	Sinn	PROPN	Noun	Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
-16	Féin	Féin	PROPN	Noun	Gender=Masc|Number=Sing	15	flat	_	NamedEntity=Yes
+15	Sinn	Sinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+16	Féin	Féin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat	_	NamedEntity=Yes
 17	nua	nua	ADJ	Adj	Degree=Pos	15	amod	_	_
 18	'	'	PUNCT	Punct	_	19	punct	_	SpaceAfter=No
 19	Poblachtach	poblachtach	ADJ	Adj	Degree=Pos	15	appos	_	SpaceAfter=No
@@ -8229,21 +8229,21 @@
 1	Nuair	nuair	SCONJ	Subord	_	3	mark	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-4	Ruaidhrí	Ruaidhrí	PROPN	Noun	Gender=Masc|Number=Sing	3	nsubj	_	NamedEntity=Yes
+4	Ruaidhrí	Ruaidhrí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	NamedEntity=Yes
 5	Ó	ó	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Flaithbeartaigh	Flaithbeartaigh	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+6	Flaithbeartaigh	Flaithbeartaigh	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 7	-	-	PUNCT	Punct	_	8	punct	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	nsubj	_	_
 9	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	4	acl:relcl	_	_
 10	Stair	stair	NOUN	Noun	Gender=Fem|Number=Sing	9	obj	_	NamedEntity=Yes
-11	Iar-Chonnacht	Iar-Chonnachta	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+11	Iar-Chonnacht	Iar-Chonnachta	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	i	i	ADP	Simp	_	13	case	_	_
 13	1684	1684	NUM	Num	_	9	obl:tmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	cuairt	cuairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obj	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
-17	Inis	inis	PROPN	Noun	Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
-18	Oírr	Oírr	PROPN	Noun	Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+17	Inis	inis	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+18	Oírr	Oírr	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	timpeall	timpeall	ADV	Dir	_	20	advmod	_	_
 20	lár	lár	NOUN	Noun	Gender=Masc|Number=Sing	3	obl	_	_
 21	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
@@ -8251,25 +8251,25 @@
 23	aoise	aois	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
 24	déag	déag	NOUN	Subst	Case=NomAcc|Number=Sing	22	nmod	_	SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Inis	inis	PROPN	Noun	Gender=Fem|Number=Sing	3	parataxis	_	NamedEntity=Yes
-27	Oirthir	oirthear	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
+26	Inis	inis	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	3	parataxis	_	NamedEntity=Yes
+27	Oirthir	oirthear	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
 28	a	a	PART	Vb	PartType=Vb|PronType=Rel	29	nsubj	_	_
 29	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	26	acl:relcl	_	_
 30	mar	mar	ADP	Simp	_	31	case	_	_
 31	ainm	ainm	NOUN	Noun	Gender=Masc|Number=Sing	29	xcomp:pred	_	_
 32	ar	ar	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	oileán	oileán	NOUN	Noun	Gender=Masc|Number=Sing	29	obl	_	_
+34	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	29	obl	_	_
 35	ach	ach	SCONJ	Subord	_	36	mark	_	_
 36	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	9	advcl	_	_
 37	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	36	nsubj	_	_
 38	go	go	PART	Vb	PartType=Cmpl	39	mark:prt	_	_
 39	dtugtaí	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Person=0|Tense=Past	36	ccomp	_	_
-40	Ára	ára	PROPN	Noun	Gender=Fem|Number=Sing	39	obj	_	NamedEntity=Yes
-41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	40	nmod	_	NamedEntity=Yes
+40	Ára	ára	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	39	obj	_	NamedEntity=Yes
+41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	40	nmod	_	NamedEntity=Yes
 42	ar	ar	ADP	Simp	_	44	case	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
-44	oileán	oileán	NOUN	Noun	Gender=Masc|Number=Sing	39	obl	_	_
+44	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	39	obl	_	_
 45	freisin	freisin	ADV	Gn	_	39	advmod	_	SpaceAfter=No
 46	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -8327,7 +8327,7 @@
 6	ar	ar	ADP	Simp	_	7	case	_	_
 7	leataobh	leataobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 8	don	do	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	tuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nmod	_	_
+9	tuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	(	(	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	obj	_	_
 12	fhoilseofar	foilsigh	VERB	VT	Form=Len|Mood=Ind|Person=0|Tense=Fut	2	acl:relcl	_	_
@@ -8348,7 +8348,7 @@
 27	go	go	PART	Vb	PartType=Cmpl	28	mark:prt	_	_
 28	gclúdaítear	clúdaigh	VERB	VT	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	26	csubj:cop	_	_
 29	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	30	nmod:poss	_	_
-30	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	obj	_	_
+30	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	28	obj	_	_
 31	de	de	ADP	Simp	_	32	case	_	_
 32	thuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	30	nmod	_	_
 33	le	le	ADP	Simp	_	34	case	_	_
@@ -8369,7 +8369,7 @@
 # text = Eascróidh na teicníochtaí measúnaithe a mbainfear leas astu go nádúrtha as an teagasc agus as an bhfoghlaim agus beidh a n-éifeacht ag brath ar chomh hinniúil agus a bheidh an múinteoir ar bhreathnóireacht, ar éisteacht, ar idirghníomhú leis na daltaí agus ar thorthaí a dtascanna foghlama san eolaíocht a mhionscrúdú.
 1	Eascróidh	eascair	VERB	VI	Mood=Ind|Tense=Fut	0	root	_	_
 2	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	teicníochtaí	teicníocht	NOUN	Noun	Gender=Fem|Number=Plur	1	nsubj	_	_
+3	teicníochtaí	teicníocht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	1	nsubj	_	_
 4	measúnaithe	measúnú	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	obl	_	_
 6	mbainfear	bain	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	3	acl:relcl	_	_
@@ -8383,11 +8383,11 @@
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	as	as	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	bhfoghlaim	foghlaim	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	13	conj	_	_
+17	bhfoghlaim	foghlaim	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	13	conj	_	_
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	1	conj	_	_
 20	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	21	nmod:poss	_	_
-21	n-éifeacht	éifeacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	19	nsubj	_	_
+21	n-éifeacht	éifeacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	19	nsubj	_	_
 22	ag	ag	ADP	Simp	_	23	case	_	_
 23	brath	brath	NOUN	Noun	VerbForm=Vnoun	19	xcomp	_	_
 24	ar	ar	ADP	Simp	_	23	obl:prep	_	_
@@ -8413,7 +8413,7 @@
 44	ar	ar	ADP	Simp	_	45	case	_	_
 45	thorthaí	toradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	52	obj	_	_
 46	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	47	nmod:poss	_	_
-47	dtascanna	tasc	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	45	nmod	_	_
+47	dtascanna	tasc	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	45	nmod	_	_
 48	foghlama	foghlaim	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	47	nmod	_	_
 49	san	i	ADP	Art	Number=Sing|PronType=Art	50	case	_	_
 50	eolaíocht	eolaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	47	nmod	_	_
@@ -8433,7 +8433,7 @@
 8	feirmeacha	feirm	NOUN	Noun	Gender=Fem|Number=Plur	13	obj	_	_
 9	bídeacha	bídeach	ADJ	Adj	NounType=NotSlender|Number=Plur	8	amod	_	_
 10	san	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	iarthar	iarthar	NOUN	Noun	Gender=Masc|Number=Sing	8	nmod	_	_
+11	iarthar	iarthar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
 13	chónascadh	cónascadh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
@@ -8460,13 +8460,13 @@
 9	polaitiúla	polaitiúil	ADJ	Adj	Case=Gen|NounType=Strong|Number=Plur	8	amod	_	_
 10	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	8	acl:relcl	_	_
 11	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	12	case	_	_
-12	n-imirt	imirt	NOUN	Noun	Form=Ecl|VerbForm=Inf	10	xcomp	_	_
+12	n-imirt	imirt	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	10	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	easaontóirí	easaontóir	NOUN	Noun	Gender=Masc|Number=Plur	12	nmod	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
 16	bpáirtí	páirtí	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
-17	David	David	PROPN	Noun	Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
-18	Trimble	Trimble	PROPN	Noun	Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+17	David	David	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Trimble	Trimble	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 794
@@ -8479,7 +8479,7 @@
 6	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	2	xcomp	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	sráid	sráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
+9	sráid	sráid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	2	punct	_	_
 11	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	0	root	_	_
 12	orthu	ar	ADP	Prep	Number=Plur|Person=3	11	obl:prep	_	_
@@ -8488,7 +8488,7 @@
 15	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	11	xcomp	_	_
 16	isteach	isteach	ADV	Dir	_	15	advmod	_	_
 17	sa	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	chathair	cathair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
+18	chathair	cathair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
 19	ar	ar	ADP	Simp	_	20	case	_	_
 20	dtúis	tús	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	11	punct	_	_
@@ -8510,17 +8510,17 @@
 # text = I mí Mheán Fómhair 1940, bhí áit pioctha ag Séamus i Kaji-htu, chun misean nua a chur ar bun.
 1	I	I	ADP	Simp	_	2	case	_	_
 2	mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obl:tmod	_	_
-3	Mheán	Meán	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
-4	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+3	Mheán	Meán	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
+4	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	1940	1940	NUM	Num	_	3	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	2	punct	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 8	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nsubj	_	_
 9	pioctha	pioctha	ADJ	Adj	VerbForm=Part	7	xcomp:pred	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
-11	Séamus	Séamus	PROPN	Noun	Gender=Masc|Number=Sing	7	obl	_	_
+11	Séamus	Séamus	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	Kaji-htu	Kaji-htu	PROPN	Noun	Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+13	Kaji-htu	Kaji-htu	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	19	punct	_	_
 15	chun	chun	ADP	Simp	_	19	case	_	_
 16	misean	misean	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
@@ -8548,13 +8548,13 @@
 1	Ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
 2	gach	gach	DET	Det	Definite=Def	4	det	_	_
 3	uile	uile	DET	Det	PronType=Ind	4	det	_	_
-4	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+4	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	mbliain	bliain	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	4	nmod	_	_
+6	mbliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	4	nmod	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	mark:prt	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	4	csubj:cleft	_	_
 9	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
-10	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nsubj	_	_
+10	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	nsubj	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
 12	scéala	scéala	NOUN	Noun	Gender=Masc|Number=Sing	10	nmod	_	_
 13	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	xcomp:pred	_	SpaceAfter=No
@@ -8582,7 +8582,7 @@
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	tugadh	tabhair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	4	conj	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	scilling	scilling	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	obj	_	_
+21	scilling	scilling	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	19	obj	_	_
 22	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	19	obl:prep	_	SpaceAfter=No
 23	!	!	PUNCT	!	_	4	punct	_	_
 
@@ -8608,9 +8608,9 @@
 # text = Díomá Dúirt Antaine Ó Faracháin, duine de choiste eagraithe Fhéile Sean-Nós Cois Life go raibh díomá ar lucht na féile faoin bpolasaí nua.
 1	Díomá	díomá	NOUN	Noun	Gender=Fem|Number=Sing	2	parataxis	_	_
 2	Dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-3	Antaine	Antaine	PROPN	Noun	Gender=Masc|Number=Sing	2	nsubj	_	NamedEntity=Yes
+3	Antaine	Antaine	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	NamedEntity=Yes
 4	Ó	ó	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Faracháin	Faracháin	PROPN	Noun	Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+5	Faracháin	Faracháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	3	appos	_	_
 8	de	de	ADP	Simp	_	9	case	_	_
@@ -8618,8 +8618,8 @@
 10	eagraithe	eagrú	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
 11	Fhéile	féile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	Sean-Nós	sean-nós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
-13	Cois	cois	PROPN	Noun	_	11	nmod	_	NamedEntity=Yes
-14	Life	Life	PROPN	Noun	Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
+13	Cois	cois	PROPN	Noun	Definite=Def	11	nmod	_	NamedEntity=Yes
+14	Life	Life	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	go	go	PART	Vb	PartType=Cmpl	16	mark:prt	_	_
 16	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	2	ccomp	_	_
 17	díomá	díomá	NOUN	Noun	Gender=Fem|Number=Sing	16	nsubj	_	_
@@ -8628,7 +8628,7 @@
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	féile	féile	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	bpolasaí	polasaí	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	16	obl	_	_
+23	bpolasaí	polasaí	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	16	obl	_	_
 24	nua	nua	ADJ	Adj	Gender=Masc|Number=Sing	23	amod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -8654,12 +8654,12 @@
 18	isteach	isteach	ADV	Dir	_	17	advmod	_	_
 19	go	go	ADP	Simp	_	20	case	_	_
 20	Coláiste	coláiste	NOUN	Noun	Gender=Masc|Number=Sing	18	obl	_	NamedEntity=Yes
-21	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
+21	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
-23	Droim	droim	PROPN	Noun	Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
-24	Conrach	conrach	PROPN	Noun	Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
+23	Droim	droim	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+24	Conrach	conrach	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	gach	gach	DET	Det	Definite=Def	26	det	_	_
-26	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obl:tmod	_	SpaceAfter=No
+26	bliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	obl:tmod	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 804
@@ -8693,7 +8693,7 @@
 27	roimh	roimh	ADP	Simp	_	28	case	_	_
 28	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-30	h-aoise	aois	NOUN	Noun	Form=HPref|Gender=Fem|Number=Sing	28	nmod	_	_
+30	h-aoise	aois	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Sing	28	nmod	_	_
 31	seo	seo	DET	Det	PronType=Dem	30	det	_	SpaceAfter=No
 32	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -8714,8 +8714,8 @@
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	Network	Network	X	Foreign	Foreign=Yes	1	nmod	_	NamedEntity=Yes
 6	2	2	NUM	Num	_	5	flat	_	NamedEntity=Yes
-7	Dé	Dé	PROPN	Subst	_	1	nmod	_	NamedEntity=Yes
-8	Luain	Luan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Dé	Dé	PROPN	Subst	Definite=Def	1	nmod	_	NamedEntity=Yes
+8	Luain	Luan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	10.30	10.30	NUM	Num	_	1	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
@@ -8725,7 +8725,7 @@
 1	Ar	ar	ADP	Simp	_	4	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	31	31	NUM	Num	_	5	obl:tmod	_	NamedEntity=Yes
-4	Lúnasa	Lúnasa	PROPN	Noun	Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+4	Lúnasa	Lúnasa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	scaip	scaip	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	tSeirbhís	seirbhís	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
@@ -8760,11 +8760,11 @@
 7	cabhlacha	cabhail	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	2	nmod	_	_
 8	crann	crann	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	7	nmod	_	_
 9	sna	i	ADP	Art	Number=Plur|PronType=Art	10	case	_	_
-10	doirí	doire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obl	_	_
+10	doirí	doire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 11	úd	úd	DET	Det	PronType=Dem	10	det	_	_
 12	agus	agus	CCONJ	Coord	_	14	cc	_	_
 13	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	14	case	_	_
-14	dteannta	teannta	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	15	nmod	_	_
+14	dteannta	teannta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	15	nmod	_	_
 15	altóirí	altóir	NOUN	Noun	Gender=Fem|Number=Plur	7	conj	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	obl	_	_
@@ -8785,7 +8785,7 @@
 7	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	5	nmod	_	_
 8	ag	ag	ADP	Simp	_	10	case	_	_
 9	gach	gach	DET	Det	Definite=Def	10	det	_	_
-10	foireann	foireann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
+10	foireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 11	:	:	PUNCT	Punct	_	12	punct	_	_
 12	éide	éide	NOUN	Noun	Gender=Fem|Number=Sing	1	parataxis	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	obl	_	_
@@ -8801,7 +8801,7 @@
 23	ag	ag	ADP	Simp	_	24	case	_	_
 24	imirt	imirt	NOUN	Noun	VerbForm=Vnoun	22	xcomp	_	_
 25	sa	i	ADP	Art	Number=Sing|PronType=Art	26	case	_	_
-26	bhaile	baile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
+26	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 27	;	;	PUNCT	Punct	_	28	punct	_	_
 28	agus	agus	CCONJ	Coord	_	29	cc	_	_
 29	éide	éide	NOUN	Noun	Gender=Fem|Number=Sing	12	conj	_	_
@@ -8834,7 +8834,7 @@
 7	lusca	lusca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 8	Bhaisleac	baisleac	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|NounType=Weak|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	Naomh	Naomh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-10	Peadar	Peadar	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat	_	NamedEntity=Yes|SpaceAfter=No
+10	Peadar	Peadar	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat	_	NamedEntity=Yes|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 811
@@ -8862,7 +8862,7 @@
 1	)	)	PUNCT	Punct	_	2	punct	_	_
 2	Lean	lean	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 3	gach	gach	DET	Det	Definite=Def	4	det	_	_
-4	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	nsubj	_	_
+4	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	eile	eile	DET	Det	PronType=Dem	4	det	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	obj	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
@@ -8873,11 +8873,11 @@
 12	nár	nár	PART	Vb	PartType=Cmpl|Tense=Past	13	mark:prt	_	_
 13	thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	11	csubj:cop	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	Prionsa	prionsa	NOUN	Noun	Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
-16	Eoin	Eoin	PROPN	Noun	Gender=Masc|Number=Sing	15	flat	_	NamedEntity=Yes
+15	Prionsa	prionsa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
+16	Eoin	Eoin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat	_	NamedEntity=Yes
 17	isteach	isteach	ADV	Dir	_	13	advmod	_	_
 18	san	i	ADP	Art	Number=Sing|PronType=Art	19	case	_	_
-19	abhainn	abhainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	_
+19	abhainn	abhainn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	13	obl	_	_
 20	arís	arís	ADV	Gn	_	13	advmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -8914,7 +8914,7 @@
 8	baint	baint	NOUN	Noun	VerbForm=Vnoun	6	xcomp	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	PronType=Art	11	det	_	_
-11	imirce	imirce	NOUN	Noun	Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
+11	imirce	imirce	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 815
@@ -8927,7 +8927,7 @@
 6	dul	dul	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 7	tríd	trí	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
-9	heachtraí	eachtra	NOUN	Noun	Form=HPref|Gender=Fem|Number=Plur	6	obl	_	_
+9	heachtraí	eachtra	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Plur	6	obl	_	_
 10	peannaideacha	peannaideach	ADJ	Adj	NounType=NotSlender|Number=Plur	9	amod	_	_
 11	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
@@ -8959,18 +8959,18 @@
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	fhéith	féith	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	réabhlóideachais	réabhlóideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
+7	réabhlóideachais	réabhlóideachas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	troda	troid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	conj	_	_
 10	de	de	ADP	Simp	_	11	case	_	_
 11	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
-12	Skinner	Skinner	PROPN	Noun	Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+12	Skinner	Skinner	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 817
 # text = San am chéanna bhí smaointiú pisreogach ag teacht fríd mo cheann gur trí ghné den anam amháin Cathal Mac Eachmharcaigh agus mé féin agus Ruairí Ó Canainn - Cathal an t-éigeas domhain filiúnta agus mise ní ba ghairbhe ná sin, eadar an fhilíocht agus éachtaí an tsaoil, agus Ruairí garbh go leor lena bhealach a throid thart ceithre ceathrúna an domhain.
 1	San	i	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	_
+2	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 3	chéanna	céanna	ADJ	Adj	Degree=Pos|Form=Len	2	amod	_	_
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 5	smaointiú	smaointiú	NOUN	Noun	VerbForm=Inf	4	nsubj	_	_
@@ -8979,25 +8979,25 @@
 8	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
 9	fríd	trí	ADP	Simp	_	11	case	_	_
 10	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	11	nmod:poss	_	_
-11	cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+11	cheann	ceann	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 12	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	14	cop	_	_
 13	trí	trí	ADP	Simp	_	14	case	_	_
 14	ghné	gné	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	4	ccomp	_	_
 15	den	de	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	anam	anam	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	_
+16	anam	anam	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	amháin	amháin	ADJ	Adj	Degree=Pos	16	amod	_	_
-18	Cathal	Cathal	PROPN	Noun	Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Cathal	Cathal	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	Mac	mac	PART	Pat	PartType=Pat	18	flat:name	_	NamedEntity=Yes
-20	Eachmharcaigh	Eachmharcach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
+20	Eachmharcaigh	Eachmharcach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	flat:name	_	NamedEntity=Yes
 21	agus	agus	CCONJ	Coord	_	22	cc	_	_
 22	mé	mé	PRON	Pers	Number=Sing|Person=1	18	conj	_	_
 23	féin	féin	PRON	Ref	Reflex=Yes	22	nmod	_	_
 24	agus	agus	CCONJ	Coord	_	25	cc	_	_
-25	Ruairí	Ruairí	PROPN	Noun	Gender=Masc|Number=Sing	18	conj	_	NamedEntity=Yes
+25	Ruairí	Ruairí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	conj	_	NamedEntity=Yes
 26	Ó	ó	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
-27	Canainn	Canann	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
+27	Canainn	Canann	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes
 28	-	-	PUNCT	Punct	_	29	punct	_	_
-29	Cathal	Cathal	PROPN	Noun	Gender=Masc|Number=Sing	4	parataxis	_	_
+29	Cathal	Cathal	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	parataxis	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	t-éigeas	éigeas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	appos	_	_
 32	domhain	domhain	ADJ	Adj	Gender=Masc|Number=Sing	31	amod	_	_
@@ -9019,19 +9019,19 @@
 48	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
 50	agus	agus	CCONJ	Coord	_	51	cc	_	_
-51	Ruairí	Ruairí	PROPN	Noun	Gender=Masc|Number=Sing	29	conj	_	_
+51	Ruairí	Ruairí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	29	conj	_	_
 52	garbh	garbh	ADJ	Adj	Degree=Pos	51	amod	_	_
 53	go	go	ADJ	Adj	_	52	amod	_	_
 54	leor	leor	NOUN	Subst	Number=Sing	53	fixed	_	_
-55	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	58	case	_	_
+55	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	56	case	_	_
 56	bhealach	bealach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	58	obj	_	_
 57	a	a	PART	Inf	PartType=Inf	58	mark	_	_
 58	throid	troid	NOUN	Noun	Form=Len|VerbForm=Inf	51	xcomp	_	_
 59	thart	thart	ADV	Dir	_	58	advmod	_	_
 60	ceithre	ceathair	NUM	Num	NumType=Card	61	nummod	_	_
-61	ceathrúna	ceathrú	NOUN	Noun	Gender=Fem|Number=Plur	58	nmod	_	_
+61	ceathrúna	ceathrú	NOUN	Noun	Gender=Fem|Number=Plur	58	obl	_	_
 62	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	63	det	_	_
-63	domhain	domhan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	61	nmod	_	SpaceAfter=No
+63	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	61	nmod	_	SpaceAfter=No
 64	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 818
@@ -9059,11 +9059,11 @@
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	11	nmod	_	_
 14	ag	ag	ADP	Simp	_	15	case	_	_
-15	Éamon	Éamon	PROPN	Noun	Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
+15	Éamon	Éamon	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
 16	Ó	ó	PART	Pat	PartType=Pat	15	flat:name	_	NamedEntity=Yes
-17	Cuív	Cuív	PROPN	Noun	Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes
+17	Cuív	Cuív	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gConamara	Conamara	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	_
+19	gConamara	Conamara	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	_
 20	-	-	PUNCT	Punct	_	21	punct	_	_
 21	sin	sin	PRON	Dem	PronType=Dem	1	parataxis	_	_
 22	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	23	det	_	_
@@ -9077,9 +9077,9 @@
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
 32	oileáin	oileán	NOUN	Noun	Gender=Masc|Number=Plur	23	conj	_	NamedEntity=Yes
-33	Árann	Árainn	PROPN	Noun	Case=Gen|Gender=Fem|NounType=Weak|Number=Plur	32	nmod	_	NamedEntity=Yes
+33	Árann	Árainn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	32	nmod	_	NamedEntity=Yes
 34	san	i	ADP	Art	Number=Sing|PronType=Art	35	case	_	_
-35	áireamh	áireamh	NOUN	Noun	Gender=Masc|Number=Sing	32	nmod	_	SpaceAfter=No
+35	áireamh	áireamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 820
@@ -9108,7 +9108,7 @@
 9	bhliana	bliain	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	5	conj	_	_
 10	measúnachta	measúnacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
 11	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	case	_	_
-12	éis	éis	NOUN	Subst	Number=Sing	10	nmod	_	SpaceAfter=No
+12	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	10	nmod	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	3	punct	_	_
 14	féadfaidh	féad	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -9134,7 +9134,7 @@
 35	aontú	aontú	NOUN	Noun	VerbForm=Inf	33	obj	_	_
 36	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	nmod	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
-38	dtráthchodanna	tráthchuid	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	36	nmod	_	_
+38	dtráthchodanna	tráthchuid	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	36	nmod	_	_
 39	comhionanna	comhionann	ADJ	Adj	NounType=Strong|Number=Plur	38	amod	_	_
 40	míosúla	míosúil	ADJ	Adj	Case=Gen|NounType=Strong|Number=Plur	38	amod	_	_
 41	a	a	PART	Vb	PartType=Vb|PronType=Rel	42	nsubj	_	_
@@ -9159,7 +9159,7 @@
 60	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	66	xcomp	_	_
 61	íoctha	íoctha	ADJ	Adj	VerbForm=Part	60	xcomp:pred	_	_
 62	sa	i	ADP	Art	Number=Sing|PronType=Art	63	case	_	_
-63	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	60	obl:tmod	_	_
+63	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	60	obl:tmod	_	_
 64	sin	sin	DET	Det	PronType=Dem	63	det	_	SpaceAfter=No
 65	,	,	PUNCT	Punct	_	60	punct	_	_
 66	aontú	aontú	NOUN	Noun	VerbForm=Inf	36	nmod	_	_
@@ -9177,10 +9177,10 @@
 78	i	i	ADP	Simp	_	79	case	_	_
 79	dtráthchodanna	tráthchuid	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	77	obl	_	_
 80	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	81	case	_	_
-81	éis	éis	NOUN	Subst	Number=Sing	75	obl	_	_
+81	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	75	obl	_	_
 82	sin	sin	PRON	Dem	PronType=Dem	81	det	_	_
 83	sa	i	ADP	Art	Number=Sing|PronType=Art	84	case	_	_
-84	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	75	obl	_	_
+84	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	75	obl	_	_
 85	sin	sin	DET	Det	PronType=Dem	84	det	_	SpaceAfter=No
 86	;	;	PUNCT	Punct	_	87	punct	_	_
 87	ach	ach	SCONJ	Subord	_	66	mark	_	_
@@ -9215,7 +9215,7 @@
 116	10	10	NUM	Num	_	117	nummod	_	_
 117	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	114	conj	_	_
 118	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	119	det	_	_
-119	dtráthchodanna	tráthchuid	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	117	nmod	_	_
+119	dtráthchodanna	tráthchuid	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	117	nmod	_	_
 120	míosúla	míosúil	ADJ	Adj	NounType=NotSlender|Number=Plur	119	amod	_	_
 121	a	a	PART	Vb	PartType=Vb|PronType=Rel	122	nsubj	_	_
 122	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	119	acl:relcl	_	_
@@ -9225,7 +9225,7 @@
 126	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	123	obl	_	_
 127	sin	sin	DET	Det	PronType=Dem	126	det	_	_
 128	sa	i	ADP	Art	Number=Sing|PronType=Art	129	case	_	_
-129	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	122	obl:tmod	_	_
+129	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	122	obl:tmod	_	_
 130	mheasúnachta	measúnacht	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	129	compound	_	SpaceAfter=No
 131	,	,	PUNCT	Punct	_	132	punct	_	_
 132	agus	agus	CCONJ	Coord	_	112	cc	_	_
@@ -9238,7 +9238,7 @@
 139	ná	ná	CCONJ	Coord	_	140	cc	_	_
 140	70	70	NUM	Num	_	136	conj	_	_
 141	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	142	case	_	_
-142	gcéad	céad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	136	nmod	_	_
+142	gcéad	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	136	nmod	_	_
 143	de	de	ADP	Simp	_	144	case	_	_
 144	mhéid	méid	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	142	nmod	_	_
 145	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	146	det	_	_
@@ -9250,7 +9250,7 @@
 151	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	135	obl	_	_
 152	sin	sin	DET	Det	PronType=Dem	151	det	_	_
 153	don	do	ADP	Art	Number=Sing|PronType=Art	154	case	_	_
-154	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	157	obj	_	_
+154	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	157	obj	_	_
 155	sin	sin	DET	Det	PronType=Dem	154	det	_	_
 156	a	a	PART	Inf	PartType=Inf	157	mark	_	_
 157	íoc	íoc	NOUN	Noun	VerbForm=Inf	135	xcomp	_	_
@@ -9261,11 +9261,11 @@
 162	roimh	roimh	ADP	Simp	_	165	case	_	_
 163	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	165	det	_	_
 164	31ú	31	NUM	Num	NumType=Ord	165	amod	_	_
-165	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	157	nmod	_	_
+165	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	157	nmod	_	_
 166	de	de	ADP	Simp	_	167	case	_	_
-167	Nollaig	Nollaig	PROPN	Noun	Gender=Fem|Number=Sing	165	nmod	_	_
+167	Nollaig	Nollaig	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	165	nmod	_	_
 168	sa	i	ADP	Art	Number=Sing|PronType=Art	169	case	_	_
-169	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	157	nmod	_	_
+169	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	157	nmod	_	_
 170	sin	sin	DET	Det	PronType=Dem	169	det	_	SpaceAfter=No
 171	.	.	PUNCT	.	_	14	punct	_	_
 
@@ -9276,12 +9276,12 @@
 3	go	go	ADP	Simp	_	4	case	_	_
 4	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	thugadh	tabhair	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Past	0	root	_	_
-6	Ljúbín	Ljúbín	PROPN	Noun	Gender=Masc|Number=Sing	5	nsubj	_	_
+6	Ljúbín	Ljúbín	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	obl:prep	_	_
 8	go	go	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
 9	dtí	dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	8	fixed	_	_
 10	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	11	nmod:poss	_	_
-11	theach	teach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+11	theach	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 12	féin	féin	PRON	Ref	Reflex=Yes	11	nmod	_	_
 13	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	obj	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	5	punct	_	_
@@ -9292,7 +9292,7 @@
 2	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 3	ceart	ceart	ADJ	Adj	Degree=Pos	0	root	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	hionsaithe	ionsaí	NOUN	Noun	Form=HPref|Gender=Masc|Number=Plur	7	obj	_	_
+5	hionsaithe	ionsaí	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	7	obj	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	cháineadh	cáineadh	NOUN	Noun	Form=Len|VerbForm=Inf	3	csubj:cop	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
@@ -9309,7 +9309,7 @@
 19	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	13	advcl	_	_
 20	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nsubj	_	_
 21	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	22	case	_	_
-22	lorg	lorg	NOUN	Noun	VerbForm=Inf	19	xcomp	_	_
+22	lorg	lorg	NOUN	Noun	Definite=Def|VerbForm=Inf	19	xcomp	_	_
 23	go	go	PART	Ad	PartType=Ad	24	mark:prt	_	_
 24	dícheallach	dícheallach	ADJ	Adj	Degree=Pos	22	advmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	_	_
@@ -9333,7 +9333,7 @@
 5	dó	dó	NUM	Num	NumType=Card	8	nummod	_	_
 6	dhéag	déag	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	5	nmod	_	_
 7	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	chlog	clog	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl:tmod	_	SpaceAfter=No
+8	chlog	clog	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl:tmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 826
@@ -9342,7 +9342,7 @@
 2	chloisim	clois	VERB	VTI	Form=Len|Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
 3	éinne	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	nsubj	_	_
 4	á	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	case	_	_
-5	caoineadh	caoineadh	NOUN	Noun	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
+5	caoineadh	caoineadh	NOUN	Noun	Definite=Def|VerbForm=Inf	2	xcomp	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	ámh	ámh	ADV	_	_	2	advmod	_	SpaceAfter=No
 8	;	;	PUNCT	Punct	_	7	punct	_	_
@@ -9355,7 +9355,7 @@
 15	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	14	nsubj	_	_
 16	chun	chun	ADP	Simp	_	18	case	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	huaighe	uaigh	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	14	obl	_	_
+18	huaighe	uaigh	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	14	obl	_	_
 19	is	agus	SCONJ	Subord	_	21	mark	_	_
 20	gan	gan	ADP	Simp	_	21	case	_	_
 21	tórramh	tórramh	NOUN	Noun	Gender=Masc|Number=Sing	14	advcl	_	_
@@ -9396,7 +9396,7 @@
 4	raimhre	raimhre	NOUN	Noun	Gender=Fem|Number=Sing	2	nsubj	_	_
 5	fós	fós	ADV	Gn	_	2	advmod	_	_
 6	sna	i	ADP	Art	Number=Plur|PronType=Art	7	case	_	_
-7	prátaí	práta	NOUN	Noun	Gender=Masc|Number=Plur	2	obl	_	_
+7	prátaí	práta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	2	obl	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
 10	formhór	formhór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
@@ -9404,7 +9404,7 @@
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
 13	dtornapaí	tornapa	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	10	nmod	_	_
 14	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	15	case	_	_
-15	bpóiríní	póirín	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	SpaceAfter=No
+15	bpóiríní	póirín	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 829
@@ -9423,9 +9423,9 @@
 # sent_id = 830
 # text = Mhol Sheena agus Richard go mb'fhéidir gur cheart dúinn teacht le chéile a eagrú don bhliain seo chugainn, chuadar timpeall ag tógaint ár seoltaí, ach ní raibh mórán suime sa tseift.
 1	Mhol	mol	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Sheena	Sheena	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Sheena	Sheena	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
-4	Richard	Richard	PROPN	Noun	Gender=Masc|Number=Sing	2	conj	_	_
+4	Richard	Richard	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	conj	_	_
 5	go	go	PART	Vb	PartType=Cmpl	7	mark:prt	_	_
 6	mb'	is	AUX	Cop	Form=Ecl,VF|Tense=Past|VerbForm=Cop	7	cop	_	SpaceAfter=No
 7	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	1	ccomp	_	_
@@ -9447,7 +9447,7 @@
 23	ag	ag	ADP	Simp	_	24	case	_	_
 24	tógaint	tógáil	NOUN	Noun	Gender=Fem|Number=Sing	21	xcomp	_	_
 25	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	26	nmod:poss	_	_
-26	seoltaí	seol	NOUN	Noun	Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
+26	seoltaí	seol	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	30	punct	_	_
 28	ach	ach	SCONJ	Subord	_	30	mark	_	_
 29	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	30	advmod	_	_
@@ -9487,11 +9487,11 @@
 # sent_id = 832
 # text = A Mháire Áine, a iníon ó, tá scéala agam duit, d'fhógair sí uirthi nuair a d'airigh sí a coisméig éadrom ag teannadh le doras an tí a bhí le taobh dhoras an agaird.
 1	A	a	PART	Voc	PartType=Voc	2	case:voc	_	_
-2	Mháire	Máire	PROPN	Noun	Case=Voc|Form=Len|Gender=Fem	9	vocative	_	NamedEntity=Yes
-3	Áine	Áine	PROPN	Noun	Case=Gen|Gender=Fem	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+2	Mháire	Máire	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Fem	9	vocative	_	NamedEntity=Yes
+3	Áine	Áine	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	a	a	PART	Voc	PartType=Voc	6	case:voc	_	_
-6	iníon	iníon	NOUN	Noun	Case=Voc|Gender=Fem|Number=Sing	9	vocative	_	_
+6	iníon	iníon	NOUN	Noun	Case=Voc|Definite=Def|Gender=Fem|Number=Sing	9	vocative	_	_
 7	ó	ó	INTJ	Itj	_	9	discourse	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	7	punct	_	_
 9	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -9509,21 +9509,21 @@
 21	airigh	airigh	VERB	VT	Mood=Ind|Tense=Past	15	advcl	_	_
 22	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	21	nsubj	_	_
 23	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	24	nmod:poss	_	_
-24	coisméig	coisméig	NOUN	Noun	Gender=Fem|Number=Sing	21	obj	_	_
+24	coisméig	coisméig	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	21	obj	_	_
 25	éadrom	éadrom	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	24	amod	_	_
 26	ag	ag	ADP	Simp	_	27	case	_	_
 27	teannadh	teannadh	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 28	le	le	ADP	Simp	_	29	case	_	_
 29	doras	doras	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	nmod	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
-31	tí	teach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	_
+31	tí	teach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	a	a	PART	Vb	PartType=Vb|PronType=Rel	33	nsubj	_	_
 33	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	29	acl:relcl	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
 35	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	obl	_	_
 36	dhoras	doras	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	_
 37	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
-38	agaird	agard	NOUN	Noun	Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
+38	agaird	agard	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 39	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 833
@@ -9532,7 +9532,7 @@
 2	Chuardaíomar	cuardaigh	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=1|Tense=Past	0	root	_	_
 3	gach	gach	DET	Det	Definite=Def	5	det	_	_
 4	aon	aon	DET	Det	PronType=Ind	5	det	_	_
-5	chuas	cuas	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
+5	chuas	cuas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
 7	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	2	obl	_	_
 8	chomh	chomh	ADV	Its	_	9	advmod	_	_
@@ -9580,9 +9580,9 @@
 6	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
 8	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
-9	Mháirtín	Máirtín	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+9	Mháirtín	Máirtín	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	Uí	uí	PART	Pat	PartType=Pat	9	flat:name	_	NamedEntity=Yes
-11	Mhéalóid	Méalóid	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes
+11	Mhéalóid	Méalóid	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes
 12	in	i	ADP	Simp	_	13	case	_	_
 13	Lig	lig	VERB	_	Mood=Imp|Number=Sing|Person=2	1	obl	_	NamedEntity=Yes
 14	Sinn	sinn	PRON	Pers	Number=Plur|Person=1	13	obj	_	NamedEntity=Yes
@@ -9617,7 +9617,7 @@
 23	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	18	advcl	_	_
 24	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	nsubj	_	_
 25	Bhráthar	bráthair	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
-26	Saidhclaps	Saidhclaps	PROPN	Noun	Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
+26	Saidhclaps	Saidhclaps	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 27	i	i	ADP	Simp	_	28	case	_	_
 28	bprobhinse	proibhinse	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing|Typo=Yes	23	obl	_	_
 29	Leatha	leath	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	28	nmod	_	NamedEntity=Yes
@@ -9637,7 +9637,7 @@
 # text = AR 10 Feabhra 1968, cúig lá tar éis do William Conor bás a fháil, d'fhoilsigh an Belfast Telegraph cartún le Rowel Friers (1920-) dar teideal 'The End of an Era,' in ómós don phrionsa fir a bhí ar lár.
 1	AR	ar	ADP	Simp	_	3	case	_	_
 2	10	10	NUM	Num	_	18	obl:tmod	_	NamedEntity=Yes
-3	Feabhra	Feabhra	PROPN	Noun	Gender=Fem|Number=Sing	2	flat	_	NamedEntity=Yes
+3	Feabhra	Feabhra	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	2	flat	_	NamedEntity=Yes
 4	1968	1968	NUM	Num	_	2	flat	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
 6	cúig	cúig	NUM	Num	NumType=Card	7	nummod	_	_
@@ -9645,8 +9645,8 @@
 8	tar	tar	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
 9	éis	éis	ADP	Cmpd	PrepForm=Cmpd	8	fixed	_	_
 10	do	do	ADP	Simp	_	15	case	_	_
-11	William	William	PROPN	Noun	Gender=Masc|Number=Sing	15	obj	_	NamedEntity=Yes
-12	Conor	Conor	PROPN	Noun	Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
+11	William	William	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	obj	_	NamedEntity=Yes
+12	Conor	Conor	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	bás	bás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	fháil	fáil	NOUN	Noun	Form=Len|VerbForm=Inf	18	xcomp	_	SpaceAfter=No
@@ -9658,8 +9658,8 @@
 21	Telegraph	Telegraph	PROPN	Noun	Foreign=Yes|Number=Sing	20	flat:foreign	_	NamedEntity=Yes
 22	cartún	cartún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	obj	_	_
 23	le	le	ADP	Simp	_	24	case	_	_
-24	Rowel	Rowel	PROPN	Noun	Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
-25	Friers	Friers	PROPN	Noun	Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
+24	Rowel	Rowel	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
+25	Friers	Friers	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
 26	(	(	PUNCT	Punct	_	27	punct	_	SpaceAfter=No
 27	1920-	1920-	NUM	Num	_	24	nmod	_	SpaceAfter=No
 28	)	)	PUNCT	Punct	_	27	punct	_	_
@@ -9676,7 +9676,7 @@
 39	in	i	ADP	Simp	_	40	case	_	_
 40	ómós	ómós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	obl	_	_
 41	don	do	ADP	Art	Number=Sing|PronType=Art	42	case	_	_
-42	phrionsa	prionsa	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	40	nmod	_	_
+42	phrionsa	prionsa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	nmod	_	_
 43	fir	fear	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	42	nmod	_	_
 44	a	a	PART	Vb	PartType=Vb|PronType=Rel	45	nsubj	_	_
 45	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	42	acl:relcl	_	_
@@ -9692,7 +9692,7 @@
 4	Ceannfort	ceannfort	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 5	Mac	mac	PART	Pat	PartType=Pat	4	flat	_	NamedEntity=Yes
 6	a'	an	PART	Pat	Definite=Def|Number=Sing|PronType=Art	4	flat:name	_	NamedEntity=Yes
-7	Bhaird	Baird	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+7	Bhaird	Baird	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	mark:prt	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	4	csubj:cleft	_	_
 10	freagrach	freagrach	ADJ	Adj	Degree=Pos	9	xcomp:pred	_	_
@@ -9702,9 +9702,9 @@
 14	seo	seo	DET	Det	PronType=Dem	13	det	_	_
 15	roimh	roimh	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	gCigirt	cigirt	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
+17	gCigirt	cigirt	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
 18	Mac	mac	PART	Pat	PartType=Pat	17	flat	_	NamedEntity=Yes
-19	Fhionnlaoich	Fionnlaoch	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Fhionnlaoich	Fionnlaoch	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 20	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 840
@@ -9713,20 +9713,20 @@
 2	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	NamedEntity=Yes
 3	Mór-Roinne	Mór-Roinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	ón	ó	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	bhFrainc	Frainc	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	nmod	_	_
+5	bhFrainc	Frainc	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	nmod	_	_
 6	soir	soir	ADV	Dir	_	1	advmod	_	_
 7	go	go	ADP	Cmpd	PrepForm=Cmpd	10	case	_	_
 8	dtí	dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	7	fixed	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	Áise	Áise	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
+10	Áise	Áise	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 841
 # text = Sin Pádraig Mac Piarais, duine cumasach, díograiseach, dúthrachtach ach duine nach raibh ceird an ionramhálaí ná an teagmhálaí dhioplómaitiúil riamh aige.
 1	Sin	sin	PRON	Dem	PronType=Dem	0	root	_	_
-2	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	Mac	mac	PART	Pat	PartType=Pat	2	flat:name	_	NamedEntity=Yes
-4	Piarais	Piarais	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+4	Piarais	Piarais	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
 6	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	appos	_	_
 7	cumasach	cumasach	ADJ	Adj	Degree=Pos	6	amod	_	SpaceAfter=No
@@ -9752,14 +9752,14 @@
 # sent_id = 842
 # text = Ón uair, áfach, gur cuireadh an leabhar i gcló, faighimid tráchtaireacht anseo is ansiúd scríofa faoi scáth an amhrais; amhras uaireanta gan de bhunús aige ach an buille faoi thuairim.
 1	Ón	ó	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
+2	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	4	punct	_	_
 4	áfach	áfach	ADV	Gn	_	7	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	4	punct	_	_
 6	gur	gur	PART	Vb	PartType=Vb|Tense=Past	7	mark:prt	_	_
 7	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	2	acl:relcl	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	leabhar	leabhar	NOUN	Noun	Gender=Masc|Number=Sing	7	obj	_	_
+9	leabhar	leabhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
 11	gcló	cló	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -9813,11 +9813,11 @@
 2	Chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	17	parataxis	_	_
 3	siad	siad	PRON	Pers	Number=Plur|Person=3	2	nsubj	_	_
 4	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obj	_	_
+5	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obj	_	_
 6	airgid	airgead	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
 7	ballraíochta	ballraíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
 8	-	-	PUNCT	Punct	_	9	punct	_	_
-9	Euro	Euro	PROPN	Noun	Gender=Masc|Number=Sing	6	nmod	_	_
+9	Euro	Euro	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 10	50	50	NUM	Num	_	9	nummod	_	_
 11	-	-	PUNCT	Punct	_	9	punct	_	_
 12	ar	ar	ADV	Dir	_	2	advmod	_	_
@@ -9826,13 +9826,13 @@
 15	,	,	PUNCT	Punct	_	17	punct	_	SpaceAfter=No
 16	'	'	PUNCT	Punct	_	17	punct	_	_
 17	adeir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-18	Proinsias	Proinsias	PROPN	Noun	Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
+18	Proinsias	Proinsias	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
-21	Euro	Euro	PROPN	Noun	Gender=Masc|Number=Sing	9	conj	_	_
+21	Euro	Euro	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
 22	10	10	NUM	Num	_	21	nummod	_	_
 23	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	24	case	_	_
-24	chois	cos	NOUN	Noun	Case=Dat|Form=Len|Gender=Fem|Number=Sing	17	obl	_	_
+24	chois	cos	NOUN	Noun	Case=Dat|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	obl	_	_
 25	sin	sin	PRON	Dem	PronType=Dem	24	det	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	17	punct	_	_
 
@@ -9850,11 +9850,11 @@
 10	27	27	NUM	Num	_	5	nmod	_	_
 11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
-13	Phiarsaigh	Piarsach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
+13	Phiarsaigh	Piarsach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
-16	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
-17	Cliath	Cliath	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes|SpaceAfter=No
+15	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+16	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes|SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 846
@@ -9862,13 +9862,13 @@
 1	Bhainfinn	bain	VERB	VTI	Form=Len|Mood=Cnd|Number=Sing|Person=1	0	root	_	_
 2	díom	de	ADP	Prep	Number=Sing|Person=1	1	obl:prep	_	_
 3	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	4	nmod:poss	_	_
-4	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
+4	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
 5	éadaí	éadach	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	4	nmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	stróicfinn	stróic	VERB	VTI	Mood=Cnd|Number=Sing|Person=1	1	conj	_	_
 8	di	de	ADP	Prep	Gender=Fem|Number=Sing|Person=3	7	obl:prep	_	_
 9	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
-10	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obj	_	_
+10	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	obj	_	_
 11	sise	sise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	10	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	ghabhfainn	gabh	VERB	VTI	Form=Len|Mood=Cnd|Number=Sing|Person=1	1	conj	_	_
@@ -9876,7 +9876,7 @@
 15	díreach	díreach	ADJ	Adj	Degree=Pos	13	amod	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	18	nmod:poss	_	_
-18	ghlúine	glúin	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	15	obl	_	_
+18	ghlúine	glúin	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	15	obl	_	_
 19	roimpi	roimh	ADP	Prep	Gender=Fem|Number=Sing|Person=3	13	obl:prep	_	_
 20	go	go	PART	Vb	PartType=Cmpl	21	mark:prt	_	_
 21	bpógfainn	póg	VERB	VTI	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	13	ccomp	_	_
@@ -9902,7 +9902,7 @@
 10	agus	agus	CCONJ	Coord	_	15	cc	_	_
 11	ag	ag	ADP	Simp	_	13	case	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obl:tmod	_	_
+13	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obl:tmod	_	_
 14	céanna	céanna	ADJ	Adj	Degree=Pos	13	amod	_	_
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 16	ardchaighdeán	ardchaighdeán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nsubj	_	_
@@ -9943,7 +9943,7 @@
 4	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 5	beairic	beairic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	bpíléar	píléar	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	5	nmod	_	_
+7	bpíléar	píléar	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	nmod	_	_
 8	dúnta	dúnta	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	agus	agus	CCONJ	Coord	_	11	mark	_	_
@@ -9987,7 +9987,7 @@
 30	a	a	PART	Vb	PartType=Vb|PronType=Rel	31	nsubj	_	_
 31	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	24	acl:relcl	_	_
 32	sa	i	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
-33	mhéid	méid	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
+33	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
 34	a	a	PART	Vb	PartType=Vb|PronType=Rel	35	obl	_	_
 35	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	33	acl:relcl	_	_
 36	aisíoctha	aisíoctha	ADJ	Adj	VerbForm=Part	35	xcomp:pred	_	_
@@ -10024,9 +10024,9 @@
 14	mura	mura	SCONJ	Subord	_	15	mark	_	_
 15	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	1	advcl	_	_
 16	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	17	det	_	_
-17	sciarshealbhóirí	sciarshealbhóir	NOUN	Noun	Gender=Masc|Number=Plur	15	nsubj	_	_
+17	sciarshealbhóirí	sciarshealbhóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	15	nsubj	_	_
 18	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	19	case	_	_
-19	n-úinéirí	úinéir	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	15	xcomp:pred	_	_
+19	n-úinéirí	úinéir	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	15	xcomp:pred	_	_
 20	cláraithe	cláraithe	ADJ	Adj	VerbForm=Part	19	amod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10034,9 +10034,9 @@
 # text = Mhair an scéal sa bhéaloideas leis na céadta bliain agus ansin scríobhadh i lámhscríbhinní é.
 1	Mhair	mair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	bhéaloideas	béaloideas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+5	bhéaloideas	béaloideas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	leis	le	ADP	Simp	_	8	case	_	_
 7	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
 8	céadta	céad	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obl:tmod	_	_
@@ -10059,13 +10059,13 @@
 6	bheagán	beagán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	daonra	daonra	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	-	-	PUNCT	Punct	_	9	punct	_	_
-9	Inis	inis	PROPN	Noun	Gender=Fem|Number=Sing	1	parataxis	_	NamedEntity=Yes
-10	Bhigil	bigil	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
+9	Inis	inis	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	parataxis	_	NamedEntity=Yes
+10	Bhigil	bigil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	amach	amach	ADV	Dir	_	9	advmod	_	_
 12	ó	ó	ADP	Simp	_	14	case	_	_
 13	chósta	cósta	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
-14	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
-15	Eo	Eo	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
+14	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
+15	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
 18	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
@@ -10092,13 +10092,13 @@
 
 # sent_id = 857
 # text = Lú leoicéime - nó ailse san fhuil - más ansin a tógadh é, i gcomparáid le páiste i gcontae Mhaigh Eo mar shampla.
-1	Lú	lú	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Lú	lú	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	leoicéime	leoicéime	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
 3	-	-	PUNCT	Punct	_	5	punct	_	_
 4	nó	nó	CCONJ	Coord	_	5	cc	_	_
 5	ailse	ailse	NOUN	Noun	Gender=Fem|Number=Sing	1	conj	_	_
 6	san	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	fhuil	fuil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+7	fhuil	fuil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 8	-	-	PUNCT	Punct	_	10	punct	_	_
 9	más	má	SCONJ	Subord	VerbForm=Cop	10	mark	_	_
 10	ansin	ansin	ADV	Loc	_	1	parataxis	_	_
@@ -10112,8 +10112,8 @@
 18	páiste	páiste	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
 19	i	i	ADP	Simp	_	20	case	_	_
 20	gcontae	contae	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	18	nmod	_	_
-21	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
-22	Eo	Eo	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
+21	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+22	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
 23	mar	mar	ADP	Simp	_	24	case	_	_
 24	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
@@ -10173,7 +10173,7 @@
 32	d'	do	PART	Vb	PartType=Vb	33	mark:prt	_	SpaceAfter=No
 33	fhan	fan	VERB	VI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	35	det	_	_
-35	tuiscint	tuiscint	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	33	nsubj	_	_
+35	tuiscint	tuiscint	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	33	nsubj	_	_
 36	don	do	ADP	Art	Number=Sing|PronType=Art	37	case	_	_
 37	stair	stair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	33	obl	_	_
 38	beo	beo	ADJ	Adj	Gender=Fem|Number=Sing	37	amod	_	_
@@ -10194,17 +10194,17 @@
 7	bhíonn	bí	VERB	PresImp	Aspect=Hab|Form=Len|Mood=Ind|Tense=Pres	5	acl:relcl	_	_
 8	acu	ag	ADP	Prep	Number=Plur|Person=3	7	obl:prep	_	_
 9	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	case	_	_
-10	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
+10	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
 11	agus	agus	CCONJ	Coord	_	13	cc	_	_
 12	lena	le	ADP	Poss	Number=Plur|Person=3|Poss=Yes	13	case	_	_
-13	n-imshaol	imshaol	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
+13	n-imshaol	imshaol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 862
 # text = Do rith Pinocchio chuige láithreach agus siúd ag dreapadóireacht in áirde ar a chuid féasóige ar nós easóige é, is ba mhór an seó an phóg le deiseacht a thug sé dho i mbarra a shróna.
 1	Do	do	PART	Vb	PartType=Vb	2	mark:prt	_	_
 2	rith	rith	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-3	Pinocchio	Pinocchio	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+3	Pinocchio	Pinocchio	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	chuige	chuig	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
 5	láithreach	láithreach	ADV	Dir	Degree=Pos	2	advmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	mark	_	_
@@ -10215,7 +10215,7 @@
 11	áirde	áirde	NOUN	Noun	Gender=Fem|Number=Sing	9	nmod	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	nmod:poss	_	_
-14	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
+14	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 15	féasóige	féasóg	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
 16	ar	ar	ADP	Cmpd	PrepForm=Cmpd	18	case	_	_
 17	nós	nós	ADP	Cmpd	_	16	fixed	_	_
@@ -10238,7 +10238,7 @@
 34	i	i	ADP	Simp	_	35	case	_	_
 35	mbarra	barra	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
 36	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	37	nmod:poss	_	_
-37	shróna	srón	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	35	nmod	_	SpaceAfter=No
+37	shróna	srón	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 863
@@ -10273,12 +10273,12 @@
 4	mhóra	mór	ADJ	Adj	Case=NomAcc|Form=Len|Number=Plur	3	amod	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	slí	slí	NOUN	Noun	Gender=Fem|Number=Sing	1	obl	_	_
+7	slí	slí	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 8	isteach	isteach	ADV	Dir	_	1	advmod	_	_
 9	go	go	ADP	Cmpd	_	12	case	_	_
 10	dtí	dtí	ADP	Cmpd	Form=Ecl	9	fixed	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	Daingean	Daingean	PROPN	Noun	_	1	obl	_	SpaceAfter=No
+12	Daingean	Daingean	PROPN	Noun	Definite=Def	1	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	Ard	ard	NOUN	Noun	Case=NomAcc|Gender=Masc	12	conj	_	NamedEntity=Yes
 15	Leataoibh	leataobh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
@@ -10286,7 +10286,7 @@
 17	Ard	ard	NOUN	Noun	Case=NomAcc|Gender=Masc	12	conj	_	NamedEntity=Yes
 18	Bhaile	Baile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	NamedEntity=Yes
-20	nÁith	áith	NOUN	Noun	Form=Ecl	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	nÁith	áith	NOUN	Noun	Definite=Def|Form=Ecl	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 865
@@ -10312,9 +10312,9 @@
 # text = D'imigh Bríd na mBróg in am trátha freisin, súilfhéachaint siar aici ar an sagart Sandeman is dúil aici nach dtiocfadh sé as treo éigin ar a bealach chun a botháin ag cúl halla an bhaile.
 1	D'	do	PART	Vb	PartType=Vb	2	mark:prt	_	SpaceAfter=No
 2	imigh	imigh	VERB	VI	Mood=Ind|Tense=Past	0	root	_	_
-3	Bríd	Bríd	PROPN	Noun	Gender=Fem|Number=Sing	2	nsubj	_	NamedEntity=Yes
-4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	flat:name	_	NamedEntity=Yes
-5	mBróg	bróg	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	3	flat:name	_	NamedEntity=Yes
+3	Bríd	Bríd	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	NamedEntity=Yes
+4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	NamedEntity=Yes
+5	mBróg	bróg	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	3	nmod	_	NamedEntity=Yes
 6	in	i	ADP	Simp	_	2	obl:tmod	_	_
 7	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	fixed	_	_
 8	trátha	tráth	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	fixed	_	_
@@ -10326,7 +10326,7 @@
 14	ar	ar	ADP	Simp	_	16	case	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	sagart	sagart	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
-17	Sandeman	Sandeman	PROPN	Noun	Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
+17	Sandeman	Sandeman	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 18	is	agus	SCONJ	Subord	_	19	mark	_	_
 19	dúil	dúil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	advcl	_	_
 20	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	11	obl:prep	_	_
@@ -10338,10 +10338,10 @@
 26	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	25	amod	_	_
 27	ar	ar	ADP	Simp	_	29	case	_	_
 28	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
-29	bealach	bealach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	obl	_	_
+29	bealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	obl	_	_
 30	chun	chun	ADP	Simp	_	32	case	_	_
 31	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
-32	botháin	bothán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	22	obj	_	_
+32	botháin	bothán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	obj	_	_
 33	ag	ag	ADP	Simp	_	34	case	_	_
 34	cúl	cúl	NOUN	Noun	Gender=Masc|Number=Sing	22	obl	_	_
 35	halla	halla	NOUN	Noun	Gender=Masc|Number=Sing	34	nmod	_	_
@@ -10365,7 +10365,7 @@
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	ghnóthaigh	gnóthaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 14	gradam	gradam	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
-15	Grammy	Grammy	PROPN	Noun	Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+15	Grammy	Grammy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	le	le	ADP	Simp	_	17	case	_	_
 17	déanaí	déanach	ADJ	Adj	Degree=Cmp,Sup	13	obl:tmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
@@ -10382,21 +10382,21 @@
 8	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	6	acl:relcl	_	_
 9	istigh	istigh	ADV	Dir	_	8	advmod	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	ghluaisteán	gluaisteán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+11	ghluaisteán	gluaisteán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	gharáiste	garáiste	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
+13	gharáiste	garáiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	16	punct	_	_
 15	mar	mar	SCONJ	Subord	_	16	mark	_	_
 16	dhein	déan	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	2	advcl	_	_
 17	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	mháthair	máthair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	16	nsubj	_	_
+18	mháthair	máthair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	nsubj	_	_
 19	dearmad	dearmad	NOUN	Noun	Gender=Masc|Number=Sing	16	obj	_	_
 20	go	go	PART	Vb	PartType=Cmpl	21	mark:prt	_	_
 21	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	16	ccomp	_	_
 22	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	_
 23	ar	ar	ADP	Simp	_	25	case	_	_
 24	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	25	nmod:poss	_	_
-25	chúl	cúl	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
+25	chúl	cúl	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
 26	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	21	obl:prep	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -10406,13 +10406,13 @@
 2	cheannaigh	ceannaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
+5	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obj	_	SpaceAfter=No
 6	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 870
 # text = Fuair Tuathal dhá sheol úra, agus maidin amháin d'imigh sé féin agus a thriúr mac amach a dh'iascaireacht.
 1	Fuair	faigh	VERB	VT	Mood=Ind|Tense=Past	0	root	_	_
-2	Tuathal	Tuathal	PROPN	Noun	_	1	nsubj	_	_
+2	Tuathal	Tuathal	PROPN	Noun	Definite=Def	1	nsubj	_	_
 3	dhá	dó	NUM	Num	Form=Len	4	nummod	_	_
 4	sheol	seol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obj	_	_
 5	úra	úr	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	4	amod	_	SpaceAfter=No
@@ -10426,12 +10426,12 @@
 13	féin	féin	PRON	Ref	_	12	nmod	_	_
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	a	a	DET	Det	Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	thriúr	triúr	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	12	conj	_	_
+16	thriúr	triúr	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	conj	_	_
 17	mac	mac	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	16	nmod	_	_
 18	amach	amach	ADV	Dir	_	11	advmod	_	_
 19	a	a	PART	Inf	_	20	mark:prt	_	_
 20	dh'	do	DET	Det	Form=Len|Number=Sing|Person=2|Poss=Yes	21	nmod:poss	_	SpaceAfter=No
-21	iascaireacht	iascaireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	xcomp	_	SpaceAfter=No
+21	iascaireacht	iascaireacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	11	xcomp	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 871
@@ -10453,19 +10453,19 @@
 15	in	i	ADP	Simp	_	18	case	_	_
 16	éindí	éindí	NOUN	Subst	Case=NomAcc|Number=Sing	15	fixed	_	_
 17	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	case	_	_
-18	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+18	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 19	nó	nó	CCONJ	Coord	_	20	cc	_	_
 20	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	18	conj	_	_
 21	pósta	pósta	ADJ	Adj	VerbForm=Part	20	xcomp:pred	_	_
 22	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
-23	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
+23	chéile	céile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	obl	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 872
 # text = Cath Bhéal Átha na Muice Bhí duine de mhuintir Uí Chorrabháin, an Muilteoir Rua, ar na mílte a d'fhulaing an díbirt a rinneadh ar chaitlicigh Ard Macha idir 1780 agus 1795.
 1	Cath	cath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-2	Bhéal	PROPN	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-3	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
+2	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+3	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
 5	Muice	muc	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 6	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
@@ -10473,26 +10473,26 @@
 8	de	de	ADP	Simp	_	9	case	_	_
 9	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 10	Uí	uí	PART	Pat	PartType=Pat	9	flat:name	_	NamedEntity=Yes
-11	Chorrabháin	Chorrabháin	PROPN	Noun	Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+11	Chorrabháin	Chorrabháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	Muilteoir	muilteoir	NOUN	Noun	Gender=Masc|Number=Sing	9	appos	_	_
+14	Muilteoir	muilteoir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	appos	_	_
 15	Rua	Rua	ADJ	Adj	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	19	punct	_	_
 17	ar	ar	ADP	Simp	_	19	case	_	_
 18	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	19	det	_	_
-19	mílte	míle	NOUN	Noun	Gender=Masc|Number=Plur	6	obl	_	_
+19	mílte	míle	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	6	obl	_	_
 20	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	nsubj	_	_
 21	d'	do	PART	Vb	PartType=Vb	22	mark:prt	_	SpaceAfter=No
 22	fhulaing	fulaing	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	19	acl:relcl	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	díbirt	díbirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	22	obj	_	_
+24	díbirt	díbirt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	22	obj	_	_
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	obj	_	_
 26	rinneadh	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Past	24	acl:relcl	_	_
 27	ar	ar	ADP	Simp	_	28	case	_	_
 28	chaitlicigh	caitliceach	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	26	obl	_	_
 29	Ard	ard	NOUN	Noun	Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
-30	Macha	Macha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	29	nmod	_	NamedEntity=Yes
+30	Macha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	29	nmod	_	NamedEntity=Yes
 31	idir	idir	ADP	Simp	_	32	case	_	_
 32	1780	1780	NUM	Num	_	26	obl:tmod	_	_
 33	agus	agus	CCONJ	Coord	_	34	cc	_	_
@@ -10502,7 +10502,7 @@
 # sent_id = 873
 # text = Sa deireadh, smaointigh sé gurbh é a b'fhearr a dtiocfadh leis a dhéanamh cupla béic chreathnaitheach a ligean as a tharraingeodh air bunadh an tí agus, nuair a d'fhosclófaí an doras, go dtiocfadh leis éaló amach sula bhfaighfí greim air.
 1	Sa	i	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
+2	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	2	punct	_	_
 4	smaointigh	smaointigh	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
 5	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
@@ -10578,10 +10578,10 @@
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	mark	_	_
 27	thrasnaíonn	trasnaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	4	xcomp	_	_
 28	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
-29	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	27	obj	_	_
+29	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	obj	_	_
 30	agus	agus	CCONJ	Coord	_	34	cc	_	_
 31	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	32	nmod:poss	_	_
-32	n-uillinneacha	uillinn	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Plur	34	obj	_	_
+32	n-uillinneacha	uillinn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	34	obj	_	_
 33	a	a	PART	Inf	PartType=Inf	34	mark	_	_
 34	tharraingt	tarraingt	NOUN	Noun	Form=Len|VerbForm=Inf	27	conj	_	_
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
@@ -10604,21 +10604,21 @@
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	2	obj	_	_
 6	dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	2	acl:relcl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	tIndiach	Indiach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
+8	tIndiach	Indiach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Iosánach	Íosánach	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	6	obl	_	_
+11	Iosánach	Íosánach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	6	obl	_	_
 12	ansin	ansin	ADV	Loc	_	6	advmod	_	SpaceAfter=No
 13	:	:	PUNCT	Punct	_	15	punct	_	_
 14	'	'	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
 15	Níl	bí	VERB	PresInd	Mood=Ind|Polarity=Neg|Tense=Pres	2	parataxis	_	_
 16	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	17	det	_	_
-17	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	15	nsubj	_	_
+17	fhios	fios	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	nsubj	_	_
 18	agat	ag	ADP	Prep	Number=Sing|Person=2	15	obl:prep	_	_
 19	cad	cad	PRON	Q	PronType=Int	20	obj	_	_
 20	tá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	15	ccomp	_	_
 21	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	22	case	_	_
-22	rá	rá	NOUN	Noun	VerbForm=Inf	20	xcomp	_	_
+22	rá	rá	NOUN	Noun	Definite=Def|VerbForm=Inf	20	xcomp	_	_
 23	agat	ag	ADP	Prep	Number=Sing|Person=2	20	obl:prep	_	SpaceAfter=No
 24	;	;	PUNCT	Punct	_	25	punct	_	_
 25	foghlaim	foghlaim	VERB	VTI	Mood=Imp|Number=Sing|Person=2	15	parataxis	_	_
@@ -10634,8 +10634,8 @@
 1	Deirtear	abair	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	3	cop	_	_
 3	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nmod	_	_
-4	Francesco	Francesco	PROPN	Noun	Gender=Masc|Number=Sing	1	ccomp	_	NamedEntity=Yes
-5	Petrarca	Petrarca	PROPN	Noun	Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+4	Francesco	Francesco	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	ccomp	_	NamedEntity=Yes
+5	Petrarca	Petrarca	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 6	(	(	PUNCT	Punct	_	7	punct	_	SpaceAfter=No
 7	1304-	1304-	NUM	Num	_	4	nmod	_	SpaceAfter=No
 8	'	'	PUNCT	Punct	_	9	punct	_	SpaceAfter=No
@@ -10663,9 +10663,9 @@
 6	i	i	ADP	Simp	_	7	case	_	_
 7	bPáirc	páirc	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	1	ccomp	_	NamedEntity=Yes
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	NamedEntity=Yes
-9	Chrócaigh	Crócach	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
-10	Dé	Dé	PROPN	Subst	_	7	obl:tmod	_	NamedEntity=Yes
-11	Sathairn	Satharn	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+9	Chrócaigh	Crócach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+10	Dé	Dé	PROPN	Subst	Definite=Def	7	obl:tmod	_	NamedEntity=Yes
+11	Sathairn	Satharn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	a	a	PART	Nm	_	14	mark:prt	_	_
 14	4.30	4.30	NUM	Num	_	7	nmod	_	SpaceAfter=No
@@ -10685,9 +10685,9 @@
 10	a	a	PART	Inf	PartType=Inf	11	mark:prt	_	_
 11	dhul	dul	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
 12	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
-13	Chondae	Chondae	PROPN	Noun	Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+13	Chondae	contae	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	NamedEntity=Yes
-15	Chláir	Clár	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
+15	Chláir	Clár	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	...	...	PUNCT	...	_	3	punct	_	_
 
 # sent_id = 879
@@ -10700,19 +10700,19 @@
 6	chuici	chuig	ADP	Prep	Gender=Fem|Number=Sing|Person=3	2	obl:prep	_	_
 7	aníos	aníos	ADV	Dir	_	2	advmod	_	_
 8	ón	ó	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	seomra	seomra	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
+9	seomra	seomra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 880
 # text = Tá Seáinín ina aonar i gclós mhuintir Bhraonáin - níl de chompánach aige ach cearc mhór mhuintir Bhraonáin.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	Seáinín	Seáinín	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Seáinín	Seáinín	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	aonar	aonar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+4	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
 6	gclós	clós	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
-8	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	7	nmod	_	_
+8	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	nmod	_	_
 9	-	-	PUNCT	Punct	_	10	punct	_	_
 10	níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
@@ -10722,7 +10722,7 @@
 15	cearc	cearc	NOUN	Noun	Gender=Fem|Number=Sing	10	nsubj	_	_
 16	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	amod	_	_
 17	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	_
-18	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
+18	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 881
@@ -10765,7 +10765,7 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	suí	suí	NOUN	Noun	Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+4	suí	suí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	fhiacail	fiacail	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
@@ -10797,7 +10797,7 @@
 
 # sent_id = 884
 # text = Glas a bhíonn na caora ar dtús.
-1	Glas	Glas	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Glas	glas	ADJ	Adj	Degree=Pos	0	root	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	bhíonn	bí	VERB	PresImp	Aspect=Hab|Form=Len|Mood=Ind|Tense=Pres	1	csubj:cleft	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
@@ -10816,21 +10816,21 @@
 6	,	,	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 7	'	'	PUNCT	Punct	_	3	punct	_	_
 8	arsa	arsa	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
-9	Pádraig	Pádraig	PROPN	Noun	Gender=Masc|Number=Sing	8	nsubj	_	_
+9	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
 11	féachaint	féachaint	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	xcomp	_	_
 12	go	go	PART	Ad	PartType=Ad	13	mark:prt	_	_
 13	tuisceanach	tuisceanach	ADJ	Adj	Degree=Pos	11	advmod	_	_
 14	ar	ar	ADP	Simp	_	15	case	_	_
-15	Neans	Neans	PROPN	Noun	Gender=Fem|Number=Sing	11	obl	_	_
+15	Neans	Neans	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	11	obl	_	_
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
-17	Treasa	Treasa	PROPN	Noun	Gender=Fem|Number=Sing	15	conj	_	SpaceAfter=No
+17	Treasa	Treasa	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	15	conj	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 886
 # text = An plúr dubh.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	plúr	plúr	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+2	plúr	plúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	dubh	dubh	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -10840,7 +10840,7 @@
 2	léi	le	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	_
 3	ag	ag	ADP	Simp	_	5	case	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	cheiliúradh	ceiliúradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	_
+5	cheiliúradh	ceiliúradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	_
 6	75	75	NUM	Num	_	7	nummod	_	_
 7	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	1	punct	_	_
@@ -10852,30 +10852,30 @@
 14	:	:	PUNCT	Punct	_	16	punct	_	_
 15	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Dr.	dochtúir	NOUN	Abr	Abbr=Yes	9	parataxis	_	NamedEntity=Yes
-17	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
+17	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 18	Mac	mac	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
-19	Giolla	Giolla	PROPN	Noun	Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
-20	Riabhaigh	Riabhaigh	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Giolla	Giolla	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
+20	Riabhaigh	Riabhaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
 22	Easpag	easpag	NOUN	Noun	Gender=Masc|Number=Sing	16	conj	_	_
-23	Dhroim	droim	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
+23	Dhroim	droim	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 24	Mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	amod	_	NamedEntity=Yes|SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
 26	Ardeaspag	ardeaspag	NOUN	Noun	Gender=Masc|Number=Sing	16	conj	_	_
-27	Ard	Ard	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
-28	Mhacha	Mhacha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
+27	Ard	Ard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
+28	Mhacha	Mhacha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	Dr	dochtúir	NOUN	Abr	Abbr=Yes	16	conj	_	NamedEntity=Yes
-32	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	flat:name	_	NamedEntity=Yes
+32	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	flat:name	_	NamedEntity=Yes
 33	Ó	ó	PART	Pat	PartType=Pat	32	flat:name	_	NamedEntity=Yes
-34	Brádaigh	Brádaigh	PROPN	Noun	Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
+34	Brádaigh	Brádaigh	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
 37	tAthair	athair	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
-38	Tomás	Tomás	PROPN	Noun	Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
+38	Tomás	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
 39	Mac	mac	PART	Pat	PartType=Pat	37	flat:name	_	NamedEntity=Yes
-40	Parthaláin	Parthaláin	PROPN	Noun	Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+40	Parthaláin	Parthaláin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 41	,	,	PUNCT	Punct	_	43	punct	_	_
 42	a	a	PART	Vb	PartType=Vb|PronType=Rel	43	nsubj	_	_
 43	léigh	léigh	VERB	VTI	Mood=Ind|Tense=Past	37	acl:relcl	_	_
@@ -10913,22 +10913,22 @@
 
 # sent_id = 890
 # text = Baile beag iascaireachta a bhí i Riasg Buidhe ar an chósta taobh ó thuaidh de Sgalasaig a tréigeadh ag deireadh an Chéad Chogaidh Dhomhanda.
-1	Baile	Baile	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	beag	beag	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	iascaireachta	iascaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	nsubj	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	acl:relcl	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	Riasg	Riasg	PROPN	Noun	Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
-8	Buidhe	Buidhe	PROPN	Noun	Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Riasg	Riasg	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
+8	Buidhe	Buidhe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	chósta	cósta	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+11	chósta	cósta	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 12	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
 13	ó	ó	ADP	Simp	_	14	case	_	_
 14	thuaidh	thuaidh	ADV	Dir	_	11	advmod	_	_
 15	de	de	ADP	Simp	_	16	case	_	_
-16	Sgalasaig	Sgalasaig	PROPN	Noun	Gender=Masc|Number=Sing	5	obl	_	_
+16	Sgalasaig	Sgalasaig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	obj	_	_
 18	tréigeadh	tréig	VERB	VTI	Mood=Ind|Person=0|Tense=Past	7	acl:relcl	_	_
 19	ag	ag	ADP	Simp	_	20	case	_	_
@@ -10942,17 +10942,17 @@
 # sent_id = 891
 # text = Chaith Alan a chloigeann san aer agus rinne gáire faoina ndúirt Learaí leis.
 1	Chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Alan	Alan	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Alan	Alan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obj	_	_
+4	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obj	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	aer	aer	NOUN	Noun	Gender=Masc|Number=Plur	1	obl	_	_
+6	aer	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
 9	gáire	gáire	NOUN	Noun	Gender=Masc|Number=Sing	8	obj	_	_
 10	faoina	faoi	PART	Rel	PronType=Rel	8	obl	_	_
 11	ndúirt	abair	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	8	acl:relcl	_	_
-12	Learaí	Learaí	PROPN	Noun	Gender=Masc|Number=Sing	11	nsubj	_	_
+12	Learaí	Learaí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 13	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	11	obl:prep	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10964,7 +10964,7 @@
 4	t-am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	do	do	ADP	Simp	_	7	case	_	SpaceAfter=No
 6	'n	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	phréamh	préamh	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
+7	phréamh	préamh	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
 8	féin	féin	PRON	Ref	Reflex=Yes	7	nmod	_	_
 9	nuair	nuair	SCONJ	Subord	_	11	mark	_	_
 10	ná	nach	PART	Vb	PartType=Cmpl|Polarity=Neg	11	mark:prt	_	_
@@ -10995,7 +10995,7 @@
 2	Chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	parataxis	_	_
 3	mé	mé	PRON	Pers	Number=Sing|Person=1	2	nsubj	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	iomad	iomad	NOUN	Subst	Case=NomAcc|Number=Sing	2	obj	_	_
+5	iomad	iomad	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	2	obj	_	_
 6	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	case	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 8	'	'	PUNCT	Punct	_	2	punct	_	_
@@ -11023,37 +11023,37 @@
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	parataxis	_	_
 16	Muintir	muintir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nsubj	_	NamedEntity=Yes
 17	Uí	uí	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
-18	Dhrisceoil	Drisceoil	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
+18	Dhrisceoil	Drisceoil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	as	as	ADP	Simp	_	20	case	_	_
 20	Béal	béal	NOUN	Noun	Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
-21	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	NamedEntity=Yes
-23	Ghaorthaigh	Gaorthach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
+23	Ghaorthaigh	Gaorthach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
-25	Tammy	Tammy	PROPN	Noun	Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
+25	Tammy	Tammy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
 26	Ní	ní	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
-27	Laoire	Laoire	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+27	Laoire	Laoire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	tuairisceoir	tuairisceoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	appos	_	_
 30	nuachta	nuacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	29	nmod	_	_
 31	TG4	TG4	PROPN	Abr	Abbr=Yes	30	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
-33	Áine	Áine	PROPN	Noun	Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
+33	Áine	Áine	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
 34	Ní	ní	PART	Pat	PartType=Pat	33	flat:name	_	NamedEntity=Yes
-35	Shé	Sé	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	33	flat:name	_	NamedEntity=Yes
+35	Shé	Sé	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	33	flat:name	_	NamedEntity=Yes
 36	as	as	ADP	Simp	_	37	case	_	_
-37	Dún	dún	PROPN	Noun	Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
-38	Chaoin	Caoin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	37	nmod	_	NamedEntity=Yes|SpaceAfter=No
+37	Dún	dún	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
+38	Chaoin	Caoin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	37	nmod	_	NamedEntity=Yes|SpaceAfter=No
 39	,	,	PUNCT	Punct	_	41	punct	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
 41	t-amhránaí	amhránaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
-42	Áine	Áine	PROPN	Noun	Gender=Fem|Number=Sing	41	appos	_	NamedEntity=Yes
+42	Áine	Áine	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	41	appos	_	NamedEntity=Yes
 43	Uí	uí	PART	Pat	PartType=Pat	42	flat:name	_	NamedEntity=Yes
-44	Laoithe	Laoithe	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	42	flat:name	_	NamedEntity=Yes
+44	Laoithe	Laoithe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	42	flat:name	_	NamedEntity=Yes
 45	agus	agus	CCONJ	Coord	_	46	cc	_	_
-46	Máire	Máire	PROPN	Noun	Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
+46	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
 47	Ní	ní	PART	Pat	PartType=Pat	46	flat:name	_	NamedEntity=Yes
-48	Chéilleachair	Céilleachar	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	46	flat:name	_	NamedEntity=Yes
+48	Chéilleachair	Céilleachar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	flat:name	_	NamedEntity=Yes
 49	as	as	ADP	Simp	_	50	case	_	_
 50	Raidió	raidió	NOUN	Noun	Gender=Masc|Number=Sing	46	nmod	_	NamedEntity=Yes
 51	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	52	det	_	_
@@ -11063,9 +11063,9 @@
 # sent_id = 896
 # text = Bhí Mick ina shuí romhainn fós nuair a chuamar isteach agus d'insíomar an scéal dó.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Mick	Mick	PROPN	Noun	Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Mick	Mick	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	shuí	suí	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp:pred	_	_
+4	shuí	suí	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	1	xcomp:pred	_	_
 5	romhainn	roimh	ADP	Prep	Number=Plur|Person=1	4	obl:prep	_	_
 6	fós	fós	ADV	Gn	_	4	advmod	_	_
 7	nuair	nuair	SCONJ	Subord	_	9	mark	_	_
@@ -11082,11 +11082,11 @@
 
 # sent_id = 897
 # text = Ó Riain faoi ina leabhar The Pope's Green Island: Nó mar a dúirt Beairtlín, buachaill aimsire Liam Bhid, fear an bhearna mhíl a luaitear i dteideal an scéil agus a mbíodh Nóra ag suirí go soineanta leis: Ná bíodh cumha ar bith ort.
-1	Ó	ó	PROPN	Noun	PartType=Pat	0	root	_	NamedEntity=Yes
-2	Riain	Riain	PROPN	Noun	Gender=Masc|Number=Sing	1	flat:name	_	NamedEntity=Yes
+1	Ó	ó	PROPN	Noun	Definite=Def|PartType=Pat	0	root	_	NamedEntity=Yes
+2	Riain	Riain	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	flat:name	_	NamedEntity=Yes
 3	faoi	faoi	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	case	_	_
 4	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	case	_	_
-5	leabhar	leabhar	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+5	leabhar	leabhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 6	The	the	X	_	Foreign=Yes	5	appos	_	_
 7	Pope's	Pope's	X	_	Foreign=Yes	6	flat:foreign	_	_
 8	Green	Green	X	_	Foreign=Yes	6	flat:foreign	_	_
@@ -11096,27 +11096,27 @@
 12	mar	mar	SCONJ	Subord	_	14	mark	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
 14	dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	1	parataxis	_	_
-15	Beairtlín	Beairtlín	PROPN	Noun	Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
+15	Beairtlín	Beairtlín	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	buachaill	buachaill	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	conj	_	_
 18	aimsire	aimsir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	compound	_	_
-19	Liam	Liam	PROPN	Noun	Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
-20	Bhid	Bhid	PROPN	Noun	Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Liam	Liam	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
+20	Bhid	Bhid	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
 22	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	17	appos	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	bhearna	bearna	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	22	nmod	_	_
+24	bhearna	bearna	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	22	nmod	_	_
 25	mhíl	míol	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	compound	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	obj	_	_
 27	luaitear	luaigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	22	acl:relcl	_	_
 28	i	i	ADP	Simp	_	29	case	_	_
 29	dteideal	teideal	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
-31	scéil	scéal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	_
+31	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
 33	a	a	PART	Vb	PartType=Vb|PronType=Rel	34	mark:prt	_	_
 34	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	27	conj	_	_
-35	Nóra	Nóra	PROPN	Noun	Gender=Fem|Number=Sing	34	nsubj	_	_
+35	Nóra	Nóra	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	34	nsubj	_	_
 36	ag	ag	ADP	Simp	_	37	case	_	_
 37	suirí	suirí	NOUN	Noun	Gender=Fem|Number=Sing	34	xcomp:pred	_	_
 38	go	go	PART	Ad	PartType=Ad	39	mark:prt	_	_
@@ -11146,13 +11146,13 @@
 11	,	,	PUNCT	Punct	_	9	punct	_	_
 12	'	'	PUNCT	Punct	_	9	punct	_	SpaceAfter=No
 13	a	a	PART	Voc	PartType=Voc	14	case:voc	_	_
-14	ridire	ridire	NOUN	Noun	Case=Voc|Gender=Masc|Number=Sing	9	vocative	_	_
+14	ridire	ridire	NOUN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	9	vocative	_	_
 15	uasail	uasal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	_
 16	fháin	fán	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	20	punct	_	_
 18	gan	gan	ADP	Simp	_	20	case	_	_
 19	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	20	nmod:poss	_	_
-20	gheallúint	geallúint	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
+20	gheallúint	geallúint	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
 21	i	i	ADP	Simp	_	22	case	_	_
 22	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -11167,7 +11167,7 @@
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 2	cáca	cáca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	_
 3	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	case	_	_
-4	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp:pred	_	_
+4	dhéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	1	xcomp:pred	_	_
 5	agam	ag	ADP	Prep	Number=Sing|Person=1	4	obl:prep	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -11186,14 +11186,14 @@
 11	-	-	PUNCT	Punct	_	14	punct	_	_
 12	agus	agus	SCONJ	Coord	_	14	mark	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	oiread	oiread	NOUN	Subst	Number=Sing	27	advcl	_	_
+14	oiread	oiread	NOUN	Subst	Definite=Def|Number=Sing	27	advcl	_	_
 15	sin	sin	DET	Det	PronType=Dem	14	det	_	_
 16	amhrais	amhras	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
 18	infheisteoirí	infheisteoir	NOUN	Noun	Gender=Masc|Number=Plur	16	nmod	_	_
 19	móra	mór	ADJ	Adj	NounType=NotSlender|Number=Plur	18	amod	_	_
 20	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
-21	gcomhnascadh	comhnascadh	NOUN	Noun	Form=Ecl|VerbForm=Inf	16	nmod	_	_
+21	gcomhnascadh	comhnascadh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	16	nmod	_	_
 22	ón	ó	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	24	amod	_	_
 24	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl:tmod	_	SpaceAfter=No
@@ -11201,7 +11201,7 @@
 26	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	27	cop	_	_
 27	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	parataxis	_	_
 28	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
-29	bharúil	barúil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	27	nsubj	_	_
+29	bharúil	barúil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	27	nsubj	_	_
 30	féin	féin	PRON	Ref	Reflex=Yes	29	nmod	_	_
 31	go	go	PART	Vb	PartType=Cmpl	32	mark:prt	_	_
 32	dtiocfadh	tar	VERB	VI	Form=Ecl|Mood=Cnd	27	ccomp	_	_
@@ -11210,17 +11210,17 @@
 35	luach	luach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	obl	_	_
 36	ar	ar	ADP	Simp	_	38	case	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
-38	scaranna	scair	NOUN	Noun	Gender=Fem|Number=Plur	32	obl	_	_
+38	scaranna	scair	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	32	obl	_	_
 39	a	a	PART	Vb	PartType=Vb|PronType=Rel	40	nsubj	_	_
 40	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	38	acl:relcl	_	_
 41	ag	ag	ADP	Simp	_	42	case	_	_
-42	Ruairí	Ruairí	PROPN	Noun	Gender=Masc|Number=Sing	40	obj	_	_
+42	Ruairí	Ruairí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	40	obj	_	_
 43	sa	i	ADP	Art	Number=Sing|PronType=Art	44	case	_	_
-44	Bhainc	banc	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
+44	Bhainc	banc	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
 45	de	de	ADP	Simp	_	46	case	_	_
 46	los	los	NOUN	Noun	Gender=Masc|Number=Sing	40	obl	_	_
 47	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	48	nmod:poss	_	_
-48	bhfaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
+48	bhfaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	;	;	PUNCT	Punct	_	50	punct	_	_
 50	ardú	ardú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	parataxis	_	_
 51	gearrthréimhseach	gearrthréimhseach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	50	amod	_	_
@@ -11232,15 +11232,15 @@
 # sent_id = 901
 # text = Rugadh Harold Alexander de shliocht plandóra i Londain sa bhliain 1891.
 1	Rugadh	beir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
-2	Harold	Harold	PROPN	Noun	Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
-3	Alexander	Alexander	PROPN	Noun	Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+2	Harold	Harold	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
+3	Alexander	Alexander	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	de	de	ADP	Simp	_	5	case	_	_
 5	shliocht	sliocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	plandóra	plandóir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	Londain	Londain	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+8	Londain	Londain	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 9	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+10	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 11	1891	1891	NUM	Num	_	10	nmod	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -11258,14 +11258,14 @@
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
 11	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	4	conj	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	chistin	cistin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	nsubj	_	SpaceAfter=No
+13	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nsubj	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	ceartlár	ceartlár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	_
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	cruinne	cruinne	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
 19	faoina	faoi	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	20	case	_	_
-20	cúram	cúram	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
+20	cúram	cúram	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 903
@@ -11303,10 +11303,10 @@
 2	tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 4	chéad	céad	NUM	Num	Form=Len|NumType=Ord	5	amod	_	_
-5	léaró	léaró	NOUN	Noun	Gender=Masc|Number=Sing	2	nsubj	_	_
+5	léaró	léaró	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 6	dóchais	dóchas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
 7	san	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	fhocal	focal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+8	fhocal	focal	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 9	sin	sin	DET	Det	PronType=Dem	8	det	_	_
 10	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
 11	bán	bán	NOUN	Noun	Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
@@ -11314,7 +11314,7 @@
 13	le	le	ADP	Cmpd	PrepForm=Cmpd	16	case	_	_
 14	cois	cois	ADP	Cmpd	PrepForm=Cmpd	13	fixed	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	heaspa	easpa	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	2	obl	_	_
+16	heaspa	easpa	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	obl	_	_
 17	róléire	róléir	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	_	_
 

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -25,7 +25,7 @@
 23	gné	gné	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	appos	_	_
 24	am-tábhachtach	an-tábhachtach	ADJ	Adj	Typo=Yes	23	amod	_	_
 25	de	de	ADP	Simp	_	26	case	_	_
-26	shaol	saol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+26	shaol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	sóisialta	sóisialta	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	26	amod	_	_
 28	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
 29	ndaoine	duine	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	26	nmod	_	SpaceAfter=No
@@ -119,7 +119,7 @@
 46	cúpla	cúpla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	34	obl:tmod	_	_
 47	nóiméad	nóiméad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	46	nmod	_	_
 48	roimh	roimh	ADP	Simp	_	49	case	_	_
-49	teacht	teacht	NOUN	Noun	VerbForm=Inf	46	nmod	_	_
+49	teacht	teacht	NOUN	Noun	Definite=Def|VerbForm=Inf	46	nmod	_	_
 50	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	51	det	_	_
 51	traenach	traein	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	49	nmod	_	_
 52	chun	chun	ADP	Simp	_	54	case	_	_
@@ -131,26 +131,26 @@
 # text = Foireann: Robert de Niro, Kenneth Branagh, Tom Hulce, Helena Bonham-Carter, John Cleese, Ian Holm, Robert Hardy.
 1	Foireann	foireann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	3	punct	_	_
-3	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+3	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	appos	_	NamedEntity=Yes
 4	de	de	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
 5	Niro	Niro	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+7	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 8	Branagh	Branagh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
-10	Tom	Tom	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+10	Tom	Tom	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 11	Hulce	Hulce	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
-13	Helena	Helena	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+13	Helena	Helena	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 14	Bonham-Carter	Bonham-Carter	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
-16	John	John	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+16	John	John	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 17	Cleese	Cleese	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Ian	Ian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+19	Ian	Ian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 20	Holm	Holm	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+22	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	list	_	NamedEntity=Yes
 23	Hardy	Hardy	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -165,7 +165,7 @@
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	nsubj	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	6	acl:relcl	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
-10	údaráis	údarás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	8	obl	_	_
+10	údaráis	údarás	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	8	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	scoile	scoil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
 13	brú	brú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
@@ -323,7 +323,7 @@
 1	Uaisle	uasal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
 2	saibhre	saibhir	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	1	amod	_	_
 3	de	de	ADP	Simp	_	4	case	_	_
-4	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	nmod	_	_
+4	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
 6	Róimhe	Róimh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	nsubj	_	_
@@ -588,9 +588,9 @@
 12	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	13	cop	_	_
 13	anseo	anseo	ADV	Loc	_	9	ccomp	_	_
 14	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	13	csubj:cleft	_	_
-15	croí	croí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
+15	croí	croí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
-17	meanma	meanma	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	conj	_	_
+17	meanma	meanma	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	conj	_	_
 18	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	19	nmod:poss	_	_
 19	sárghluaiseachta	sárghluaiseacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	15	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
@@ -682,7 +682,7 @@
 19	de	de	ADP	Simp	_	20	case	_	_
 20	dhearmad	dearmad	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	le	le	ADP	Simp	_	22	case	_	_
-22	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
+22	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	Cúirte	cúirt	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	NamedEntity=Yes
 25	Breithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -696,7 +696,7 @@
 33	sheoladh	seoladh	NOUN	Noun	Form=Len|VerbForm=Inf	27	xcomp	_	_
 34	láithreach	láithreach	ADJ	Adj	Degree=Pos	33	advmod	_	_
 35	chuig	chuig	ADP	Simp	_	36	case	_	_
-36	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	obl	_	NamedEntity=Yes
+36	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	NamedEntity=Yes
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	NamedEntity=Yes
 38	Cúirte	cúirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	36	nmod	_	NamedEntity=Yes
 39	Céadchéime	céadchéim	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	38	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -724,7 +724,7 @@
 61	de	de	ADP	Simp	_	62	case	_	_
 62	dhearmad	dearmad	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	60	nmod	_	_
 63	le	le	ADP	Simp	_	64	case	_	_
-64	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	60	nmod	_	NamedEntity=Yes
+64	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	60	nmod	_	NamedEntity=Yes
 65	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	66	det	_	NamedEntity=Yes
 66	Cúirte	cúirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	64	nmod	_	NamedEntity=Yes
 67	Céadchéime	céadchéim	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	66	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -738,7 +738,7 @@
 75	sheoladh	seoladh	NOUN	Noun	Form=Len|VerbForm=Inf	69	xcomp	_	_
 76	láithreach	láithreach	ADJ	Adj	Degree=Pos	75	advmod	_	_
 77	chuig	chuig	ADP	Simp	_	78	case	_	_
-78	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	75	obl	_	NamedEntity=Yes
+78	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	75	obl	_	NamedEntity=Yes
 79	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	80	det	_	NamedEntity=Yes
 80	Cúirte	cúirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	78	nmod	_	NamedEntity=Yes
 81	Breithiúnais	breithiúnas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	80	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -934,7 +934,7 @@
 3	de	de	ADP	Simp	_	4	case	_	_
 4	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obl:tmod	_	_
 5	o	ó	ADP	Simp	_	6	case	_	_
-6	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	_
+6	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	rithte	rithte	ADJ	Adj	VerbForm=Part	6	amod	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	Achta	acht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -962,7 +962,7 @@
 14	Ó	ó	PART	Pat	PartType=Pat	13	flat:name	_	NamedEntity=Yes
 15	Gallchóir	Gallchóir	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
-17	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	_
+17	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	appos	_	_
 18	Ginearálta	ginearálta	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	17	amod	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	Fhorais	foras	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
@@ -1006,7 +1006,7 @@
 7	,	,	PUNCT	Punct	_	3	punct	_	_
 8	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	10	cop	_	_
 9	trí	trí	ADP	Simp	_	10	case	_	_
-10	mheán	meán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+10	mheán	meán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	Bhéarla	Béarla	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	nmod	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
@@ -1051,7 +1051,7 @@
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	NamedEntity=Yes
 21	bPoc	poc	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
-23	Contae	contae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+23	Contae	contae	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 24	Chiarraí	Chiarraí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes|SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1248,7 +1248,7 @@
 30	maithe	maith	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	29	amod	_	_
 31	eile	eile	DET	Det	PronType=Dem	29	det	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
-33	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	appos	_	_
+33	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	appos	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
 35	18ú	18	NUM	Num	NumType=Ord	36	amod	_	_
 36	céad	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
@@ -1345,7 +1345,7 @@
 10	ar	ar	ADP	Cmpd	PrepForm=Cmpd	13	case	_	_
 11	feadh	feadh	ADP	Cmpd	_	10	fixed	_	_
 12	leath	leath	DET	Det	_	13	det	_	_
-13	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obl	_	_
+13	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obl	_	_
 14	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	chloig	clog	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
 16	nuair	nuair	SCONJ	Subord	_	18	mark	_	_
@@ -1361,12 +1361,12 @@
 2	slad	slad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
 4	bhuíon	buíon	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
-5	de	de	ADP	Simp	_	8	case	_	_
-6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
-7	Sherwood	Sherwood	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-8	Foresters	Foresters	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+5	de	de	ADP	Simp	_	7	case	_	_
+6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
+7	Sherwood	Sherwood	X	Foreign	Foreign=Yes	4	nmod	_	NamedEntity=Yes
+8	Foresters	Foresters	X	Foreign	Foreign=Yes	7	flat:foreign	_	NamedEntity=Yes
 9	ag	ag	ADP	Simp	_	10	case	_	_
-10	droichead	droichead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+10	droichead	droichead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 11	Shráid	sráid	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	Mhóta	Móta	PROPN	Noun	Definite=Def|Form=Len	11	nmod	_	NamedEntity=Yes
@@ -1380,7 +1380,7 @@
 21	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	17	xcomp	_	_
 22	isteach	isteach	ADV	Dir	_	21	advmod	_	_
 23	go	go	ADP	Simp	_	24	case	_	_
-24	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nmod	_	_
+24	lár	lár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
 25	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
 26	cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	24	nmod	_	_
 27	ó	ó	ADP	Simp	_	28	case	_	_
@@ -1547,7 +1547,7 @@
 17	Cille	cill	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
 19	de	de	ADP	Simp	_	20	case	_	_
-20	scríobh	scríobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl	_	_
+20	scríobh	scríobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	_
 21	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
 22	altrach	altrach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	25	punct	_	_
@@ -1565,7 +1565,7 @@
 35	óir	óir	SCONJ	Subord	_	37	mark	_	_
 36	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	37	advmod	_	_
 37	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Polarity=Neg|Tense=Fut	1	advcl	_	_
-38	uireasa	uireasa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	37	nsubj	_	_
+38	uireasa	uireasa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	37	nsubj	_	_
 39	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	41	det	_	_
 40	n-uile	uile	DET	Det	Form=Ecl|PronType=Ind	41	det	_	_
 41	maitheas	maitheas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	38	nmod	_	_
@@ -1581,7 +1581,7 @@
 # sent_id = 65
 # text = I nDáil na bhFlaitheas go raibh sé.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	nDáil	dáil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	0	root	_	_
+2	nDáil	dáil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	0	root	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	bhFlaitheas	flaitheas	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	2	nmod	_	_
 5	go	go	PART	Vb	Mood=Sub|PartType=Vb	6	mark:prt	_	_
@@ -1608,7 +1608,7 @@
 4	mé	mé	PRON	Pers	Number=Sing|Person=1	3	nsubj	_	_
 5	idir	idir	ADP	Simp	_	7	case	_	_
 6	dhá	dó	NUM	Num	Form=Len|NumType=Card	7	nummod	_	_
-7	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	xcomp:pred	_	_
+7	cheann	ceann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	xcomp:pred	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	meá	meá	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	mar	mar	SCONJ	Subord	_	12	mark	_	_
@@ -1733,7 +1733,7 @@
 19	smeara	sméar	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	15	xcomp	_	_
 20	gúscéimhe	gúscéimhe	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
 21	thar	thar	ADP	Simp	_	22	case	_	_
-22	ghaimh	gaimh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	_
+22	ghaimh	gaimh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	_
 23	ghránna	gránna	ADJ	Adj	Degree=Pos|Form=Len	22	amod	_	_
 24	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	25	det	_	_
 25	chnis	cneas	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
@@ -1750,14 +1750,14 @@
 # text = Caithfidh siad focail an Airteagail a phlé i gcomhthéacs fuarchúis an phobail ar thaobh amháin, agus díograis an mhionlaigh ar an taobh eile.
 1	Caithfidh	caith	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 2	siad	siad	PRON	Pers	Number=Plur|Person=3	1	nsubj	_	_
-3	focail	focal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	7	obj	_	_
+3	focail	focal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	7	obj	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 5	Airteagail	airteagal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	phlé	plé	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	gcomhthéacs	comhthéacs	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	7	nmod	_	_
-10	fuarchúis	fuarchúis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	nmod	_	_
+9	gcomhthéacs	comhthéacs	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	7	nmod	_	_
+10	fuarchúis	fuarchúis	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	nmod	_	_
 13	ar	ar	ADP	Simp	_	14	case	_	_
@@ -1765,7 +1765,7 @@
 15	amháin	amháin	ADJ	Adj	Degree=Pos	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	agus	agus	CCONJ	Coord	_	18	cc	_	_
-18	díograis	díograis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	conj	_	_
+18	díograis	díograis	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	conj	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	mhionlaigh	mionlach	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	ar	ar	ADP	Simp	_	23	case	_	_
@@ -1868,9 +1868,9 @@
 8	le	le	ADP	Cmpd	PrepForm=Cmpd	10	case	_	_
 9	linn	linn	ADP	Cmpd	_	8	fixed	_	_
 10	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl	_	_
-11	gnéithe	gné	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	35	obj	_	_
-12	cosanta	cosaint	NOUN	Noun	Case=Gen|VerbForm=Inf	11	nmod	_	_
-13	Chomhbheartas	comhbheartas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	_
+11	gnéithe	gné	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	35	obj	_	_
+12	cosanta	cosaint	NOUN	Noun	Case=Gen|Definite=Def|VerbForm=Inf	11	nmod	_	_
+13	Chomhbheartas	comhbheartas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	_
 14	Eachtraigh	eachtrach	ADJ	Adj	Case=Gen|Gender=Masc|Number=Sing|PartType=Voc	13	amod	_	_
 15	agus	agus	CCONJ	Coord	_	16	cc	_	_
 16	Slándála	slándáil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	conj	_	_
@@ -1924,7 +1924,7 @@
 7	eolais	eolas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	dúinn	do	ADP	Prep	Number=Plur|Person=1	4	obl:prep	_	_
 9	faoi	faoi	ADP	Simp	_	10	case	_	_
-10	ionannú	ionannú	NOUN	Noun	VerbForm=Inf	7	nmod	_	_
+10	ionannú	ionannú	NOUN	Noun	Definite=Def|VerbForm=Inf	7	nmod	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	clainne	clann	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
 13	suntasaí	suntasach	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	12	amod	_	_
@@ -2006,7 +2006,7 @@
 30	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	18	xcomp	_	_
 31	nasctha	nasctha	ADJ	Adj	VerbForm=Part	30	xcomp:pred	_	_
 32	le	le	ADP	Simp	_	33	case	_	_
-33	fírinne	fírinne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	31	obl	_	_
+33	fírinne	fírinne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	31	obl	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	35	det	_	_
 35	tSlánaithe	slánú	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	12	punct	_	_
@@ -2036,7 +2036,7 @@
 3	Tiarna	tiarna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 4	Longueville	Longueville	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Co.	contae	NOUN	Abr	Abbr=Yes	3	nmod	_	NamedEntity=Yes
+6	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	3	nmod	_	NamedEntity=Yes
 7	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	6	punct	_	_
 9	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
@@ -2211,7 +2211,7 @@
 13	banaisteoir	banaisteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	appos	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	13	acl:relcl	_	_
-16	tús	tús	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
+16	tús	tús	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obj	_	_
 17	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
 18	saoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 19	i	i	ADP	Simp	_	21	case	_	_
@@ -2331,13 +2331,13 @@
 7	san	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
 8	insint	insint	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	obl	_	_
 9	cuirtear	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
-10	imeachtaí	imeacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	9	obj	_	_
+10	imeachtaí	imeacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	9	obj	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 13	i	i	ADP	Cmpd	PrepForm=Cmpd	14	case	_	_
 14	láthair	láthair	ADP	Cmpd	_	9	obl	_	_
 15	tré	tré	ADP	Simp	_	16	case	_	_
-16	shúile	súil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	9	obl	_	_
+16	shúile	súil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	9	obl	_	_
 17	Mhairéid	Mhairéid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 18	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	obl	_	_
 19	mhaith	maith	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	18	amod	_	SpaceAfter=No
@@ -2532,7 +2532,7 @@
 33	fós	fós	ADV	Gn	_	31	advmod	_	_
 34	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	31	nsubj	_	_
 35	d'	de	ADP	Simp	_	36	case	_	SpaceAfter=No
-36	ualach	ualach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	nmod	_	_
+36	ualach	ualach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	nmod	_	_
 37	géagach	géagach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	36	amod	_	_
 38	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	39	det	_	_
 39	croise	cros	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	36	nmod	_	_
@@ -2591,7 +2591,7 @@
 17	chuireann	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	15	acl:relcl	_	_
 18	cosc	cosc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obj	_	_
 19	ar	ar	ADP	Simp	_	20	case	_	_
-20	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obl	_	_
+20	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	obl	_	_
 21	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	22	det	_	_
 22	nIonchúiseamh	ionchúiseamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	20	nmod	_	_
 23	Poiblí	poiblí	ADJ	Adj	Degree=Pos	22	amod	_	SpaceAfter=No
@@ -2689,7 +2689,7 @@
 30	a	a	PART	Vb	PartType=Vb|PronType=Rel	31	nsubj	_	_
 31	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	26	acl:relcl	_	_
 32	de	de	ADP	Simp	_	33	case	_	_
-33	thurus	turas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
+33	thurus	turas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	huaire	uair	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	_
 36	ar	ar	ADP	Simp	_	38	case	_	_
@@ -2832,9 +2832,9 @@
 7	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	8	nmod:poss	_	_
 8	chos	cos	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	obj	_	_
 9	thar	thar	ADP	Simp	_	10	case	_	_
-10	tairseach	tairseach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
+10	tairseach	tairseach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Cultúrlainne	Cultúrlainne	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
+12	Cultúrlainne	Cultúrlann	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
 13	ag	ag	ADP	Simp	_	17	case	_	_
 14	a	a	PART	Nm	PartType=Num	15	mark:prt	_	_
 15	sé	sé	NUM	Num	NumType=Card	5	obl:tmod	_	_
@@ -2852,10 +2852,10 @@
 27	sa	i	ADP	Art	Number=Sing|PronType=Art	28	case	_	_
 28	bhaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
 29	i	i	ADP	Simp	_	30	case	_	_
-30	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl	_	_
+30	measc	measc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	obl	_	_
 31	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	32	nmod:poss	_	_
-32	chomhghael	comhghael	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
-33	Feirsteach	Feirsteach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
+32	chomhghael	comhghael	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Plur	30	nmod	_	_
+33	Feirsteach	Feirsteach	ADJ	Adj	Case=Gen|Gender=Masc|Number=Plur	32	amod	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	20	punct	_	_
 
 # sent_id = 116
@@ -2877,7 +2877,7 @@
 15	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	appos	_	_
 16	suite	suite	ADJ	Adj	VerbForm=Part	15	xcomp:pred	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
-18	bhruch	bruach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
+18	bhruch	bruach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
 19	Loch	loch	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 20	Dhún	dún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Lúiche	Lúiche	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
@@ -2893,14 +2893,14 @@
 4	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	1	ccomp	_	_
 5	ollfhadhbanna	ollfhadhb	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	4	nsubj	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
-7	institiúidí	institiúid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	4	obl	_	_
+7	institiúidí	institiúid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	4	obl	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	hEorpa	Eoraip	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	7	nmod	_	_
 10	nuair	nuair	SCONJ	Subord	_	12	mark	_	_
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	mark:prt	_	_
 12	chuirtear	cuir	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	4	advcl	_	_
 13	le	le	ADP	Simp	_	14	case	_	_
-14	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
+14	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
 16	mballstát	ballstát	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
@@ -2956,17 +2956,17 @@
 
 # sent_id = 121
 # text = Aonach a' Phoic Duine a bheadh ag ceannach capaill ní dhéanfadh sé margadh le tincéirí ar eagla go mbuailfí bob air faoi mar a buaileadh ar Phádraig Bán ar Aonach a' Phoic i gCill Orglan uair.
-1	Aonach	aonach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+1	Aonach	aonach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	NamedEntity=Yes
 3	Phoic	poc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-4	Duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
+4	Duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	parataxis	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd|Polarity=Neg	4	acl:relcl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	ceannach	ceannach	NOUN	Noun	VerbForm=Vnoun	6	xcomp	_	_
 9	capaill	capall	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	obj	_	_
 10	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	11	advmod	_	_
-11	dhéanfadh	déan	VERB	VTI	Form=Len|Mood=Cnd|Polarity=Neg	0	root	_	_
+11	dhéanfadh	déan	VERB	VTI	Form=Len|Mood=Cnd|Polarity=Neg	1	parataxis	_	_
 12	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	11	nsubj	_	_
 13	margadh	margadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obj	_	_
 14	le	le	ADP	Simp	_	15	case	_	_
@@ -2985,7 +2985,7 @@
 27	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
 28	Bán	Bán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	27	flat:name	_	NamedEntity=Yes
 29	ar	ar	ADP	Simp	_	30	case	_	_
-30	Aonach	aonach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
+30	Aonach	aonach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
 31	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	NamedEntity=Yes
 32	Phoic	poc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes
 33	i	i	ADP	Simp	_	34	case	_	_
@@ -3099,13 +3099,13 @@
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	ceangal	ceangal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 15	idir	idir	ADP	Simp	_	16	case	_	_
-16	barr	barr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	_
+16	barr	barr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
 18	bliana	bliain	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 19	seo	seo	DET	Det	PronType=Dem	18	det	_	_
 20	caite	caite	ADJ	Adj	VerbForm=Part	19	fixed	_	_
 21	agus	agus	CCONJ	Coord	_	22	cc	_	_
-22	barr	barr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	conj	_	_
+22	barr	barr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	bliana	bliain	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	_
 25	nua	nua	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	24	amod	_	SpaceAfter=No
@@ -3116,7 +3116,7 @@
 30	láthair	láthair	ADP	Cmpd	_	29	fixed	_	_
 31	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	28	nsubj	_	_
 32	de	de	ADP	Simp	_	33	case	_	_
-33	thimthriall	timthriall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	_
+33	thimthriall	timthriall	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	beatha	beatha	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	7	punct	_	_
@@ -3184,7 +3184,7 @@
 4	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	5	nmod:poss	_	_
 5	chuairt	cuairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	_
 6	go	go	ADP	Simp	_	7	case	_	_
-7	hIarthar	iarthar	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
+7	hIarthar	iarthar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	Feirste	Feirste	PROPN	Noun	Definite=Def	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 10	?	?	PUNCT	?	_	2	punct	_	_
@@ -3209,7 +3209,7 @@
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	mark:prt	_	_
 17	tharla	tarlaigh	VERB	PastInd	Form=Len|Mood=Ind|Polarity=Neg|Tense=Past	7	xcomp	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
+19	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
 20	Laoise	Laoise	PROPN	Noun	Definite=Def	19	nmod	_	SpaceAfter=No
 21	,	,	PUNCT	Punct	_	7	punct	_	_
 22	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
@@ -3226,7 +3226,7 @@
 33	m'	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	34	nmod:poss	_	SpaceAfter=No
 34	fhear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	nmod	_	_
 35	i	i	ADP	Simp	_	36	case	_	_
-36	gcaitheamh	caitheamh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
+36	gcaitheamh	caitheamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
 37	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	38	nmod:poss	_	_
 38	shaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	nmod	_	_
 39	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	42	cop	_	_
@@ -3294,7 +3294,7 @@
 12	rachas	téigh	VERB	VTI	Mood=Ind|PronType=Rel|Tense=Fut	10	acl:relcl	_	_
 13	thart	thart	ADV	Dir	_	12	advmod	_	_
 14	ar	ar	ADP	Simp	_	15	case	_	_
-15	chaol	caol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+15	chaol	caol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 16	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	17	nmod:poss	_	_
 17	láimhe	lámh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
@@ -3310,7 +3310,7 @@
 7	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	nsubj	_	_
 8	suíomh	suíomh	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	7	nmod	_	_
 9	chun	chun	ADP	Simp	_	10	case	_	_
-10	tairbhe	tairbhe	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
+10	tairbhe	tairbhe	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 11	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	12	nmod:poss	_	_
 12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	10	nmod	_	_
 13	feidhmeanna	feidhm	NOUN	Noun	Case=Gen|Gender=Fem|Number=Plur	12	nmod	_	SpaceAfter=No
@@ -3336,7 +3336,7 @@
 6	anuas	anuas	ADV	Dir	_	5	advmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	5	punct	_	_
 8	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-9	pobal	pobal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	_
+9	pobal	pobal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 10	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 11	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 12	Feirste	Feirste	PROPN	Noun	Definite=Def	11	nmod	_	NamedEntity=Yes
@@ -3392,7 +3392,7 @@
 8	Ó	ó	PART	Pat	PartType=Pat	7	flat:name	_	NamedEntity=Yes
 9	Muláin	Muláin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
-11	údar	údar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	appos	_	_
+11	údar	údar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	appos	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	amhráin	amhrán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
 14	úd	úd	DET	Det	PronType=Dem	13	det	_	SpaceAfter=No
@@ -3406,7 +3406,7 @@
 22	amhrán	amhrán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	_
 23	go	go	PART	Vb	PartType=Cmpl	24	obl	_	_
 24	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	22	acl:relcl	_	_
-25	báidh	báidh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	nsubj	_	_
+25	báidh	báidh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	24	nsubj	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
 27	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
 28	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	24	obl:prep	_	SpaceAfter=No
@@ -3427,7 +3427,7 @@
 43	ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	44	cop	_	_
 44	hamháin	amháin	ADJ	Adj	Degree=Pos|Form=HPref	46	parataxis	_	_
 45	ar	ar	ADP	Simp	_	44	case	_	_
-46	fuaid	fuaid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	33	obl	_	_
+46	fuaid	fuaid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	33	obl	_	_
 47	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	48	det	_	_
 48	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
@@ -3435,7 +3435,7 @@
 51	go	go	PART	Ad	PartType=Ad	52	mark:prt	_	_
 52	deimhin	deimhin	ADJ	Adj	Degree=Pos	54	advmod	_	_
 53	ar	ar	ADP	Simp	_	54	case	_	_
-54	fuaid	fuaid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	46	conj	_	_
+54	fuaid	fuaid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	46	conj	_	_
 55	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	56	det	_	_
 56	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	54	nmod	_	SpaceAfter=No
 57	.	.	PUNCT	.	_	2	punct	_	_
@@ -3473,7 +3473,7 @@
 11	ar	ar	ADP	Simp	_	12	case	_	_
 12	siúl	siúl	NOUN	Noun	VerbForm=Inf	10	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
-14	Comhdháil	comhdháil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
+14	Comhdháil	comhdháil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
 15	Vín	Vín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	go	go	PART	Vb	PartType=Cmpl	17	mark:prt	_	_
 17	dtuigfí	tuig	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	3	ccomp	_	_
@@ -3482,7 +3482,7 @@
 20	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nsubj	_	_
 21	féin	féin	PRON	Ref	Reflex=Yes	20	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	mála	mála	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	xcomp:pred	_	_
+23	mála	mála	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	xcomp:pred	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
 25	tsnátha	snáth	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	_
 26	ghil	geal	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	25	amod	_	_
@@ -3584,7 +3584,7 @@
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
 14	ghaineamh	gaineamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
-16	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	8	obl	_	_
+16	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	8	obl	_	_
 17	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	18	nmod:poss	_	_
 18	ngoradh	goradh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	16	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
@@ -3619,7 +3619,7 @@
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	nsubj	_	_
 18	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	15	acl:relcl	_	_
 19	le	le	ADP	Simp	_	20	case	_	_
-20	tógáil	tógáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	obl	_	_
+20	tógáil	tógáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	stáisiúin	stáisiún	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	_
 23	agus	agus	CCONJ	Coord	_	24	cc	_	_
@@ -3634,7 +3634,7 @@
 32	le	le	ADP	Simp	_	33	case	_	_
 33	fáil	fáil	NOUN	Noun	VerbForm=Inf	29	xcomp	_	_
 34	ag	ag	ADP	Simp	_	35	case	_	_
-35	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	obl	_	_
+35	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	_
 36	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	37	det	_	_
 37	míosa	mí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	35	nmod	_	_
 38	seo	seo	DET	Det	PronType=Dem	37	det	_	_
@@ -3761,7 +3761,7 @@
 # text = Meabhraítear dhá arcaitíopa Mháire dúinn arís, 'fear sanntach saoghalta agus fear fial fileamhanta', (1942, 5) a luaigh mé i gCaibidil 1.
 1	Meabhraítear	meabhraigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	dhá	dó	NUM	Num	Form=Len|NumType=Card	3	nummod	_	_
-3	arcaitíopa	arcaitíopa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
+3	arcaitíopa	arcaitíopa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	Mháire	Máire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 5	dúinn	do	ADP	Prep	Number=Plur|Person=1	1	obl:prep	_	_
 6	arís	arís	ADV	Gn	_	1	advmod	_	SpaceAfter=No
@@ -3820,13 +3820,13 @@
 13	ar	ar	ADP	Cmpd	PrepForm=Cmpd	16	case	_	_
 14	nós	nós	ADP	Cmpd	_	13	fixed	_	_
 15	'	'	PUNCT	Punct	_	16	punct	_	SpaceAfter=No
-16	Leatrom	leatrom	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+16	Leatrom	leatrom	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
 18	Cinniúna	cinniúint	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes|SpaceAfter=No
 19	'	'	PUNCT	Punct	_	16	punct	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	22	punct	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
-22	Mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
+22	Mac	mac	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
 23	Rí	rí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 24	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
 25	nDeachmann	deachmha	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	22	nmod	_	SpaceAfter=No
@@ -3840,14 +3840,14 @@
 33	'	'	PUNCT	Punct	_	30	punct	_	_
 34	(	(	PUNCT	Punct	_	36	punct	_	SpaceAfter=No
 35	Idir	idir	ADP	Simp	_	36	case	_	_
-36	Shúgradh	súgradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
+36	Shúgradh	súgradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	16	appos	_	_
 37	agus	agus	CCONJ	Coord	_	38	cc	_	_
 38	Dáiríre	dáiríre	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	36	conj	_	SpaceAfter=No
 39	)	)	PUNCT	Punct	_	36	punct	_	_
 40	agus	agus	CCONJ	Coord	_	43	cc	_	_
 41	in	i	ADP	Simp	_	43	case	_	_
 42	'	'	PUNCT	Punct	_	43	punct	_	SpaceAfter=No
-43	Tnúthán	tnúthán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	conj	_	_
+43	Tnúthán	tnúthán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	conj	_	_
 44	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	45	det	_	_
 45	Dúchais	dúchas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	43	nmod	_	SpaceAfter=No
 46	'	'	PUNCT	Punct	_	43	punct	_	_
@@ -3856,11 +3856,11 @@
 49	Ag	ag	ADP	Simp	_	50	case	_	_
 50	Dul	dul	NOUN	Noun	VerbForm=Vnoun	43	conj	_	_
 51	ar	ar	ADP	Simp	_	52	case	_	_
-52	Aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	50	nmod	_	SpaceAfter=No
+52	Aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	50	obl	_	SpaceAfter=No
 53	'	'	PUNCT	Punct	_	50	punct	_	_
 54	(	(	PUNCT	Punct	_	56	punct	_	SpaceAfter=No
 55	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	56	det	_	_
-56	Braon	braon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	50	nmod	_	_
+56	Braon	braon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	50	appos	_	_
 57	Broghach	broghach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	56	amod	_	SpaceAfter=No
 58	)	)	PUNCT	Punct	_	56	punct	_	SpaceAfter=No
 59	.	.	PUNCT	.	_	1	punct	_	_
@@ -3880,7 +3880,7 @@
 11	de	de	ADP	Simp	_	12	case	_	_
 12	dhéantús	déantús	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 13	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	14	case	_	_
-14	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	_
+14	linn	linn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	_
 15	ach	ach	SCONJ	Subord	_	17	mark:prt	_	_
 16	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	Bíobla	Bíobla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -3894,7 +3894,7 @@
 25	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	obl	_	_
 26	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	28	cop	_	_
 27	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	28	nmod	_	_
-28	Fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	csubj:cop	_	_
+28	Fear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	csubj:cop	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
 30	Leabhair	leabhar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	_
 31	úd	úd	DET	Det	PronType=Dem	32	det	_	_
@@ -3905,7 +3905,7 @@
 36	faoi	faoi	ADP	Simp	_	37	case	_	_
 37	ómós	ómós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	xcomp:pred	_	_
 38	mar	mar	ADP	Simp	_	39	case	_	_
-39	Fhear	fear	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	37	nmod	_	_
+39	Fhear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	37	nmod	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
 41	Leabhair	leabhar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	39	nmod	_	_
 42	seo	seo	DET	Det	PronType=Dem	41	det	_	_
@@ -4058,8 +4058,8 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	CÉIMÍOCHT	céimíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 3	:	:	PUNCT	Punct	_	4	punct	_	_
-4	Páistí	páiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	nmod	_	_
-5	Naíscoil	naíscoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
+4	Páistí	páiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	2	appos	_	_
+5	Naíscoil	naíscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	NamedEntity=Yes
 7	Lóiste	lóiste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	Úir	úr	ADJ	Adj	Case=Gen|Gender=Masc|Number=Sing	7	amod	_	NamedEntity=Yes
@@ -4068,7 +4068,7 @@
 11	dul	dul	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 12	isteach	isteach	ADV	Dir	_	11	advmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	rang	rang	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	_
+14	rang	rang	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 15	1	1	NUM	Num	_	14	nmod	_	_
 16	Bunscoil	bunscoil	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	16	nmod	_	NamedEntity=Yes
@@ -4107,7 +4107,7 @@
 26	luas	luas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nmod	_	_
 27	gar	gar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	_
 28	do	do	ADP	Simp	_	29	case	_	_
-29	luas	luas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	nmod	_	_
+29	luas	luas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	tsolais	solas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	nó	nó	CCONJ	Coord	_	34	cc	_	_
@@ -4163,7 +4163,7 @@
 8	Ball	ball	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	Oinigh	oineach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
-11	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	8	nmod	_	_
+11	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	8	nmod	_	_
 12	Hartlepoole	Hartlepoole	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	scríobh	scríobh	NOUN	Noun	VerbForm=Vnoun	6	xcomp	_	_
@@ -4171,7 +4171,7 @@
 16	go	go	PART	Ad	PartType=Ad	17	mark:prt	_	_
 17	scríobach	scríobach	ADJ	Adj	Degree=Pos	14	advmod	_	_
 18	faoi	faoi	ADP	Simp	_	19	case	_	_
-19	cheist	ceist	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	_
+19	cheist	ceist	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
 21	tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
 22	san	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
@@ -4198,7 +4198,7 @@
 3	seacht	seacht	NUM	Num	NumType=Card	4	nummod	_	_
 4	croitheadh	croitheadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	as	as	ADP	Simp	_	6	case	_	_
-6	láimh	lámh	NOUN	Noun	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
+6	láimh	lámh	NOUN	Noun	Case=Dat|Definite=Def|Gender=Fem|Number=Sing	2	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	mná	bean	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 9	fónta	fónta	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	8	amod	_	_
@@ -4297,7 +4297,7 @@
 2	ghearr	gearr	ADJ	Adj	Degree=Pos|Form=Len	0	root	_	_
 3	gur	gur	PART	Vb	PartType=Vb|Tense=Past	4	mark:prt	_	_
 4	fhás	fás	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cop	_	_
-5	drochiontaoibh	drochiontaoibh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
+5	drochiontaoibh	drochiontaoibh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	Kitchener	Kitchener	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 7	-	-	PUNCT	Punct	_	8	punct	_	_
 8	eisean	eisean	PRON	Pers	Gender=Masc|Number=Sing|Person=3|PronType=Emp	6	nmod	_	_
@@ -4344,7 +4344,7 @@
 8	deara	deara	NOUN	Subst	Number=Sing	6	obl	_	_
 9	go	go	PART	Ad	PartType=Ad	10	mark:prt	_	_
 10	luath	luath	ADJ	Adj	Degree=Pos	6	advmod	_	_
-11	buanna	bua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	6	obj	_	_
+11	buanna	bua	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	obj	_	_
 12	Chaitlín	Caitlín	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	Maude	Maude	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
@@ -4388,7 +4388,7 @@
 # sent_id = 184
 # text = Ghlac aintín a máthar, Bean Uí Eidhin, as Sráid na Cathrach, Co. an Chláir, cúram na beirte chuici féin.
 1	Ghlac	glac	VERB	VT	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	aintín	aintín	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+2	aintín	aintín	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
 4	máthar	máthair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -4397,15 +4397,15 @@
 8	Eidhin	Eidhin	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	11	punct	_	_
 10	as	as	ADP	Simp	_	11	case	_	_
-11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nmod	_	_
+11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	Cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	11	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	Co.	contae	NOUN	Abr	Abbr=Yes	11	nmod	_	NamedEntity=Yes
+15	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	11	nmod	_	NamedEntity=Yes
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	NamedEntity=Yes
 17	Chláir	Clár	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	cúram	cúram	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
+19	cúram	cúram	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	beirte	beirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	chuici	chuig	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	_
@@ -4474,7 +4474,7 @@
 42	Sinn	sinn	PRON	Pers	Number=Plur|Person=1	41	obj	_	NamedEntity=Yes
 43	i	i	ADP	Simp	_	44	case	_	_
 44	gCathú	cathú	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	41	obl	_	_
-45	seanchairde	seanchara	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	39	obj	_	_
+45	seanchairde	seanchara	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	39	obj	_	_
 46	Bhreandáin	Breandáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	45	nmod	_	_
 47	i	i	ADP	Simp	_	48	case	_	_
 48	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	45	nmod	_	_
@@ -4596,7 +4596,7 @@
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
 12	loite	loite	ADJ	Adj	VerbForm=Part	10	xcomp:pred	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
-14	leathchuimhní	leathchuimhne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	10	xcomp	_	_
+14	leathchuimhní	leathchuimhne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	10	xcomp	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	léinn	léann	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
@@ -4763,7 +4763,7 @@
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	plé	plé	NOUN	Noun	VerbForm=Inf	6	conj	_	_
 14	le	le	ADP	Simp	_	15	case	_	_
-15	gnáthchúrsaí	gnáthchúrsa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	13	obl	_	_
+15	gnáthchúrsaí	gnáthchúrsa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	13	obl	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
 18	ina	i	PART	Rel	PronType=Rel	19	obl	_	_
@@ -4835,7 +4835,7 @@
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	nsubj	_	_
 18	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	15	acl:relcl	_	_
 19	flúirseach	flúirseach	ADJ	Adj	Degree=Pos	18	xcomp:pred	_	_
-20	timpeall	timpeall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obl	_	_
+20	timpeall	timpeall	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	cheantair	ceantar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
 23	sin	sin	DET	Det	PronType=Dem	22	det	_	SpaceAfter=No
@@ -4889,7 +4889,7 @@
 17	i	i	ADP	Simp	_	18	case	_	_
 18	gceist	ceist	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	12	xcomp:pred	_	_
 19	i	i	ADP	Simp	_	20	case	_	_
-20	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
+20	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 21	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
 22	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	20	nmod	_	_
 23	agus	agus	CCONJ	Coord	_	25	mark	_	_
@@ -4897,12 +4897,12 @@
 25	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	12	xcomp	_	_
 26	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	25	xcomp:pred	_	_
 27	i	i	ADP	Simp	_	28	case	_	_
-28	gcomhthéacs	comhthéacs	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
+28	gcomhthéacs	comhthéacs	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
 30	ilteangachais	ilteangachas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	_
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	obj	_	_
 32	chothaigh	cothaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	30	acl:relcl	_	_
-33	athréimniú	athréimniú	NOUN	Noun	VerbForm=Inf	32	nsubj	_	_
+33	athréimniú	athréimniú	NOUN	Noun	Definite=Def|VerbForm=Inf	32	nsubj	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	hEabhraise	Eabhrais	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	4	punct	_	_
@@ -4910,7 +4910,7 @@
 # sent_id = 207
 # text = De réir a chéile, éirionn an teannas idir na saighdiúirí agus bunadh na háite agus téann an cur i gcoinne i ndéine... De réir cosúlacht níl a dhath le déanamh agatsa ach bheith i do shuí ansin ag leathnú do thóin agus ag cuimhniú ar phleanannaí.
 1	De	de	ADP	Simp	_	2	case	_	_
-2	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	nmod	_	_
+2	réir	réir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
 4	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -4921,7 +4921,7 @@
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
 11	saighdiúirí	saighdiúir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
-13	bunadh	bunadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	conj	_	_
+13	bunadh	bunadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	conj	_	_
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 15	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	13	nmod	_	_
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
@@ -4986,9 +4986,9 @@
 23	-	-	PUNCT	Punct	_	24	punct	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
 25	cothú	cothú	NOUN	Noun	VerbForm=Vnoun	20	xcomp	_	_
-26	cluichí	cluiche	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	25	obj	_	_
+26	cluichí	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	25	obj	_	_
 27	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	gclub	club	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	26	nmod	_	_
+28	gclub	club	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	26	nmod	_	_
 29	agus	agus	CCONJ	Coord	_	31	cc	_	_
 30	ag	ag	ADP	Simp	_	31	case	_	_
 31	riaradh	riaradh	NOUN	Noun	VerbForm=Vnoun	25	conj	_	_
@@ -5068,10 +5068,10 @@
 # sent_id = 211
 # text = Tá dearadh fisiciúil an stáitse ag teacht leis an ábhar.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	dearadh	dearadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	dearadh	dearadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	fisiciúil	fisiciúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	stáitse	stát	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
+5	stáitse	stáitse	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
 7	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 8	leis	le	ADP	Simp	_	10	case	_	_
@@ -5164,7 +5164,7 @@
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	18	det	_	_
 18	gcúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	obl	_	_
-19	chois	cois	NOUN	Noun	Case=Dat|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	_
+19	chois	cois	NOUN	Noun	Case=Dat|Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
 21	chlaí	claí	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	8	punct	_	_
@@ -5181,7 +5181,7 @@
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	hóglaigh	óglach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	6	obl	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	gcomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
+11	gcomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
 12	Champabasso	Champabasso	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
 13	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	14	cop	_	_
 14	olc	olc	ADJ	Adj	Degree=Pos	6	ccomp	_	_
@@ -5201,7 +5201,7 @@
 5	fosta	fosta	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	8	punct	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	súile	súil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	obl	_	_
+8	súile	súil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	obl	_	_
 9	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
 10	dearbhdhúinte	dearbhdhúinte	ADJ	Adj	VerbForm=Part	8	amod	_	SpaceAfter=No
 11	'	'	PUNCT	Punct	_	10	punct	_	_
@@ -5283,15 +5283,15 @@
 3	amháin	amháin	ADJ	Adj	Degree=Pos	2	amod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-6	lucht	lucht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
+6	lucht	lucht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	hollmhaoine	ollmhaoin	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	6	nmod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
-10	togha	togha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	_
+10	togha	togha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
 12	bia	bia	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 13	agus	agus	CCONJ	Coord	_	5	nsubj	_	_
-14	rogha	rogha	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
+14	rogha	rogha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	conj	_	_
 15	gach	gach	DET	Det	Definite=Def	16	det	_	_
 16	dí	deoch	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	acu	ag	ADP	Prep	Number=Plur|Person=3	5	obl:prep	_	_
@@ -5465,7 +5465,7 @@
 3	crua	crua	ADJ	Adj	Degree=Pos	2	amod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	6	punct	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
-6	Rí	rí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+6	Rí	rí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 9	Is	agus	CCONJ	Coord	_	10	cc	_	_
@@ -5474,7 +5474,7 @@
 12	dallóg	dallóg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obj	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	ar	ar	ADP	Simp	_	15	case	_	_
-15	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
+15	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 16	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	17	nmod:poss	_	_
 17	éadain	éadan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
 18	A	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
@@ -5524,7 +5524,7 @@
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	nsubj	_	_
 23	chuidigh	cuidigh	VERB	VI	Form=Len|Mood=Ind|Tense=Past	15	conj	_	_
 24	le	le	ADP	Simp	_	25	case	_	_
-25	fórsaí	fórsa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	23	obl	_	_
+25	fórsaí	fórsa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	23	obl	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
 27	Breataine	Breatain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	3	punct	_	_
@@ -5553,7 +5553,7 @@
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	obj	_	_
 12	bheirtear	beir	VERB	PresInd	Form=Len|Mood=Ind|Person=0|Tense=Pres	10	acl:relcl	_	_
 13	in	i	ADP	Simp	_	14	case	_	_
-14	oileán	oileán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
+14	oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
 16	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	14	nmod	_	_
 17	mura	mura	SCONJ	Subord	_	18	mark	_	_
@@ -5678,11 +5678,11 @@
 11	timpiste	timpiste	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	_
 12	Comhairle	comhairle	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	list	_	_
 13	do	do	ADP	Simp	_	14	case	_	_
-14	scoileanna	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	12	nmod	_	_
+14	scoileanna	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	12	nmod	_	_
 15	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
-16	Tí	tí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+16	Tí	tí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Chulainn	Culann	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
-18	Co.	contae	NOUN	Abr	Abbr=Yes	17	nmod	_	NamedEntity=Yes
+18	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	17	nmod	_	NamedEntity=Yes
 19	Ard	Ard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 20	Mhacha	Mhacha	PROPN	Noun	Definite=Def	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	_	_
@@ -5713,7 +5713,7 @@
 22	i	i	ADP	Cmpd	PrepForm=Cmpd	14	obl	_	_
 23	láthair	láthair	ADP	Cmpd	_	22	fixed	_	_
 24	chun	chun	ADP	Simp	_	25	case	_	_
-25	úsáid	úsáid	NOUN	Noun	VerbForm=Inf	31	obj	_	_
+25	úsáid	úsáid	NOUN	Noun	Definite=Def|VerbForm=Inf	31	obj	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
 27	leithreasaí	leithreas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	_
 28	lena	le	PART	Rel	PronType=Rel	29	obl	_	_
@@ -5831,7 +5831,7 @@
 9	coistí	coiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
 10	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 11	ná	ná	CCONJ	Coord	_	12	mark:prt	_	_
-12	comhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
+12	comhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
 13	tofa	tofa	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	12	amod	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	údaráis	údarás	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	_
@@ -5945,7 +5945,7 @@
 6	tar	tar	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
 7	éis	éis	ADP	Cmpd	_	6	fixed	_	_
 8	do	do	ADP	Simp	_	9	case	_	_
-9	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	11	nsubj	_	NamedEntity=Yes
+9	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nsubj	_	NamedEntity=Yes
 10	Amstardam	Amstardam	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	teacht	teacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	xcomp	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
@@ -6017,7 +6017,7 @@
 78	bearta	beart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	19	parataxis	_	_
 79	maidir	maidir	ADP	CmpdNoGen	_	86	case	_	_
 80	le	le	ADP	CmpdNoGen	_	79	fixed	_	_
-81	teorainneacha	teorainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	86	obj	_	_
+81	teorainneacha	teorainn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	86	obj	_	_
 82	seachtracha	seachtrach	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	81	amod	_	_
 83	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	84	det	_	_
 84	mBallstát	ballstát	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	81	nmod	_	_
@@ -6067,7 +6067,7 @@
 128	n-áirítear	áirigh	VERB	VT	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	113	acl:relcl	_	SpaceAfter=No
 129	:	:	PUNCT	Punct	_	131	punct	_	_
 130	(i)	(i)	NUM	Item	_	131	list	_	_
-131	liosta	liosta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	128	obj	_	_
+131	liosta	liosta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	128	obj	_	_
 132	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	134	det	_	_
 133	dtríú	trí	NUM	Num	Form=Ecl|NumType=Ord	134	amod	_	_
 134	tíortha	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	131	nmod	_	_
@@ -6088,7 +6088,7 @@
 149	seachtracha	seachtrach	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	148	amod	_	_
 150	dóibh	do	ADP	Prep	Number=Plur|Person=3	147	obl:prep	_	_
 151	agus	agus	CCONJ	Coord	_	152	cc	_	_
-152	liosta	liosta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	131	conj	_	_
+152	liosta	liosta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	131	conj	_	_
 153	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	155	det	_	_
 154	dtríú	trí	NUM	Num	Form=Ecl|NumType=Ord	155	amod	_	_
 155	tíortha	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	152	nmod	_	_
@@ -6144,7 +6144,7 @@
 205	tríú	tríú	NUM	Num	NumType=Ord	206	amod	_	_
 206	tíortha	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	204	nmod	_	_
 207	ar	ar	ADP	Simp	_	208	case	_	_
-208	chríoch	críoch	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	206	nmod	_	_
+208	chríoch	críoch	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	206	nmod	_	_
 209	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	210	det	_	_
 210	mBallstát	ballstát	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	208	nmod	_	_
 211	le	le	ADP	Cmpd	PrepForm=Cmpd	213	case	_	_
@@ -6180,7 +6180,7 @@
 1	ras	rás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	Nua-Ealaíne	nua-ealaín	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
-4	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
+4	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 5	(	(	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
 6	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 7	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
@@ -6194,7 +6194,7 @@
 15	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	Cliath	Cliath	PROPN	Noun	Definite=Def	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 17	)	)	PUNCT	Punct	_	14	punct	_	_
-18	Gailearaí	gailearaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+18	Gailearaí	gailearaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 19	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	18	amod	_	NamedEntity=Yes
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	NamedEntity=Yes
 21	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	18	nmod	_	NamedEntity=Yes
@@ -6212,7 +6212,7 @@
 33	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	NamedEntity=Yes
 34	Cliath	Cliath	PROPN	Noun	Definite=Def	33	nmod	_	NamedEntity=Yes|SpaceAfter=No
 35	)	)	PUNCT	Punct	_	32	punct	_	_
-36	Leabharlann	leabharlann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	list	_	NamedEntity=Yes
+36	Leabharlann	leabharlann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	list	_	NamedEntity=Yes
 37	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	36	amod	_	NamedEntity=Yes
 38	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	39	det	_	NamedEntity=Yes
 39	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	36	nmod	_	NamedEntity=Yes
@@ -6225,7 +6225,7 @@
 46	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	47	det	_	NamedEntity=Yes
 47	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	45	nmod	_	NamedEntity=Yes|SpaceAfter=No
 48	,	,	PUNCT	Punct	_	49	punct	_	_
-49	Dún	dún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	nmod	_	NamedEntity=Yes
+49	Dún	dún	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	45	nmod	_	NamedEntity=Yes
 50	Uí	uí	PART	Pat	PartType=Pat	49	nmod	_	NamedEntity=Yes
 51	Choileáin	Coileáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
 52	(	(	PUNCT	Punct	_	53	punct	_	SpaceAfter=No
@@ -6245,9 +6245,9 @@
 66	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	65	nmod	_	NamedEntity=Yes
 67	Cliath	Cliath	PROPN	Noun	Definite=Def	66	nmod	_	NamedEntity=Yes|SpaceAfter=No
 68	)	)	PUNCT	Punct	_	65	punct	_	_
-69	National	National	PROPN	Noun	Case=NomAcc|Foreign=Yes|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
-70	Photographic	photographic	NOUN	Noun	Case=NomAcc|Foreign=Yes|Gender=Fem|Number=Sing	69	flat:foreign	_	NamedEntity=Yes
-71	Archive	Archive	PROPN	Noun	Case=NomAcc|Foreign=Yes|Gender=Masc|Number=Sing	70	flat:foreign	_	NamedEntity=Yes
+69	National	National	X	Foreign	Foreign=Yes	1	list	_	NamedEntity=Yes
+70	Photographic	photographic	X	Foreign	Foreign=Yes	69	flat:foreign	_	NamedEntity=Yes
+71	Archive	Archive	X	Foreign	Foreign=Yes	69	flat:foreign	_	NamedEntity=Yes
 72	(	(	PUNCT	Punct	_	73	punct	_	SpaceAfter=No
 73	Dublin	Dublin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	69	nmod	_	NamedEntity=Yes|SpaceAfter=No
 74	)	)	PUNCT	Punct	_	73	punct	_	SpaceAfter=No
@@ -6259,8 +6259,8 @@
 2	leor	leor	ADJ	Adj	Degree=Pos	0	root	_	_
 3	breathnú	breathnú	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	staitisticí	staitistic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	3	obl	_	_
-6	scrúdúcháin	scrúdúchán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
+5	staitisticí	staitistic	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	3	obl	_	_
+6	scrúdúcháin	scrúdúchán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	Bhéarla	Béarla	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	nó	nó	CCONJ	Coord	_	11	cc	_	_
@@ -6282,12 +6282,12 @@
 25	réir	réir	ADP	Cmpd	_	24	fixed	_	_
 26	mar	mar	SCONJ	Subord	_	27	mark	_	_
 27	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	16	advcl	_	_
-28	daonra	daonra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	nsubj	_	_
+28	daonra	daonra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
 30	scoile	scoil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	28	nmod	_	_
 31	i	i	ADP	Simp	_	32	case	_	_
-32	dtreo	treo	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
-33	dhaonra	daonra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	32	nmod	_	_
+32	dtreo	treo	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
+33	dhaonra	daonra	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	32	nmod	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	_
 36	san	i	ADP	Art	Number=Sing|PronType=Art	37	case	_	_
@@ -6309,7 +6309,7 @@
 
 # sent_id = 249
 # text = Caomhnú an dúlra - Féachaint chuige nach loitfí an timpeallacht nádúrtha le linn d'fhorbairt gheilleagrach nó eile a bheith ar siúl.
-1	Caomhnú	caomhnú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Caomhnú	caomhnú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	dúlra	dúlra	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 4	-	-	PUNCT	Punct	_	5	punct	_	_
@@ -6676,7 +6676,7 @@
 78	tabhairt	tabhairt	NOUN	Noun	VerbForm=Inf	70	xcomp	_	_
 79	le	le	ADP	Cmpd	PrepForm=Cmpd	81	case	_	_
 80	linn	linn	ADP	Cmpd	_	79	fixed	_	_
-81	trádáil	trádáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	87	obj	_	_
+81	trádáil	trádáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	87	obj	_	_
 82	leithleach	leithleach	ADJ	Adj	Degree=Pos	81	amod	_	_
 83	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	84	det	_	_
 84	pearsan	pearsa	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	81	nmod	_	_
@@ -6765,8 +6765,8 @@
 167	méid	méid	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	165	nsubj	_	_
 168	bhrabúis	brabús	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	167	nmod	_	_
 169	nó	nó	CCONJ	Coord	_	170	cc	_	_
-170	ghnóchain	gnóchan	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	168	conj	_	_
-171	thrádáil	trádáil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	170	nmod	_	_
+170	ghnóchain	gnóchan	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	168	conj	_	_
+171	thrádáil	trádáil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	170	nmod	_	_
 172	leithleach	leithleach	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	171	amod	_	_
 173	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	174	det	_	_
 174	pearsan	pearsa	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	171	nmod	_	_
@@ -6787,13 +6787,13 @@
 # text = Cé gur rogha na coitiantachta Tiobraid Árann chun craobh na Mumhan a thógáil is beag atá idir an dhá fhoireann agus is cinnte go mbeidh Nicky English ag cur go mór ina luí ar a chuid fear cé chomh héifeachtach a d'imir Luimneach in aghaidh Chorcaí sa chéad bhabhta den chraobh agus an cluiche in aghaidh Phort Láirge dha sheachtain ó shin.
 1	Cé	cé	SCONJ	Subord	_	3	mark	_	_
 2	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
-3	rogha	rogha	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	advcl	_	_
+3	rogha	rogha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	advcl	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	coitiantachta	coitiantacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	Tiobraid	Tiobraid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	nsubj	_	NamedEntity=Yes
 7	Árann	Árann	PROPN	Noun	Definite=Def	6	nmod	_	NamedEntity=Yes
 8	chun	chun	ADP	Simp	_	13	case	_	_
-9	craobh	craobh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obj	_	_
+9	craobh	craobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	13	obj	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
 11	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
@@ -6939,7 +6939,7 @@
 2	Tógann	tóg	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	dhá	dó	NUM	Num	Form=Len|NumType=Card	5	nummod	_	_
-5	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obj	_	_
+5	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obj	_	_
 6	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	chloig	clog	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	nmod	_	_
 8	taisteal	taisteal	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
@@ -6947,14 +6947,14 @@
 10	Leamhchán	Leamhcán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	8	obl	_	_
 11	go	go	ADP	Cmpd	PrepForm=Cmpd	13	case	_	_
 12	dtí	dtí	ADP	Cmpd	Form=Ecl	11	fixed	_	_
-13	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
+13	lár	lár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 15	cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
 17	maidin	maidin	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nmod	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	dhá	dó	NUM	Num	Form=Len|NumType=Card	20	nummod	_	_
-20	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	conj	_	_
+20	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	conj	_	_
 21	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	chloig	clog	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
 23	arís	arís	ADV	Gn	_	20	advmod	_	_
@@ -7083,17 +7083,17 @@
 38	as	as	ADP	Simp	_	39	case	_	_
 39	amharc	amharc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	37	obl	_	_
 40	ag	ag	ADP	Simp	_	41	case	_	_
-41	bun	bun	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	37	obl	_	_
+41	bun	bun	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	37	obl	_	_
 42	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	43	det	_	_
 43	spéire	spéir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	41	nmod	_	_
 44	siar	siar	ADV	Dir	_	37	advmod	_	_
 45	ó	ó	ADV	Dir	_	44	advmod	_	_
 46	thuaidh	thuaidh	ADV	Dir	_	45	fixed	_	_
 47	de	de	ADP	Simp	_	48	case	_	_
-48	Oileán	oileán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	obl	_	_
+48	Oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	45	obl	_	_
 49	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	51	det	_	_
 50	dá	dó	NUM	Num	Definite=Def|NumType=Card	51	nummod	_	_
-51	Bhrannóg	Bhrannóg	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	nmod	_	SpaceAfter=No
+51	Bhrannóg	Brannóg	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	nmod	_	SpaceAfter=No
 52	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 275
@@ -7164,7 +7164,7 @@
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
 12	taighde	taighde	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	conj	_	_
 13	ar	ar	ADP	Simp	_	14	case	_	_
-14	cheol	ceol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+14	cheol	ceol	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
 16	nGael	Gael	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	14	nmod	_	_
 17	thall	thall	ADV	Dir	_	7	advmod	_	_
@@ -7205,7 +7205,7 @@
 18	is	agus	CCONJ	Coord	_	19	mark	_	_
 19	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	17	advcl	_	_
 20	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nsubj	_	_
-21	iomláine	iomláine	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	25	obj	_	_
+21	iomláine	iomláine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	25	obj	_	_
 22	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
 23	trialach	triail	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	21	nmod	_	_
 24	a	a	PART	Inf	PartType=Inf	25	mark	_	_
@@ -7272,7 +7272,7 @@
 4	bád	bád	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	obj	_	_
 6	chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	acl:relcl	_	_
-7	mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
+7	mac	mac	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	fhir	fear	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
@@ -7320,7 +7320,7 @@
 4	thinneas	tinneas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	fiacaile	fiacail	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
 6	in	i	ADP	Simp	_	7	case	_	_
-7	Uachtar	uachtar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	xcomp:pred	_	NamedEntity=Yes
+7	Uachtar	uachtar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	NamedEntity=Yes
 8	Achaidh	Achaidh	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	conj	_	_
@@ -7458,7 +7458,7 @@
 # sent_id = 287
 # text = I seó Abábú, beidh Máire Andrews ag insint scéalta difriúla trí mheán an cheoil agus na gluaiseachta.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	seó	seó	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
+2	seó	seó	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	Abábú	Abábú	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
@@ -7469,7 +7469,7 @@
 10	scéalta	scéal	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	9	obj	_	_
 11	difriúla	difriúil	ADJ	Adj	Case=Gen|NounType=Strong|Number=Plur	10	amod	_	_
 12	trí	trí	ADP	Simp	_	13	case	_	_
-13	mheán	meán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
+13	mheán	meán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	cheoil	ceol	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
 16	agus	agus	CCONJ	Coord	_	18	cc	_	_
@@ -7504,9 +7504,9 @@
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	léargas	léargas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	shaíocht	saíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+5	shaíocht	saíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Sean-Ghréige	Sean-Ghréige	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	5	nmod	_	_
+7	Sean-Ghréige	Sean-Ghréig	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	5	nmod	_	_
 8	ná	nach	PART	Vb	PartType=Vb|Polarity=Neg|PronType=Rel	9	mark:prt	_	_
 9	fuair	faigh	VERB	VT	Mood=Ind|Tense=Past	1	ccomp	_	_
 10	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	9	obj	_	_
@@ -7655,7 +7655,7 @@
 # sent_id = 298
 # text = I measc na n-aíonna a bheidh i láthair beidh Aiden Coffey, Jackie Daly, Máire O Keefe, Séamus Creagh, Tony Linnane, Breándán Ó Beaglaoich, Denis Doody, agus Eamonn Coyne.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
+2	measc	measc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	n-aíonna	aoi	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	2	nmod	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
@@ -7831,7 +7831,7 @@
 23	,	,	PUNCT	Punct	_	24	punct	_	_
 24	gar	gar	ADJ	Adj	Degree=Pos	20	amod	_	_
 25	do	do	ADP	Simp	_	26	case	_	_
-26	Theampall	teampall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	24	obl	_	NamedEntity=Yes
+26	Theampall	teampall	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	obl	_	NamedEntity=Yes
 27	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	26	nmod	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	parataxis	_	_
@@ -7997,7 +7997,7 @@
 32	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	30	obj	_	_
 33	peacaí	peaca	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	32	nmod	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
-35	hart	hart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	obl	_	_
+35	hart	hart	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	30	obl	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
 37	dathadóra	dathadóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	12	punct	_	_
@@ -8033,8 +8033,8 @@
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
 13	hinstitiúidí	institiúid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Plur	11	nsubj	_	_
 14	de	de	ADP	Simp	_	15	case	_	_
-15	thoradh	toradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	11	obl	_	_
-16	fhorálacha	foráil	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Plur	15	nmod	_	_
+15	thoradh	toradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	obl	_	_
+16	fhorálacha	foráil	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Plur	15	nmod	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	Chonartha	conradh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 19	ar	ar	ADP	Simp	_	21	case	_	_
@@ -8200,7 +8200,7 @@
 9	t-athneartú	athneartú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 10	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 11	do	do	ADP	Simp	_	12	case	_	_
-12	chlabhsúr	clabhsúr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
+12	chlabhsúr	clabhsúr	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 13	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 14	chéad	céad	NUM	Num	Form=Len|NumType=Ord	15	amod	_	_
 15	chaibidlíochta	caibidlíocht	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
@@ -8277,7 +8277,7 @@
 21	Ghaoth	gaoth	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	Dobhair	dobhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
-24	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl:tmod	_	_
+24	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl:tmod	_	_
 25	Dé	Dé	PROPN	Subst	Definite=Def|Number=Sing	24	nmod	_	NamedEntity=Yes
 26	Sathairn	Satharn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes|SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
@@ -8292,7 +8292,7 @@
 # sent_id = 324
 # text = I mí Eanáir, thuairisc na taighdeoirí céanna go raibh dath turcaide uirthi.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl:tmod	_	_
+2	mí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl:tmod	_	_
 3	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	thuairisc	tuairisc	VERB	_	Mood=Ind|Tense=Past	0	root	_	_
@@ -8383,7 +8383,7 @@
 9	bonn	bonn	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	advcl	_	_
 10	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	9	amod	_	_
 11	ag	ag	ADP	Simp	_	12	case	_	_
-12	iomaitheoirí	iomaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	9	nmod	_	_
+12	iomaitheoirí	iomaitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	9	nmod	_	_
 13	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
 14	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	_
 15	sin	sin	DET	Det	PronType=Dem	14	det	_	_
@@ -8425,7 +8425,7 @@
 12	Néill	Néill	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	chualathas	clois	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Past	1	parataxis	_	_
-15	sainléacht	sainléacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	obj	_	_
+15	sainléacht	sainléacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	obj	_	_
 16	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	Nicholls	Nicholls	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
@@ -8433,7 +8433,7 @@
 20	le	le	ADP	Simp	_	21	case	_	_
 21	Stair	stair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	nmod	_	_
+23	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	19	nmod	_	_
 24	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
 25	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	27	punct	_	_
@@ -8490,7 +8490,7 @@
 17	Nic	nic	PART	Pat	PartType=Pat	16	flat	_	NamedEntity=Yes
 18	Suibhne	Suibhne	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	le	le	ADP	Simp	_	20	case	_	_
-20	traenáil	traenáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	_
+20	traenáil	traenáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	13	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	fhoireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	_
 23	camógaíochta	camógaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	22	nmod	_	SpaceAfter=No
@@ -8514,19 +8514,19 @@
 4	aitheantas	aitheantas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	tugtha	tugtha	ADJ	Adj	VerbForm=Part	3	xcomp:pred	_	_
 6	do	do	ADP	Simp	_	7	case	_	_
-7	chaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+7	chaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 8	ard	ard	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
 10	cumadóireachta	cumadóireacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 11	cheana	cheana	ADV	Gn	_	10	nmod	_	_
 12	féin	féin	PRON	Ref	Reflex=Yes	11	nmod	_	_
 13	agus	agus	CCONJ	Coord	_	14	mark	_	_
-14	duais	duais	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	advcl	_	_
+14	duais	duais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	advcl	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Oireachtais	oireachtas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	tabhaithe	tabhaithe	ADJ	Adj	VerbForm=Part	14	xcomp:pred	_	_
 18	ag	ag	ADP	Simp	_	19	case	_	_
-19	bunlámhscríbhinn	bunlámhscríbhinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obl	_	_
+19	bunlámhscríbhinn	bunlámhscríbhinn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	obl	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	díolama	díolaim	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
@@ -8549,7 +8549,7 @@
 12	Mhainistir	mainistir	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	Co.	contae	NOUN	Abr	Abbr=Yes	12	nmod	_	NamedEntity=Yes
+15	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	12	nmod	_	NamedEntity=Yes
 16	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	Dara	Dara	PROPN	Noun	Definite=Def	16	nmod	_	NamedEntity=Yes
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
@@ -8607,7 +8607,7 @@
 5	céanna	céanna	ADJ	Adj	Degree=Pos	4	amod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	4	punct	_	_
 7	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-8	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
+8	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	10	det	_	_
 10	nGaeilgeoirí	Gaeilgeoir	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	8	nmod	_	_
 11	maithe	maith	ADJ	Adj	Case=Gen|NounType=Strong|Number=Plur	10	amod	_	_
@@ -8762,7 +8762,7 @@
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	nsubj	_	_
 19	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	17	acl:relcl	_	_
 20	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	21	case	_	_
-21	n-aimsir	aimsir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	19	obl	_	_
+21	n-aimsir	aimsir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	19	obl	_	_
 22	féin	féin	PRON	Ref	Reflex=Yes	21	nmod	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	fhorbairt	forbairt	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	12	conj	_	SpaceAfter=No
@@ -8872,7 +8872,7 @@
 36	-	-	PUNCT	Punct	_	37	punct	_	_
 37	ach	ach	SCONJ	Subord	_	38	mark	_	_
 38	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
-39	dlí	dlí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	38	nsubj	_	_
+39	dlí	dlí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	38	nsubj	_	_
 40	choitianta	coitianta	ADJ	Adj	Degree=Pos|Form=Len	39	amod	_	_
 41	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	42	det	_	_
 42	troscaidh	troscadh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	39	nmod	_	_
@@ -8952,7 +8952,7 @@
 55	Chabhraigh	cabhraigh	VERB	VI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 56	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	55	nsubj	_	_
 57	chun	chun	ADP	Simp	_	64	case	_	_
-58	tuairim	tuairim	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	64	obj	_	_
+58	tuairim	tuairim	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	64	obj	_	_
 59	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	61	det	_	_
 60	'	'	PUNCT	Punct	_	61	punct	_	SpaceAfter=No
 61	saorthrádála	saorthrádáil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	58	nmod	_	SpaceAfter=No
@@ -9415,7 +9415,7 @@
 1	Cuirtear	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
-4	stair	stair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	conj	_	_
+4	stair	stair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	conj	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	raidió	raidió	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	in	i	ADP	Simp	_	8	case	_	_
@@ -9721,8 +9721,8 @@
 11	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	9	flat:name	_	NamedEntity=Yes
 12	Foilsithe	foilsithe	ADJ	Adj	VerbForm=Part	6	xcomp:pred	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
-14	Coiste	coiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	NamedEntity=Yes
-15	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
+14	Coiste	coiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	NamedEntity=Yes
+15	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	15	nmod	_	_
 18	Teoranta	teoranta	ADJ	Adj	Degree=Pos	17	amod	_	_
@@ -9730,10 +9730,10 @@
 20	5	5	NUM	Num	_	19	nmod	_	_
 21	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
 22	iad	iad	PRON	Pers	Number=Plur|Person=3	23	nmod	_	_
-23	Coiste	coiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	parataxis	_	NamedEntity=Yes
-24	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	23	nmod	_	NamedEntity=Yes
+23	Coiste	coiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	parataxis	_	NamedEntity=Yes
+24	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	NamedEntity=Yes
-26	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	23	nmod	_	NamedEntity=Yes
+26	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	24	nmod	_	NamedEntity=Yes
 27	a	a	PART	Vb	PartType=Vb|PronType=Rel	28	mark:prt	_	_
 28	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	23	csubj:cleft	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
@@ -9745,7 +9745,7 @@
 35	Ó	ó	PART	Pat	PartType=Pat	34	flat:name	_	NamedEntity=Yes
 36	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	34	flat:name	_	NamedEntity=Yes
 37	i	i	ADP	Simp	_	38	case	_	_
-38	dtoll	toll	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
+38	dtoll	toll	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
 39	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	40	nmod:poss	_	_
 40	chéile	céile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	38	nmod	_	SpaceAfter=No
 41	.	.	PUNCT	.	_	6	punct	_	_
@@ -9847,7 +9847,7 @@
 24	mórán	mórán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
 25	eile	eile	DET	Det	PronType=Dem	24	det	_	_
 26	de	de	ADP	Simp	_	27	case	_	_
-27	dhamhsaí	damhsa	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	24	nmod	_	_
+27	dhamhsaí	damhsa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	24	nmod	_	_
 28	bríomhara	bríomhar	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	27	amod	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
 30	hAlban	Albain	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
@@ -9890,9 +9890,9 @@
 2	ar	ar	ADP	Cmpd	PrepForm=Cmpd	5	case	_	_
 3	fud	fud	ADP	Cmpd	_	2	fixed	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	bhóthair	bóthar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obj	_	SpaceAfter=No
+5	bhóthair	bóthar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	miotal	miotal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	_
+7	miotal	miotal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	cairte	cairt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	lúbtha	lúbtha	ADJ	Adj	VerbForm=Part	7	xcomp:pred	_	SpaceAfter=No
@@ -9911,7 +9911,7 @@
 3	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	-	-	PUNCT	Punct	_	6	punct	_	_
-6	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
+6	lár	lár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	lae	lá	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	más	má	SCONJ	Subord	VerbForm=Cop	10	mark	_	_
@@ -9983,7 +9983,7 @@
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	seanGhall	seanGhall	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	19	conj	_	_
 22	ó	ó	ADP	Simp	_	23	case	_	_
-23	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
+23	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
 25	séú	sé	NUM	Num	NumType=Ord	26	amod	_	_
 26	haois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	_
@@ -10132,7 +10132,7 @@
 13	bpiont	piont	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	10	nmod	_	_
 14	go	go	PART	Vb	PartType=Cmpl	15	mark:prt	_	_
 15	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	10	ccomp	_	_
-16	dath	dath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nsubj	_	_
+16	dath	dath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	nsubj	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	bháis	bás	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
@@ -10247,7 +10247,7 @@
 4	nach	nach	PART	Vb	PartType=Cmpl|Polarity=Neg	5	mark:prt	_	_
 5	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Polarity=Neg|Tense=Pres	1	ccomp	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	gcúraimí	cúram	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	5	xcomp:pred	_	_
+7	gcúraimí	cúram	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	xcomp:pred	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	ach	ach	SCONJ	Subord	_	5	mark:prt	_	_
@@ -10390,7 +10390,7 @@
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
 32	clamhsán	clamhsán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	conj	_	_
 33	i	i	ADP	Simp	_	34	case	_	_
-34	sean-ard	sean-ard	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	nmod	_	_
+34	sean-ard	sean-ard	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	_
 35	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
 36	cinn	ceann	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
 37	i	i	ADP	Simp	_	38	case	_	_
@@ -10578,7 +10578,7 @@
 32	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	31	obl:prep	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
-35	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	obl	_	_
+35	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	obl	_	_
 36	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10620,7 +10620,7 @@
 11	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	nmod:poss	_	_
 12	láimhe	lámh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	obj	_	_
 13	ó	ó	ADP	Simp	_	14	case	_	_
-14	ghualainn	gualainn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
+14	ghualainn	gualainn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
 15	Phóil	Pól	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	14	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	shiúil	siúil	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	advcl	_	_
@@ -10799,7 +10799,7 @@
 61	mé	mé	PRON	Pers	Number=Sing|Person=1	60	nsubj	_	_
 62	go	go	ADP	Cmpd	PrepForm=Cmpd	64	case	_	_
 63	dtí	dtí	ADP	Cmpd	Form=Ecl	62	fixed	_	_
-64	doras	doras	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	60	obl	_	_
+64	doras	doras	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	60	obl	_	_
 65	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	66	det	_	_
 66	bhflaitheas	flaitheas	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	64	nmod	_	SpaceAfter=No
 67	.	.	PUNCT	.	_	7	punct	_	_
@@ -10973,7 +10973,7 @@
 # sent_id = 430
 # text = Tá Bealach a' Choin Ghlais, an caolas idir Lunga agus Sgarba ag dul thart le Eilean a' Bhealaich chomh contúirteach le Coire Bhreacháin atá idir Sgarba agus Eilean Diùra an áit a raibh an sgríobhnóir George Orwell fá aon do bheith báite.
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
-2	Bealach	bealach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Bealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	Choin	Choin	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 5	Ghlais	glas	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	4	amod	_	NamedEntity=Yes|SpaceAfter=No
@@ -11100,8 +11100,8 @@
 
 # sent_id = 435
 # text = Suirbhéireacht Ordanáis Éireann, Rehab Group, Irish Shell, Sportsfile, Tesco Ireland agus The Yard.
-1	Suirbhéireacht	suirbhéireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	NamedEntity=Yes
-2	Ordanáis	ordanás	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+1	Suirbhéireacht	suirbhéireacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	NamedEntity=Yes
+2	Ordanáis	ordanás	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	Éireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	Rehab	Rehab	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
@@ -11200,7 +11200,7 @@
 6	rudaí	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	obj	_	_
 7	dúinn	do	ADP	Prep	Number=Plur|Person=1	2	obl:prep	_	_
 8	faoi	faoi	ADP	Simp	_	9	case	_	_
-9	ghnó	gnó	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
+9	ghnó	gnó	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	cheoil	ceol	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 12	idir	idir	ADP	Simp	_	13	case	_	_
@@ -11233,7 +11233,7 @@
 12	scéalta	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	8	obl	_	_
 13	seo	seo	DET	Det	PronType=Dem	12	det	_	_
 14	Mháire	Máire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
-15	rian	rian	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nsubj	_	_
+15	rian	rian	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
 16	seo	seo	DET	Det	PronType=Dem	15	det	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
 18	healaíne	ealaín	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	15	nmod	_	_
@@ -11365,7 +11365,7 @@
 # text = Tuairisc ar limistéir thuaithe cháilitheacha Shligigh.
 1	Tuairisc	tuairisc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	ar	ar	ADP	Simp	_	3	case	_	_
-3	limistéir	limistéar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	nmod	_	_
+3	limistéir	limistéar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	nmod	_	_
 4	thuaithe	tuath	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 5	cháilitheacha	cáilitheach	ADJ	Adj	Case=NomAcc|Form=Len|NounType=Slender|Number=Plur	4	amod	_	_
 6	Shligigh	Sligeach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	SpaceAfter=No
@@ -11418,7 +11418,7 @@
 3	múnla	múnla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 4	réadúil	réadúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
-6	ghníomhaíochtaí	gníomhaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	3	nmod	_	_
+6	ghníomhaíochtaí	gníomhaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	3	nmod	_	_
 7	Phípí	Pípí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
 9	phríomhchathair	príomhchathair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
@@ -11460,7 +11460,7 @@
 17	,	,	PUNCT	Punct	_	15	punct	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	in	i	ADP	Simp	_	20	case	_	_
-20	iarmairt	iarmairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	conj	_	_
+20	iarmairt	iarmairt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	conj	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	ghnímh	gníomh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
 23	sin	sin	DET	Det	PronType=Dem	22	det	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -1051,7 +1051,7 @@
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	NamedEntity=Yes
 21	bPoc	poc	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
-23	Contae	contae	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+23	Contae	contae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 24	Chiarraí	Chiarraí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes|SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2034,9 +2034,9 @@
 1	Thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	Tiarna	tiarna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-4	Longueville	longueville	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes|SpaceAfter=No
+4	Longueville	Longueville	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Co.	Co.	PROPN	Abr	Abbr=Yes	3	nmod	_	NamedEntity=Yes
+6	Co.	contae	NOUN	Abr	Abbr=Yes	3	nmod	_	NamedEntity=Yes
 7	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	6	punct	_	_
 9	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
@@ -3061,8 +3061,8 @@
 3	ansin	ansin	ADV	Loc	_	1	advmod	_	_
 4	fríd	fríd	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Eastát	eastát	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-7	Tionsclaíocha	tionsclaíocht	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
+6	Eastát	eastát	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+7	Tionsclaíocha	tionsclaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing|Typo=Yes	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 126
@@ -3714,7 +3714,7 @@
 2	le	le	ADP	Simp	_	3	case	_	_
 3	Maidhc	Maidhc	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	Ó	ó	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Seachnasaí	seachnasaí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+5	Seachnasaí	Seachnasaí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 153
@@ -4401,7 +4401,7 @@
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	Cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	11	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	Co.	contae	PROPN	Abr	Abbr=Yes	13	nmod	_	NamedEntity=Yes
+15	Co.	contae	NOUN	Abr	Abbr=Yes	11	nmod	_	NamedEntity=Yes
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	NamedEntity=Yes
 17	Chláir	Chláir	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
@@ -5311,7 +5311,7 @@
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	3	nmod	_	_
 3	Dearbhla	Dearbhla	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	Ní	ní	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Bhrolacháin	bhrolachán	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
+5	Bhrolacháin	Brolachán	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	mark:prt	_	_
 7	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
@@ -5532,8 +5532,8 @@
 # sent_id = 231
 # text = Máirseach Sergeant major de bhean.
 1	Máirseach	máirseach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	NamedEntity=Yes
-2	Sergeant	Sergeant	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	1	nmod	_	NamedEntity=Yes
-3	major	major	PROPN	Foreign	Foreign=Yes	2	nmod	_	_
+2	Sergeant	Sergeant	X	Foreign	Foreign=Yes	1	nmod	_	NamedEntity=Yes
+3	major	major	X	Foreign	Foreign=Yes	2	flat:foreign	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
 5	bhean	bean	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
@@ -5682,7 +5682,7 @@
 15	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
 16	Tí	tí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Chulainn	Culann	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
-18	Co.	contae	PROPN	Abr	Abbr=Yes	17	nmod	_	NamedEntity=Yes
+18	Co.	contae	NOUN	Abr	Abbr=Yes	17	nmod	_	NamedEntity=Yes
 19	Ard	Ard	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 20	Mhacha	Mhacha	PROPN	Noun	_	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	_	_
@@ -6187,7 +6187,7 @@
 8	Cliath	Cliath	PROPN	Noun	_	7	nmod	_	NamedEntity=Yes|SpaceAfter=No
 9	)	)	PUNCT	Punct	_	6	punct	_	_
 10	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Ceoláras	áras	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+11	Ceoláras	ceoláras	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 12	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	11	amod	_	NamedEntity=Yes
 13	(	(	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
 14	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
@@ -6480,7 +6480,7 @@
 14	,	,	PUNCT	Punct	_	16	punct	_	_
 15	a	a	PART	Voc	PartType=Voc	16	case:voc	_	_
 16	mhaca	mac	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Plur	11	vocative	_	_
-17	Uisnigh	Uisnigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
+17	Uisnigh	Uisneach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	agus	agus	CCONJ	Coord	_	21	cc	_	_
 20	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	21	cop	_	_
@@ -6878,7 +6878,7 @@
 1	A	a	PART	Voc	PartType=Voc	2	case:voc	_	_
 2	Phádraig	Pádraig	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc	5	vocative	_	NamedEntity=Yes
 3	Uí	uí	PART	Pat	PartType=Pat	2	flat:name	_	NamedEntity=Yes
-4	Chaiticín	chaiticín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+4	Chaiticín	Caiticín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 5	beirim	beir	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	sbhae	svae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
@@ -7679,7 +7679,7 @@
 23	Tony	Tony	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
 24	Linnane	Linnane	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Breándán	breándán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+26	Breándán	Breándán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
 27	Ó	ó	PART	Pat	PartType=Pat	26	flat:name	_	NamedEntity=Yes
 28	Beaglaoich	Beaglaoich	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	30	punct	_	_
@@ -7824,7 +7824,7 @@
 16	éadaitheoir	éadaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
 17	olla	olann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	Liobartaí	lioba	PROPN	Noun	_	10	obl	_	_
+19	Liobartaí	Liobartaí	PROPN	Noun	_	10	obl	_	_
 20	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	Cliath	Cliath	PROPN	Noun	_	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -8249,7 +8249,7 @@
 38	i	i	ADP	Simp	_	39	case	_	_
 39	gCill	Cill	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	34	nmod	_	NamedEntity=Yes
 40	Iníon	iníon	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	39	nmod	_	NamedEntity=Yes
-41	Léinín	léan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	40	nmod	_	NamedEntity=Yes|SpaceAfter=No
+41	Léinín	Léinín	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	40	nmod	_	NamedEntity=Yes|SpaceAfter=No
 42	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 323
@@ -8549,7 +8549,7 @@
 12	Mhainistir	mainistir	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Gender=Masc	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
-15	Co.	contae	PRON	Abr	Abbr=Yes	12	nmod	_	NamedEntity=Yes
+15	Co.	contae	NOUN	Abr	Abbr=Yes	12	nmod	_	NamedEntity=Yes
 16	Chill	Cill	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	Dara	Dara	PROPN	Noun	_	16	nmod	_	NamedEntity=Yes
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
@@ -9861,8 +9861,8 @@
 4	eile	eile	DET	Det	PronType=Dem	3	det	_	_
 5	siar	siar	ADV	Dir	_	3	advmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
-7	Johnny	johnny	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
-8	Rua	Rua	PROPN	Noun	Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+7	Johnny	Johnny	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+8	Rua	Rua	ADJ	Adj	Gender=Masc|Number=Sing	7	amod	_	NamedEntity=Yes|SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 387

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -1,14 +1,14 @@
 # sent_id = 1
 # text = Crothnófar Pól nó ba úrlabhraí maith é ar Raidió na Gaeltachta agus na meáin eile ag cosaint na n-oifigí poist tuaithe, gné am-tábhachtach de shaol sóisialta na ndaoine.
 1	Crothnófar	cronaigh	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
-2	Pól	Pól	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
+2	Pól	Pól	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 3	nó	nó	SCONJ	Subord	_	5	mark	_	_
 4	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	5	cop	_	_
 5	úrlabhraí	urlabhraí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	1	advcl	_	_
 6	maith	maith	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	5	amod	_	_
 7	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	_
 8	ar	ar	ADP	Simp	_	9	case	_	_
-9	Raidió	raidió	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
+9	Raidió	raidió	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	NamedEntity=Yes
 11	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
 12	agus	agus	CCONJ	Coord	_	14	cc	_	_
@@ -18,7 +18,7 @@
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	cosaint	cosaint	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 18	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	n-oifigí	oifig	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	17	obj	_	_
+19	n-oifigí	oifig	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	17	obj	_	_
 20	poist	post	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	compound	_	_
 21	tuaithe	tuath	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
@@ -28,7 +28,7 @@
 26	shaol	saol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	sóisialta	sóisialta	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	26	amod	_	_
 28	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
-29	ndaoine	duine	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	26	nmod	_	SpaceAfter=No
+29	ndaoine	duine	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	26	nmod	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 2
@@ -43,7 +43,7 @@
 8	siorc	siorc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 9	eile	eile	DET	Det	PronType=Dem	8	det	_	_
 10	óna	ó	ADP	Poss	Number=Plur|Person=3|Poss=Yes	11	case	_	_
-11	scoilteanna	scoilt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	5	nmod	_	_
+11	scoilteanna	scoilt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	5	nmod	_	_
 12	fada	fada	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Plur	11	amod	_	_
 13	geolbhaigh	geolbhach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
@@ -81,18 +81,18 @@
 8	bhfaca	feic	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	2	advcl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	tSiúr	siúr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	nsubj	_	NamedEntity=Yes
-11	Concepta	Concepta	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
+11	Concepta	Concepta	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	tréadaí	tréadaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obj	_	_
-14	Eoin	Eoin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	NamedEntity=Yes
+14	Eoin	Eoin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	appos	_	NamedEntity=Yes
 15	Mac	mac	PART	Pat	PartType=Pat	14	flat:name	_	NamedEntity=Yes
-16	Diarmada	Diarmaid	PROPN	Noun	Case=Gen|Gender=Masc	14	flat:name	_	NamedEntity=Yes
+16	Diarmada	Diarmaid	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	14	flat:name	_	NamedEntity=Yes
 17	ag	ag	ADP	Simp	_	18	case	_	_
 18	bailiú	bailiú	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
 19	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	18	obl:prep	_	_
 20	ag	ag	ADP	Simp	_	22	case	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	mbreacsholas	breacsholas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
+22	mbreacsholas	breacsholas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	2	punct	_	_
 24	níorbh	is	AUX	Cop	Form=VF|Polarity=Neg|Tense=Past|VerbForm=Cop	25	cop	_	_
 25	aistí	aisteach	ADJ	Adj	Degree=Cmp,Sup	0	root	_	_
@@ -106,9 +106,9 @@
 33	le	le	ADP	Simp	_	34	case	_	_
 34	feiceáil	feiceáil	NOUN	Noun	VerbForm=Inf	32	xcomp	_	_
 35	i	i	ADP	Simp	_	36	case	_	_
-36	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	34	obl	_	NamedEntity=Yes
+36	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	34	obl	_	NamedEntity=Yes
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	NamedEntity=Yes
-38	dTor	tor	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	36	nmod	_	NamedEntity=Yes
+38	dTor	tor	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	36	nmod	_	NamedEntity=Yes
 39	níos	níos	PART	Cmp	PartType=Comp	40	mark:prt	_	_
 40	faide	fada	ADJ	Adj	Degree=Cmp,Sup	34	advmod	_	_
 41	anonn	anonn	ADV	Dir	_	34	advmod	_	_
@@ -131,27 +131,27 @@
 # text = Foireann: Robert de Niro, Kenneth Branagh, Tom Hulce, Helena Bonham-Carter, John Cleese, Ian Holm, Robert Hardy.
 1	Foireann	foireann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	3	punct	_	_
-3	Robert	Robert	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+3	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	de	de	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Niro	Niro	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+5	Niro	Niro	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-8	Branagh	Branagh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+7	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+8	Branagh	Branagh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
-10	Tom	Tom	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-11	Hulce	Hulce	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+10	Tom	Tom	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+11	Hulce	Hulce	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
-13	Helena	Helena	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-14	Bonham-Carter	Bonham-Carter	PROPN	Noun	Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+13	Helena	Helena	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+14	Bonham-Carter	Bonham-Carter	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
-16	John	John	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-17	Cleese	Cleese	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+16	John	John	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+17	Cleese	Cleese	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Ian	Ian	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-20	Holm	Holm	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Ian	Ian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+20	Holm	Holm	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	Robert	Robert	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-23	Hardy	Hardy	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+22	Robert	Robert	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+23	Hardy	Hardy	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 6
@@ -175,7 +175,7 @@
 17	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	18	det	_	_
 18	daltaí	dalta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	15	obl	_	_
 19	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	20	nmod:poss	_	_
-20	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	23	obj	_	_
+20	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	23	obj	_	_
 21	teangacha	teanga	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Strong|Number=Plur	20	nmod	_	_
 22	a	a	PART	Inf	PartType=Inf	23	mark	_	_
 23	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	15	xcomp	_	_
@@ -184,7 +184,7 @@
 
 # sent_id = 7
 # text = Cailín is ea í.
-1	Cailín	Cailín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Cailín	cailín	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	is	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	1	cop	_	_
 3	ea	ea	PRON	Pers	Number=Sing|Person=3	4	nmod	_	_
 4	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	1	nsubj	_	SpaceAfter=No
@@ -199,8 +199,8 @@
 5	imíodh	imigh	VERB	VI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 6	sealgairí	sealgaire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	5	nsubj	_	_
 7	go	go	ADP	Simp	_	8	case	_	_
-8	Corrán	corrán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
-9	Binne	beann	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
+8	Corrán	corrán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
+9	Binne	beann	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	ag	ag	ADP	Simp	_	11	case	_	_
 11	crochaireacht	crochaireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	xcomp	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
@@ -224,7 +224,7 @@
 5	an-tóir	an-tóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	uilig	uile	DET	Det	_	5	det	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
-8	Barcó	Barcó	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	_
+8	Barcó	Barcó	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 9	(	(	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
 10	de	de	ADP	Simp	_	8	appos	_	NamedEntity=Yes
 11	barra	barra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
@@ -246,11 +246,11 @@
 7	thabharfadh	tabhair	VERB	VTI	Form=Len|Mood=Cnd	3	acl:relcl	_	_
 8	treoir	treoir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obj	_	_
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	Taoiseach	taoiseach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+10	Taoiseach	taoiseach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 11	oiread	oiread	NOUN	Subst	Number=Sing	18	nsubj	_	_
 12	áirithe	áirithe	ADJ	Adj	Degree=Pos	11	amod	_	_
-13	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	15	case	_	_
-14	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
+13	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	case	_	_
+14	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
 15	Seanadóirí	seanadóir	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	14	nmod	_	_
 16	seisean	seisean	PRON	Pers	Gender=Masc|Number=Sing|Person=3|PronType=Emp	15	nmod	_	_
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
@@ -258,13 +258,13 @@
 19	lonnaithe	lonnaithe	ADJ	Adj	VerbForm=Part	18	xcomp:pred	_	_
 20	sna	i	ADP	Art	Number=Plur|PronType=Art	22	case	_	_
 21	Sé	sé	NUM	Num	NumType=Card	22	nummod	_	_
-22	Contae	contae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
+22	Contae	contae	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	obl	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 11
 # text = Plunket Greene.
-1	Plunket	Plunket	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-2	Greene	Greene	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+1	Plunket	Plunket	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+2	Greene	Greene	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 12
@@ -315,7 +315,7 @@
 19	fearr	maith	ADJ	Adj	Degree=Cmp,Sup	16	amod	_	_
 20	ar	ar	ADP	Simp	_	22	case	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	mbaile	baile	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
+22	mbaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
 23	?	?	PUNCT	?	_	5	punct	_	_
 
 # sent_id = 15
@@ -325,7 +325,7 @@
 3	de	de	ADP	Simp	_	4	case	_	_
 4	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Róimhe	Róimh	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
+6	Róimhe	Róimh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	nsubj	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	acl:relcl	_	_
 9	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	10	case	_	_
@@ -361,7 +361,7 @@
 21	dúirt	abair	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
 22	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	_
 23	lena	le	ADP	Poss	Poss=Yes	24	case	_	_
-24	mheangadh	meangadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
+24	mheangadh	meangadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
 25	milis	milis	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	24	amod	_	_
 26	nach	nach	PART	Vb	PartType=Vb|Polarity=Neg|PronType=Rel	27	mark:prt	_	_
 27	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	21	ccomp	_	_
@@ -377,9 +377,9 @@
 3	i	i	ADP	Simp	_	4	case	_	_
 4	gcead	cead	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	nmod	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
-6	George	George	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-7	Mackay	Mackay	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
-8	Brown	Brown	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+6	George	George	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+7	Mackay	Mackay	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
+8	Brown	Brown	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 18
@@ -389,7 +389,7 @@
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	nsubj	_	_
 4	theastaigh	teastaigh	VERB	VI	Form=Len|Mood=Ind|Tense=Past	2	acl:relcl	_	_
 5	ó	ó	ADP	Simp	_	6	case	_	_
-6	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
+6	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	uaim	ó	ADP	Prep	Number=Sing|Person=1	6	conj	_	_
 9	féin	féin	PRON	Ref	Reflex=Yes	8	nmod	_	_
@@ -414,10 +414,10 @@
 28	éirigh	éirigh	VERB	VI	Mood=Ind|Polarity=Neg|Tense=Past	11	conj	_	_
 29	leis	le	ADP	Simp	_	31	case	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
-31	bplean	plean	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
+31	bplean	plean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
 32	ag	ag	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
+34	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	11	punct	_	_
 
 # sent_id = 19
@@ -436,7 +436,7 @@
 3	eile	eile	DET	Det	PronType=Dem	2	det	_	_
 4	ag	ag	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Scéaltacht	scéaltacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
+6	Scéaltacht	scéaltacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 21
@@ -445,15 +445,15 @@
 2	fíor	fíor	ADJ	Adj	Degree=Pos	0	root	_	_
 3	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
 4	láidre	láidir	ADJ	Adj	Degree=Cmp,Sup	2	csubj:cop	_	_
-5	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	4	nsubj	_	NamedEntity=Yes
-6	Fáil	Fál	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
+5	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	4	nsubj	_	NamedEntity=Yes
+6	Fáil	Fál	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	cosaint	cosaint	NOUN	Noun	VerbForm=Vnoun	5	xcomp	_	_
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
 10	neodrachta	neodracht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	obj	_	_
 11	ná	ná	CCONJ	Coord	_	12	cc	_	_
-12	Fine	Fine	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	conj	_	NamedEntity=Yes
-13	Gael	Gael	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	12	nmod	_	NamedEntity=Yes
+12	Fine	Fine	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	conj	_	NamedEntity=Yes
+13	Gael	Gael	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	NamedEntity=Yes
 14	faoi	faoi	ADP	Simp	_	15	case	_	_
 15	láthair	láthair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obl	_	_
 16	agus	agus	CCONJ	Coord	_	22	cc	_	_
@@ -471,9 +471,9 @@
 28	a	a	PART	Vb	PartType=Vb|PronType=Rel	29	obj	_	_
 29	chuireann	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	27	acl:relcl	_	_
 30	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	nmod:poss	_	_
-31	cheannairí	ceannaire	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	29	nsubj	_	_
+31	cheannairí	ceannaire	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	29	nsubj	_	_
 32	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
-33	bpolasaí	polasaí	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	29	obl	_	_
+33	bpolasaí	polasaí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	29	obl	_	_
 34	náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	33	amod	_	_
 35	seo	seo	DET	Det	PronType=Dem	33	det	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	2	punct	_	_
@@ -483,7 +483,7 @@
 1	Sliogáin	sliogán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	6	obl	_	_
 2	Eile	eile	DET	Det	PronType=Dem	1	det	_	_
 3	Faoin	faoi	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
-4	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obl	_	_
+4	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 5	seo	seo	DET	Det	PronType=Dem	4	det	_	_
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 7	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	_
@@ -501,14 +501,14 @@
 19	mhaith	maith	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	18	amod	_	_
 20	de	de	ADP	Simp	_	22	case	_	_
 21	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	22	det	_	_
-22	hainmhithe	ainmhí	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	18	nmod	_	_
+22	hainmhithe	ainmhí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	18	nmod	_	_
 23	beaga	beag	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	22	amod	_	_
 24	a	a	PART	Vb	PartType=Vb|PronType=Rel	25	obj	_	_
 25	fheiceann	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	22	acl:relcl	_	_
 26	tú	tú	PRON	Pers	Number=Sing|Person=2	25	nsubj	_	_
 27	ar	ar	ADP	Simp	_	29	case	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
-29	gcladach	cladach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	SpaceAfter=No
+29	gcladach	cladach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 23
@@ -532,7 +532,7 @@
 
 # sent_id = 24
 # text = ART: Céard tá i gceist agat?
-1	ART	Art	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	dislocated	_	SpaceAfter=No
+1	ART	Art	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	dislocated	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	1	punct	_	_
 3	Céard	cé	PRON	Q	PronType=Int	0	root	_	_
 4	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	3	acl:relcl	_	_
@@ -547,7 +547,7 @@
 2	gá	gá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	leis	le	ADP	Simp	_	5	case	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	gcogadh	cogadh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+5	gcogadh	cogadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 6	sin	sin	DET	Det	PronType=Dem	5	det	_	_
 7	cé	cé	SCONJ	Subord	_	9	mark	_	_
 8	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	9	cop	_	_
@@ -584,7 +584,7 @@
 8	ó	ó	SCONJ	Subord	_	9	mark	_	_
 9	thuigeann	tuig	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	1	advcl	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	námha	námha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
+11	námha	námha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	13	cop	_	_
 13	anseo	anseo	ADV	Loc	_	9	ccomp	_	_
 14	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	13	csubj:cleft	_	_
@@ -592,7 +592,7 @@
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
 17	meanma	meanma	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	conj	_	_
 18	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	19	nmod:poss	_	_
-19	sárghluaiseachta	sárghluaiseacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	15	nmod	_	SpaceAfter=No
+19	sárghluaiseachta	sárghluaiseacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	15	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 27
@@ -600,16 +600,16 @@
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	teipthe	teipthe	ADJ	Adj	VerbForm=Part	1	nsubj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	Aodh	Aodh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+4	Aodh	Aodh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chath	cath	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	chath	cath	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	seo	seo	DET	Det	PronType=Dem	6	det	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 28
 # text = Chonaic Máire an fear a bhí ag iascaireacht.
 1	Chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Máire	Máire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+2	Máire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	fear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
@@ -629,7 +629,7 @@
 # text = Ar labhair Seán?
 1	Ar	ar	PART	Vb	PartType=Vb|Tense=Past	2	mark:prt	_	_
 2	labhair	labhair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-3	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
+3	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
 4	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 31
@@ -645,10 +645,10 @@
 9	a	a	PART	Vb	PartType=Vb|PronType=Rel	10	mark:prt	_	_
 10	deir	abair	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 11	Cumann	cumann	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	NamedEntity=Yes
-12	Fíoncheannaithe	Fíoncheannaithe	PROPN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	11	nmod	_	NamedEntity=Yes
-13	Bhaile	Baile	PROPN	Noun	Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
-14	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
-15	Cliath	Cliath	PROPN	Noun	_	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
+12	Fíoncheannaithe	Fíoncheannaithe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	11	nmod	_	NamedEntity=Yes
+13	Bhaile	Baile	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+14	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
+15	Cliath	Cliath	PROPN	Noun	Definite=Def	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	bíonn	bí	VERB	PresImp	Aspect=Hab|Mood=Ind|Tense=Pres	10	parataxis	_	_
 18	orthu	ar	ADP	Prep	Number=Plur|Person=3	17	obl:prep	_	_
@@ -675,8 +675,8 @@
 12	seoladh	seoladh	NOUN	Noun	VerbForm=Inf	5	xcomp	_	_
 13	chuig	chuig	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	gCúirt	cúirt	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
-16	Chéadchéime	céadchéim	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+15	gCúirt	cúirt	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
+16	Chéadchéime	céadchéim	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
 18	thaisceadh	taisceadh	NOUN	Noun	Form=Len|VerbForm=Inf	4	xcomp	_	_
 19	de	de	ADP	Simp	_	20	case	_	_
@@ -685,7 +685,7 @@
 22	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	Cúirte	cúirt	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	NamedEntity=Yes
-25	Breithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
+25	Breithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 26	,	,	PUNCT	Punct	_	4	punct	_	_
 27	déanfaidh	déan	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
@@ -703,7 +703,7 @@
 40	;	;	PUNCT	Punct	_	43	punct	_	_
 41	mar	mar	ADP	Simp	_	43	case	_	_
 42	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	43	det	_	_
-43	gcéanna	céanna	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	46	obl	_	SpaceAfter=No
+43	gcéanna	céanna	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	46	obl	_	SpaceAfter=No
 44	,	,	PUNCT	Punct	_	43	punct	_	_
 45	má	má	SCONJ	Subord	_	46	mark	_	_
 46	dhéantar	déan	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	69	advcl	_	_
@@ -717,8 +717,8 @@
 54	seoladh	seoladh	NOUN	Noun	VerbForm=Inf	47	xcomp	_	_
 55	chuig	chuig	ADP	Simp	_	57	case	_	_
 56	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
-57	gCúirt	cúirt	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	54	nmod	_	NamedEntity=Yes
-58	Bhreithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
+57	gCúirt	cúirt	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	54	nmod	_	NamedEntity=Yes
+58	Bhreithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
 59	a	a	PART	Inf	PartType=Inf	60	mark	_	_
 60	thaisceadh	taisceadh	NOUN	Noun	Form=Len|VerbForm=Inf	46	xcomp	_	_
 61	de	de	ADP	Simp	_	62	case	_	_
@@ -731,7 +731,7 @@
 68	,	,	PUNCT	Punct	_	46	punct	_	_
 69	déanfaidh	déan	VERB	VTI	Mood=Ind|Tense=Fut	27	parataxis	_	_
 70	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	71	det	_	_
-71	Chláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	69	nsubj	_	_
+71	Chláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	69	nsubj	_	_
 72	sin	sin	DET	Det	PronType=Dem	71	det	_	_
 73	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	75	obj	_	_
 74	a	a	PART	Inf	PartType=Inf	75	mark	_	_
@@ -757,13 +757,13 @@
 # sent_id = 34
 # text = den Chonradh seo, de réir an réimse i dtrácht, agus go bhfuil sé údaraithe ag an gComhairle i gcomhréir leis na nósanna imeachta atá leagtha síos iontu.
 1	den	de	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+2	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 3	seo	seo	DET	Det	PronType=Dem	2	det	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	de	de	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 6	réir	réir	ADP	Cmpd	_	5	fixed	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	réimse	réimse	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	conj	_	_
+8	réimse	réimse	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	conj	_	_
 9	i	i	ADP	Simp	_	10	case	_	_
 10	dtrácht	trácht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
@@ -774,7 +774,7 @@
 16	údaraithe	údaraithe	ADJ	Adj	VerbForm=Part	14	xcomp:pred	_	_
 17	ag	ag	ADP	Simp	_	19	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
-19	gComhairle	comhairle	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	_
+19	gComhairle	comhairle	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
 21	gcomhréir	comhréir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	_
 22	leis	le	ADP	Simp	_	24	case	_	_
@@ -794,14 +794,14 @@
 3	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
 4	bráithre	bráthair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	nmod	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	fhrainc	Frainc	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
+6	fhrainc	Frainc	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 36
 # text = Cnocán an Ultaigh atá ar an reilig mar gur Ultach fir an chéad duine a cuireadh inti, de réir an tseanchais.
-1	Cnocán	cnocán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Cnocán	cnocán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	NamedEntity=Yes
-3	Ultaigh	Ultaigh	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+3	Ultaigh	Ultach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	1	csubj:cleft	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
@@ -812,7 +812,7 @@
 11	fir	fear	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 13	chéad	céad	NUM	Num	Form=Len|NumType=Ord	14	amod	_	_
-14	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nsubj	_	_
+14	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	obj	_	_
 16	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	14	acl:relcl	_	_
 17	inti	i	ADP	Prep	Gender=Fem|Number=Sing|Person=3	16	obl:prep	_	SpaceAfter=No
@@ -836,18 +836,18 @@
 5	thar	thar	ADP	Simp	_	6	case	_	_
 6	fóir	fóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nmod	_	_
 7	sa	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	chuntas	cuntas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+8	chuntas	cuntas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 9	seo	seo	DET	Det	PronType=Dem	8	det	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	nsubj	_	_
 11	leanas	lean	VERB	VTI	Mood=Ind|PronType=Rel|Tense=Pres	8	acl:relcl	_	_
 12	ó	ó	ADP	Simp	_	13	case	_	_
-13	Sheán	Seán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-14	Sheáin	Seáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
+13	Sheán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+14	Sheáin	Seáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
 15	Í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	flat:name	_	NamedEntity=Yes
-16	Chearnaigh	Cearnaigh	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
+16	Chearnaigh	Cearnaigh	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
 17	ar	ar	ADP	Simp	_	19	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
-19	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
+19	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 20	seo	seo	DET	Det	PronType=Dem	19	det	_	_
 21	ach	ach	SCONJ	Subord	_	23	mark	_	_
 22	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
@@ -873,10 +873,10 @@
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	as	as	ADP	Simp	_	9	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Dublin	Dublin	PROPN	Noun	_	2	obl	_	NamedEntity=Yes
-7	and	and	CCONJ	Coord	_	6	flat:foreign	_	NamedEntity=Yes
-8	Banagher	Banagher	PROPN	Noun	_	6	flat:foreign	_	NamedEntity=Yes
-9	Distillery	Distillery	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	flat:foreign	_	NamedEntity=Yes
+6	Dublin	Dublin	X	Foreign	Foreign=Yes	2	obl	_	NamedEntity=Yes
+7	and	and	X	Foreign	Foreign=Yes	6	flat:foreign	_	NamedEntity=Yes
+8	Banagher	Banagher	X	Foreign	Foreign=Yes	6	flat:foreign	_	NamedEntity=Yes
+9	Distillery	Distillery	X	Foreign	Foreign=Yes	6	flat:foreign	_	NamedEntity=Yes
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
 11	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
 12	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	11	nsubj	_	_
@@ -886,7 +886,7 @@
 16	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
 17	leis	le	ADP	Simp	_	19	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
-19	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
+19	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 40
@@ -894,14 +894,14 @@
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	2	cop	_	_
 2	mhaith	maith	ADJ	Adj	Degree=Pos|Form=Len	0	root	_	_
 3	le	le	ADP	Simp	_	4	case	_	_
-4	Smyllie	Smyllie	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
+4	Smyllie	Smyllie	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 5	go	go	PART	Vb	PartType=Cmpl	6	mark:prt	_	_
 6	nglacfadh	glac	VERB	VT	Form=Ecl|Mood=Cnd	2	csubj:cop	_	_
 7	Protastúnaigh	Protastúnach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	6	nsubj	_	_
 8	páirt	páirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obj	_	_
 9	chuí	cuí	ADJ	Adj	Degree=Pos|Form=Len	8	amod	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	saol	saol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obl	_	_
+11	saol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 12	phoiblí	poiblí	ADJ	Adj	Degree=Pos|Form=Len	11	amod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -950,7 +950,7 @@
 2	mian	mian	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
 3	linn	le	ADP	Prep	Number=Plur|Person=1	2	obl:prep	_	_
 4	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	mbuíochas	buíochas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	7	obj	_	_
+5	mbuíochas	buíochas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	7	obj	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 8	in	i	ADP	Simp	_	9	case	_	_
@@ -958,15 +958,15 @@
 10	go	go	PART	Ad	PartType=Ad	11	mark:prt	_	_
 11	háirithe	áirithe	ADJ	Adj	Degree=Pos|Form=HPref	7	advmod	_	_
 12	do	do	ADP	Simp	_	13	case	_	_
-13	Sheán	Seán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+13	Sheán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 14	Ó	ó	PART	Pat	PartType=Pat	13	flat:name	_	NamedEntity=Yes
-15	Gallchóir	Gallchóir	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+15	Gallchóir	Gallchóir	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	Stiúrthóir	stiúrthóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	appos	_	_
 18	Ginearálta	ginearálta	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	17	amod	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	Fhorais	foras	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
-21	Riaracháin	riarachán	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	Fhorais	foras	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+21	Riaracháin	riarachán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	nsubj	_	_
 24	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	17	acl:relcl	_	_
@@ -986,12 +986,12 @@
 5	drúcht	drúcht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	d'	do	DET	Det	Number=Sing|Person=2|Poss=Yes	8	nmod:poss	_	SpaceAfter=No
-8	aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
+8	aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	shín	sín	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 11	tú	tú	PRON	Pers	Number=Sing|Person=2	10	nsubj	_	_
 12	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	13	nmod:poss	_	_
-13	lámha	lámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	10	obj	_	_
+13	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	10	obj	_	_
 14	chugam	chuig	ADP	Prep	Number=Sing|Person=1	10	obl:prep	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1013,7 +1013,7 @@
 14	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	10	csubj:cleft	_	_
 15	orthu	ar	ADP	Prep	Number=Plur|Person=3	14	obl:prep	_	_
 16	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	17	nmod:poss	_	_
-17	ngnó	gnó	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	obj	_	_
+17	ngnó	gnó	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	19	obj	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	14	xcomp	_	_
 20	le	le	ADP	Simp	_	21	case	_	_
@@ -1033,26 +1033,26 @@
 2	agus	agus	CCONJ	Coord	_	3	cc	_	_
 3	craoltóir	craoltóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
 4	le	le	ADP	Simp	_	5	case	_	_
-5	Raidió	raidió	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+5	Raidió	raidió	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	NamedEntity=Yes
 7	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
-9	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
-10	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-11	Cliath	Cliath	PROPN	Noun	_	10	nmod	_	NamedEntity=Yes
+9	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
+10	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+11	Cliath	Cliath	PROPN	Noun	Definite=Def	10	nmod	_	NamedEntity=Yes
 12	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	nmod	_	_
-13	Seosaimhín	Seosaimhín	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
+13	Seosaimhín	Seosaimhín	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
 14	Ní	ní	PART	Pat	PartType=Pat	13	flat:name	_	NamedEntity=Yes
-15	Bheaglaoich	Beaglaoich	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
+15	Bheaglaoich	Beaglaoich	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	obj	_	_
 17	tógadh	tóg	VERB	VTI	Mood=Ind|Person=0|Tense=Past	13	acl:relcl	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	NamedEntity=Yes
+19	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	NamedEntity=Yes
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	NamedEntity=Yes
 21	bPoc	poc	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
 23	Contae	contae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
-24	Chiarraí	Chiarraí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes|SpaceAfter=No
+24	Chiarraí	Chiarraí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes|SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 47
@@ -1074,7 +1074,7 @@
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
 16	Ghaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	obj	_	_
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
-18	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	12	xcomp	_	_
+18	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	12	xcomp	_	_
 19	chun	chun	ADP	Simp	_	20	case	_	_
 20	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 21	,	,	PUNCT	Punct	_	5	punct	_	_
@@ -1092,7 +1092,7 @@
 33	teanga	teanga	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	29	obl	_	_
 34	le	le	ADP	Cmpd	PrepForm=Cmpd	36	case	_	_
 35	linn	linn	ADP	Cmpd	_	34	fixed	_	_
-36	Seachtain	seachtain	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	29	nmod	_	NamedEntity=Yes
+36	Seachtain	seachtain	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	29	nmod	_	NamedEntity=Yes
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	NamedEntity=Yes
 38	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	36	nmod	_	NamedEntity=Yes
 39	idir	idir	ADP	Simp	_	45	case	_	_
@@ -1101,7 +1101,7 @@
 42	agus	agus	CCONJ	Coord	_	44	cc	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	17ú	17	NUM	Num	NumType=Ord	41	conj	_	_
-45	Márta	Márta	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
+45	Márta	Márta	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 46	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 48
@@ -1110,7 +1110,7 @@
 2	COMHAONTUITHE	comhaontú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	5	nmod	_	_
 3	FAOI	faoi	ADP	Simp	_	4	case	_	_
 4	SHAINCHEADU	saincheadú	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	2	nmod	_	_
-5	Comharsain	Comharsain	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
+5	Comharsain	comharsa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 6	aoibhne	aoibhinn	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Plur	5	amod	_	_
 7	ab	is	AUX	Cop	Form=VF|PronType=Rel|Tense=Past|VerbForm=Cop	5	cop	_	_
 8	ea	ea	PRON	Pers	Number=Sing|Person=3	9	nmod	_	_
@@ -1208,7 +1208,7 @@
 2	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nmod	_	_
 3	ar	ar	ADP	Simp	_	5	case	_	_
 4	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	sáil	sáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+5	sáil	sáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 6	d'	do	PART	Vb	PartType=Vb	8	case	_	SpaceAfter=No
 7	aon	aon	DET	Det	PronType=Ind	8	det	_	_
 8	chéim	céim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
@@ -1224,7 +1224,7 @@
 6	áfach	áfach	ADV	Gn	_	2	advmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	6	punct	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	nmod:poss	_	_
-9	mheon	meon	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obj	_	_
+9	mheon	meon	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	obj	_	_
 10	cathrach	cathair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
 11	sofaisticiúil	sofaisticiúil	ADJ	Adj	Degree=Pos	9	amod	_	_
 12	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
@@ -1251,7 +1251,7 @@
 33	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	appos	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
 35	18ú	18	NUM	Num	NumType=Ord	36	amod	_	_
-36	céad	céad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
+36	céad	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 52
@@ -1262,7 +1262,7 @@
 4	nach	is	AUX	Cop	Polarity=Neg|PronType=Rel|Tense=Pres|VerbForm=Cop	3	cop	_	_
 5	beag	beag	ADJ	Adj	Degree=Pos	2	acl:relcl	_	_
 6	sa	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	ghairm	gairm	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	xcomp:pred	_	_
+7	ghairm	gairm	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	xcomp:pred	_	_
 8	bheatha	beatha	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	7	compound	_	_
 9	seo	seo	DET	Det	PronType=Dem	7	det	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
@@ -1273,8 +1273,8 @@
 15	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	2	xcomp	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	tabhairt	tabhairt	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
-18	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	20	nmod:poss	_	_
-19	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	17	obj	_	_
+18	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	19	nmod:poss	_	_
+19	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	17	obj	_	_
 20	oibre	obair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
 21	abhaile	abhaile	ADV	Dir	_	17	advmod	_	_
 22	liom	le	ADP	Prep	Number=Sing|Person=1	17	obl:prep	_	SpaceAfter=No
@@ -1297,21 +1297,21 @@
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	obj	_	_
 14	thugtar	tabhair	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	12	acl:relcl	_	_
 15	san	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	Bhíobla	Bíobla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
+16	Bhíobla	Bíobla	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
 17	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	bhithiúnach	bithiúnach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
+18	bhithiúnach	bithiúnach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 19	:	:	PUNCT	Punct	_	21	punct	_	_
 20	'	'	PUNCT	Punct	_	21	punct	_	SpaceAfter=No
 21	Dá	dá	SCONJ	Subord	_	23	mark	_	_
 22	mb'	is	AUX	Cop	Form=Ecl,VF|Tense=Past|VerbForm=Cop	23	cop	_	SpaceAfter=No
 23	eol	eol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	36	advcl	_	_
 24	don	do	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	fhear	fear	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+25	fhear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 26	tí	teach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
 27	cén	cé	PRON	Q	Number=Sing|PronType=Int	23	ccomp	_	_
 28	t-am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	nsubj	_	_
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
-30	oíche	oíche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	nmod	_	_
+30	oíche	oíche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	28	nmod	_	_
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	obl	_	_
 32	dtiocfadh	tar	VERB	VI	Form=Ecl|Mood=Cnd	28	acl:relcl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
@@ -1363,19 +1363,19 @@
 4	bhuíon	buíon	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 5	de	de	ADP	Simp	_	8	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
-7	Sherwood	Sherwood	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
-8	Foresters	Foresters	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Sherwood	Sherwood	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+8	Foresters	Foresters	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	droichead	droichead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
-11	Shráid	sráid	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+11	Shráid	sráid	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
-13	Mhóta	Móta	PROPN	Noun	Form=Len	11	nmod	_	NamedEntity=Yes
+13	Mhóta	Móta	PROPN	Noun	Definite=Def|Form=Len	11	nmod	_	NamedEntity=Yes
 14	agus	agus	CCONJ	Coord	_	15	cc	_	_
 15	iad	iad	PRON	Pers	Number=Plur|Person=3	1	conj	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	iarraidh	iarraidh	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
 18	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	mbealach	bealach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	obj	_	_
+19	mbealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	21	obj	_	_
 20	a	a	PART	Inf	PartType=Inf	21	mark	_	_
 21	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	17	xcomp	_	_
 22	isteach	isteach	ADV	Dir	_	21	advmod	_	_
@@ -1384,8 +1384,8 @@
 25	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
 26	cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	24	nmod	_	_
 27	ó	ó	ADP	Simp	_	28	case	_	_
-28	Dhún	dún	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
-29	Laoghaoire	Laoghaoire	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes|SpaceAfter=No
+28	Dhún	dún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
+29	Laoghaoire	Laoghaoire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes|SpaceAfter=No
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	appos	_	_
 32	ar	ar	PART	Vb	PartType=Vb|PronType=Rel|Tense=Past	33	obl	_	_
@@ -1399,11 +1399,11 @@
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 3	dá	dó	NUM	Num	Definite=Def|NumType=Card	4	nummod	_	_
-4	shloinne	sloinne	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
+4	shloinne	sloinne	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Corvin	Corvin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	appos	_	_
+6	Corvin	Corvin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	appos	_	_
 7	&	agus	CCONJ	Coord	_	8	cc	_	_
-8	Thornbury	Thornbury	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	_
+8	Thornbury	Thornbury	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 9	neamhchoitianta	neamhchoitianta	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 10	go	go	ADJ	Adj	_	9	amod	_	_
 11	leor	leor	ADJ	Adj	_	10	fixed	_	_
@@ -1413,7 +1413,7 @@
 15	strainséar	strainséar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	toirt	toirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nmod	_	_
+18	toirt	toirt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	_
 19	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	20	cop	_	_
 20	Fhíníní	Fínín	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	14	ccomp	_	_
 21	iad	iad	PRON	Pers	Number=Plur|Person=3	20	nsubj	_	SpaceAfter=No
@@ -1423,9 +1423,9 @@
 # text = Is é Micheal D. Higgins ba chionsiocair leis an Roinn a bhunú sa bhliain 1992.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nmod	_	_
-3	Micheal	Micheal	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	Micheal	Micheal	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	D.	D.	PROPN	Abr	Abbr=Yes	3	flat:name	_	NamedEntity=Yes
-5	Higgins	Higgins	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
+5	Higgins	Higgins	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 6	ba	is	AUX	Cop	PronType=Rel|Tense=Past|VerbForm=Cop	7	cop	_	_
 7	chionsiocair	cionsiocair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	csubj:cleft	_	_
 8	leis	le	ADP	Simp	_	12	case	_	_
@@ -1448,7 +1448,7 @@
 
 # sent_id = 60
 # text = Oighe chuimealta a bhíos aige leis an obair is fíneálta a dhéanamh.
-1	Oighe	Oighe	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Oighe	oighe	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	chuimealta	cuimealta	ADJ	Adj	Form=Len|VerbForm=Part	1	amod	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
 4	bhíos	bí	VERB	PresImp	Aspect=Hab|Form=Len|Mood=Ind|Tense=Pres	1	csubj:cleft	_	_
@@ -1470,7 +1470,7 @@
 4	dorcha	dorcha	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 5	ag	ag	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+7	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	stop	stop	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
 10	Garda	garda	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
@@ -1483,7 +1483,7 @@
 17	acu	ag	ADP	Prep	Number=Plur|Person=3	14	obl:prep	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-20	rothair	rothar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	16	nmod	_	SpaceAfter=No
+20	rothair	rothar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	16	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 62
@@ -1500,36 +1500,36 @@
 1	Nuair	nuair	SCONJ	Subord	_	3	mark	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	16	advcl	_	_
-4	Sáraid	Sáraid	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	_
+4	Sáraid	Sáraid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	6	nmod:poss	_	_
-6	clann	clann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obj	_	_
+6	clann	clann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	obj	_	_
 7	chuici	chuig	ADP	Prep	Gender=Fem|Number=Sing|Person=3	6	nmod	_	_
 8	agus	agus	SCONJ	Subord	_	9	mark	_	_
 9	iad	iad	PRON	Pers	Number=Plur|Person=3	3	nsubj	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
 11	brath	brath	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 12	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	13	det	_	_
-13	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
+13	fear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	mharú	marú	NOUN	Noun	Form=Len|VerbForm=Inf	11	xcomp	_	_
 16	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 17	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	16	nsubj	_	_
 18	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	lámha	lámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	16	obj	_	_
+19	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	16	obj	_	_
 20	fána	faoi	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	21	case	_	_
-21	chorp	corp	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
+21	chorp	corp	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
 22	agus	agus	CCONJ	Coord	_	24	cc	_	_
 23	d'	do	PART	Vb	PartType=Vb	24	mark:prt	_	SpaceAfter=No
 24	iarr	iarr	VERB	VT	Mood=Ind|Tense=Past	16	conj	_	_
 25	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	26	det	_	_
-26	choimirce	coimirce	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	24	obj	_	_
+26	choimirce	coimirce	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	24	obj	_	_
 27	orthu	ar	ADP	Prep	Number=Plur|Person=3	24	obl:prep	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	16	punct	_	_
 
 # sent_id = 64
 # text = Tá Adhamhnán ag meabhrú gurb iomchuí an t-ionad inar scoir an tAthair naofa sin, Colm Cille, de scríobh na altrach, is é sin, ag an véarsa a dúramar romhainn, óir ní bheidh uireasa na n-uile maitheas go síoraí suthain ar Cholm Cille....
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-2	Adhamhnán	Adhamhnán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Adhamhnán	Adhamhnán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	meabhrú	meabhrú	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 5	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	6	cop	_	_
@@ -1543,13 +1543,13 @@
 13	naofa	naofa	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	12	amod	_	_
 14	sin	sin	DET	Det	PronType=Dem	12	det	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
-16	Colm	Colm	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	appos	_	NamedEntity=Yes
-17	Cille	cill	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+16	Colm	Colm	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	appos	_	NamedEntity=Yes
+17	Cille	cill	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
 19	de	de	ADP	Simp	_	20	case	_	_
 20	scríobh	scríobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl	_	_
 21	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	altrach	altrach	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
+22	altrach	altrach	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	25	punct	_	_
 24	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	25	cop	_	_
 25	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	parataxis	_	_
@@ -1568,13 +1568,13 @@
 38	uireasa	uireasa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	37	nsubj	_	_
 39	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	41	det	_	_
 40	n-uile	uile	DET	Det	Form=Ecl|PronType=Ind	41	det	_	_
-41	maitheas	maitheas	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	38	nmod	_	_
+41	maitheas	maitheas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	38	nmod	_	_
 42	go	go	PART	Ad	PartType=Ad	43	mark:prt	_	_
 43	síoraí	síoraí	ADJ	Adj	Degree=Pos	37	advmod	_	_
 44	suthain	suthain	ADJ	Adj	Degree=Pos	43	amod	_	_
 45	ar	ar	ADP	Simp	_	47	case	_	_
-46	Cholm	Colm	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	37	obl	_	NamedEntity=Yes
-47	Cille	cill	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	46	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+46	Cholm	Colm	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	37	obl	_	NamedEntity=Yes
+47	Cille	cill	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	46	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 48	...	...	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
 49	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1583,7 +1583,7 @@
 1	I	I	ADP	Simp	_	2	case	_	_
 2	nDáil	dáil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	0	root	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	bhFlaitheas	flaitheas	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	2	nmod	_	_
+4	bhFlaitheas	flaitheas	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	2	nmod	_	_
 5	go	go	PART	Vb	Mood=Sub|PartType=Vb	6	mark:prt	_	_
 6	raibh	bí	VERB	VI	Mood=Sub|Tense=Pres	2	csubj:cleft	_	_
 7	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	SpaceAfter=No
@@ -1592,12 +1592,12 @@
 # sent_id = 66
 # text = Beidh Michael Mullen sa bhunscoil i Lecanvey.
 1	Beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
-2	Michael	Michael	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Mullen	Mullen	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	2	flat:name	_	NamedEntity=Yes
+2	Michael	Michael	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Mullen	Mullen	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	2	flat:name	_	NamedEntity=Yes
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
 5	bhunscoil	bunscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	xcomp:pred	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	Lecanvey	Lecanvey	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
+7	Lecanvey	Lecanvey	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 67
@@ -1610,7 +1610,7 @@
 6	dhá	dó	NUM	Num	Form=Len|NumType=Card	7	nummod	_	_
 7	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	xcomp:pred	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	meá	meá	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
+9	meá	meá	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 10	mar	mar	SCONJ	Subord	_	12	mark	_	_
 11	go	go	PART	Vb	PartType=Cmpl	12	mark:prt	_	_
 12	rabhas	bí	VERB	PastInd	Mood=Ind|Number=Sing|Person=1|Tense=Past	3	advcl	_	_
@@ -1628,7 +1628,7 @@
 24	agus	agus	SCONJ	Subord	_	26	mark	_	_
 25	d'	do	PART	Vb	PartType=Vb	26	mark:prt	_	SpaceAfter=No
 26	aontaigh	aontaigh	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-27	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	nsubj	_	_
+27	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nsubj	_	_
 28	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	29	cop	_	_
 29	mar	mar	ADP	Simp	_	26	ccomp	_	_
 30	sin	sin	PRON	Dem	PronType=Dem	29	fixed	_	_
@@ -1660,7 +1660,7 @@
 56	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
 57	t-am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	54	nsubj	_	_
 58	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	59	det	_	_
-59	réiteach	réiteach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	61	obj	_	_
+59	réiteach	réiteach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	61	obj	_	_
 60	a	a	PART	Inf	PartType=Inf	61	mark	_	_
 61	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	57	xcomp	_	SpaceAfter=No
 62	;	;	PUNCT	Punct	_	63	punct	_	_
@@ -1678,12 +1678,12 @@
 # text = Níl a fhios agat cad é an éagóir orm é mé a choimeád anseo.
 1	Níl	bí	VERB	VI	Mood=Ind|Polarity=Neg|Tense=Pres	0	root	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	det	_	_
-3	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	fhios	fios	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	agat	ag	ADP	Prep	Number=Sing|Person=2	1	obl:prep	_	_
 5	cad	cad	PRON	Q	PronType=Int	1	ccomp	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nmod	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	éagóir	éagóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
+8	éagóir	éagóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	_
 9	orm	ar	ADP	Prep	Number=Sing|Person=1	8	obl:prep	_	_
 10	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nmod	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	13	obj	_	_
@@ -1736,14 +1736,14 @@
 22	ghaimh	gaimh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	_
 23	ghránna	gránna	ADJ	Adj	Degree=Pos|Form=Len	22	amod	_	_
 24	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	25	det	_	_
-25	chnis	cneas	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
+25	chnis	cneas	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 71
 # text = Foinse sa Rang.
 1	Foinse	foinse	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
 2	sa	i	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	Rang	rang	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
+3	Rang	rang	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 72
@@ -1776,16 +1776,16 @@
 
 # sent_id = 73
 # text = PÁIDÍ Cuir do lámh thar mo ghualainn, a sheanduine.
-1	PÁIDÍ	Páidí	PROPN	Noun	Case=Voc|Gender=Masc|Number=Sing	2	vocative	_	_
+1	PÁIDÍ	Páidí	PROPN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	2	vocative	_	_
 2	Cuir	cuir	VERB	VTI	Mood=Imp|Number=Sing|Person=2	0	root	_	_
 3	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	4	nmod:poss	_	_
-4	lámh	lámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obj	_	_
+4	lámh	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obj	_	_
 5	thar	thar	ADP	Simp	_	7	case	_	_
 6	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
-7	ghualainn	gualainn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
+7	ghualainn	gualainn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	a	a	PART	Voc	PartType=Voc	10	case:voc	_	_
-10	sheanduine	seanduine	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
+10	sheanduine	seanduine	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 74
@@ -1798,9 +1798,9 @@
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
 7	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
-9	Pádraic	Pádraic	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
-10	Ua	Ua	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
-11	Dubhthaigh	Dubhthaigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	Pádraic	Pádraic	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
+10	Ua	Ua	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+11	Dubhthaigh	Dubhthaigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	go	go	PART	Vb	PartType=Cmpl	14	mark:prt	_	_
 14	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
@@ -1812,7 +1812,7 @@
 20	leith	leith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	nmod	_	_
 21	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
 22	sa	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	phobal	pobal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
+23	phobal	pobal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	obl	_	_
 24	Preispitéireach	Preispitéireach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	amod	_	_
 25	nuair	nuair	SCONJ	Subord	_	27	mark	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	mark:prt	_	_
@@ -1831,7 +1831,7 @@
 2	go	go	PART	Vb	PartType=Cmpl	3	mark:prt	_	_
 3	moltar	mol	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	13	advcl	_	_
 4	don	do	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	tosnaitheoir	tosnaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	_
+5	tosnaitheoir	tosnaitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	fhliúit	fliúit	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	obj	_	_
 8	neamheochrach	neamheochrach	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	7	amod	_	_
@@ -1839,16 +1839,16 @@
 10	sheinnt	seinnt	NOUN	Noun	Form=Len|VerbForm=Inf	3	xcomp	_	_
 11	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	13	cop	_	_
 12	den	de	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	dearadh	dearadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+13	dearadh	dearadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	den	de	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	gcaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	13	conj	_	_
+16	gcaighdeán	caighdeán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	13	conj	_	_
 17	díreach	díreach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	18	advmod	_	_
 18	céanna	céanna	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	13	amod	_	_
 19	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 20	leis	le	ADP	Simp	_	22	case	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	bhfliúit	fliúit	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	13	nmod	_	_
+22	bhfliúit	fliúit	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	13	nmod	_	_
 23	eochrach	eochair	ADJ	Adj	Case=NomAcc|Number=Sing	22	amod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	22	acl:relcl	_	_
@@ -1864,7 +1864,7 @@
 4	thaca	taca	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	ag	ag	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	Aontas	aontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+7	Aontas	aontas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 8	le	le	ADP	Cmpd	PrepForm=Cmpd	10	case	_	_
 9	linn	linn	ADP	Cmpd	_	8	fixed	_	_
 10	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl	_	_
@@ -1886,10 +1886,10 @@
 26	J.	J.	NOUN	Abr	Abbr=Yes	25	nmod	_	_
 27	7	7	NUM	Num	_	25	nmod	_	_
 28	den	de	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
-29	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
+29	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
 30	ar	ar	ADP	Simp	_	32	case	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
-32	Aontas	aontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
+32	Aontas	aontas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
 33	Eorpach	Eorpach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	32	amod	_	NamedEntity=Yes
 34	a	a	PART	Inf	PartType=Inf	35	mark	_	_
 35	chumadh	cumadh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	SpaceAfter=No
@@ -1910,7 +1910,7 @@
 1	Och	och	INTJ	Itj	_	4	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	Punct	_	1	punct	_	_
 3	a	a	PART	Voc	PartType=Voc	4	case:voc	_	_
-4	chumannaigh	cumannach	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	chumannaigh	cumannach	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 5	!	!	PUNCT	!	_	4	punct	_	_
 
 # sent_id = 79
@@ -1930,7 +1930,7 @@
 13	suntasaí	suntasach	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	12	amod	_	_
 14	seo	seo	DET	Det	PronType=Dem	12	det	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
-16	hÉirinn	Éire	PROPN	Noun	Case=Dat|Form=HPref|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
+16	hÉirinn	Éire	PROPN	Noun	Case=Dat|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 80
@@ -1956,7 +1956,7 @@
 9	chreidimh	creideamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	mar	mar	ADP	Simp	_	12	case	_	_
-12	Shéamas	Shéamas	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
+12	Shéamas	Shéamas	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 82
@@ -1982,8 +1982,8 @@
 6	bhfocal	focal	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	4	obj	_	_
 7	úd	úd	DET	Det	PronType=Dem	6	det	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	gCearnóg	cearnóg	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	NamedEntity=Yes
-10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes|SpaceAfter=No
+9	gCearnóg	cearnóg	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	NamedEntity=Yes
+10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes|SpaceAfter=No
 11	,	,	PUNCT	Punct	_	2	punct	_	_
 12	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 13	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	nsubj	_	_
@@ -1995,11 +1995,11 @@
 19	ar	ar	ADP	Simp	_	22	case	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 21	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	22	amod	_	_
-22	Imlitir	imlitir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	obl	_	_
+22	Imlitir	imlitir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	obl	_	_
 23	agus	agus	CCONJ	Coord	_	26	cc	_	_
 24	ar	ar	ADP	Simp	_	26	case	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
-26	bPápacht	pápacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	22	conj	_	_
+26	bPápacht	pápacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	22	conj	_	_
 27	go	go	PART	Ad	PartType=Ad	28	mark:prt	_	_
 28	léir	léir	ADJ	Adj	Degree=Pos	26	amod	_	_
 29	a	a	PART	Inf	PartType=Inf	30	mark	_	_
@@ -2023,10 +2023,10 @@
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	Bainisteoir	bainisteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 10	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	11	nmod:poss	_	_
-11	aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obj	_	_
+11	aghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	obj	_	_
 12	suas	suas	ADV	Dir	_	7	advmod	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	staighre	staighre	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+14	staighre	staighre	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 85
@@ -2034,10 +2034,10 @@
 1	Thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	Tiarna	tiarna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-4	Longueville	Longueville	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes|SpaceAfter=No
+4	Longueville	Longueville	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
 6	Co.	contae	NOUN	Abr	Abbr=Yes	3	nmod	_	NamedEntity=Yes
-7	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
+7	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	6	punct	_	_
 9	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
 10	that	that	PRON	Dem	Foreign=Yes|PronType=Dem	1	obj	_	_
@@ -2069,7 +2069,7 @@
 13	óg	óg	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	12	amod	_	_
 14	rua	rua	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	12	amod	_	_
 15	d'	do	ADP	Simp	_	16	case	_	SpaceAfter=No
-16	Eithne	Eithne	PROPN	Noun	_	11	obl	_	SpaceAfter=No
+16	Eithne	Eithne	PROPN	Noun	Definite=Def	11	obl	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	19	punct	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
 19	Bhanríon	banríon	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	appos	_	_
@@ -2110,7 +2110,7 @@
 
 # sent_id = 88
 # text = Máire.
-1	Máire	Máire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
+1	Máire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 89
@@ -2120,7 +2120,7 @@
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	comóradh	comóradh	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 5	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	6	nmod:poss	_	_
-6	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	_
+6	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obj	_	_
 7	breithe	breith	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	compound	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	tseachtain	seachtain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obl:tmod	_	_
@@ -2133,27 +2133,27 @@
 2	ise	ise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	0	root	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
 4	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
-5	Dick	Dick	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	NamedEntity=Yes
-6	Spring	Spring	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
+5	Dick	Dick	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obj	_	NamedEntity=Yes
+6	Spring	Spring	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
 7	i	i	ADP	Cmpd	PrepForm=Cmpd	10	case	_	_
 8	mbun	bun	ADP	Cmpd	Form=Ecl	7	fixed	_	_
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Roinne	roinn	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	obl	_	NamedEntity=Yes
-11	Oideachais	oideachas	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
+10	Roinne	roinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	obl	_	NamedEntity=Yes
+11	Oideachais	oideachas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	nuair	nuair	SCONJ	Subord	_	15	mark	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	mark:prt	_	_
 15	bunaíodh	bunaigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	2	advcl	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 17	chéad	céad	NUM	Num	Form=Len|NumType=Ord	18	amod	_	_
-18	Chomhrialtas	comhrialtas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	15	obj	_	_
+18	Chomhrialtas	comhrialtas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obj	_	_
 19	idir	idir	ADP	Simp	_	20	case	_	_
-20	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	18	nmod	_	NamedEntity=Yes
-21	Fáil	Fál	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+20	Fianna	Fiann	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	18	nmod	_	NamedEntity=Yes
+21	Fáil	Fál	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	agus	agus	CCONJ	Coord	_	24	cc	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	Lucht	Lucht	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
-25	Oibre	Oibre	PROPN	Noun	_	24	nmod	_	NamedEntity=Yes
+24	Lucht	Lucht	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
+25	Oibre	Oibre	PROPN	Noun	Definite=Def	24	nmod	_	NamedEntity=Yes
 26	sa	i	ADP	Art	Number=Sing|PronType=Art	27	case	_	_
 27	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	obl:tmod	_	_
 28	1992	1992	NUM	Num	_	27	nmod	_	SpaceAfter=No
@@ -2165,7 +2165,7 @@
 2	leat	le	ADP	Prep	Number=Sing|Person=2	1	obl:prep	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	5	punct	_	_
 4	a	a	PART	Voc	PartType=Voc	5	case:voc	_	_
-5	Mhichíl	Micheál	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	1	vocative	_	_
+5	Mhichíl	Micheál	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	vocative	_	_
 6	ghrinn	grinn	ADJ	Adj	Form=Len|Gender=Masc|Number=Sing|PartType=Voc	5	amod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2197,15 +2197,15 @@
 # sent_id = 95
 # text = Sa chlár seo, déantar léiriú ar Shiobhán O' Keefe, an banaisteoir a chaith tús a saoil i gCeann Trá go ndeachaigh sí go Hollywood sna daichidí.
 1	Sa	i	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+2	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 3	seo	seo	DET	Det	PronType=Dem	2	det	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	déantar	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 6	léiriú	léiriú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
-8	Shiobhán	Siobhán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
+8	Shiobhán	Siobhán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
 9	O'	o	PART	Pat	PartType=Pat	8	flat:name	_	NamedEntity=Yes
-10	Keefe	Keefe	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+10	Keefe	Keefe	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 11	,	,	PUNCT	Punct	_	13	punct	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
 13	banaisteoir	banaisteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	appos	_	_
@@ -2213,15 +2213,15 @@
 15	chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	13	acl:relcl	_	_
 16	tús	tús	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
 17	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	saoil	saol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	_
+18	saoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 19	i	i	ADP	Simp	_	21	case	_	_
-20	gCeann	ceann	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
-21	Trá	trá	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes
+20	gCeann	ceann	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
+21	Trá	trá	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	go	go	PART	Vb	PartType=Cmpl	23	mark:prt	_	_
 23	ndeachaigh	téigh	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	15	ccomp	_	_
 24	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	23	nsubj	_	_
 25	go	go	ADP	Simp	_	26	case	_	_
-26	Hollywood	Hollywood	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	obl	_	_
+26	Hollywood	Hollywood	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
 27	sna	i	ADP	Art	Number=Plur|PronType=Art	28	case	_	_
 28	daichidí	daichead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	23	obl	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	5	punct	_	_
@@ -2245,8 +2245,8 @@
 15	go	go	PART	Ad	PartType=Ad	16	mark:prt	_	_
 16	maith	maith	ADJ	Adj	Degree=Pos	14	advmod	_	_
 17	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	gCloch	cloch	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	14	obl	_	NamedEntity=Yes
-19	Chora	Cora	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+18	gCloch	cloch	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	14	obl	_	NamedEntity=Yes
+19	Chora	Cora	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 20	a	a	PART	Vb	PartType=Vb|PronType=Rel	21	nsubj	_	_
 21	shíl	síl	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	18	acl:relcl	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
@@ -2274,8 +2274,8 @@
 6	Fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 7	cathrach	cathair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	amod	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	9	nmod	_	_
-9	Pearse	Pearse	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	NamedEntity=Yes
-10	Hutchinson	Hutchinson	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	Pearse	Pearse	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	NamedEntity=Yes
+10	Hutchinson	Hutchinson	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 11	,	,	PUNCT	Punct	_	13	punct	_	_
 12	mar	mar	ADP	Simp	_	13	case	_	_
 13	shampla	sampla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
@@ -2284,7 +2284,7 @@
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	nsubj	_	_
 17	bheadh	bí	VERB	VI	Form=Len|Mood=Cnd	15	acl:relcl	_	_
 18	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	éan	éan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	xcomp:pred	_	_
+19	éan	éan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	xcomp:pred	_	_
 20	corr	corr	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	19	amod	_	_
 21	i	i	ADP	Simp	_	22	case	_	_
 22	bpobal	pobal	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
@@ -2295,8 +2295,8 @@
 27	léar	léar	ADJ	Adj	Degree=Pos	6	conj	_	_
 28	sin	sin	PRON	Dem	PronType=Dem	27	nsubj	_	_
 29	ar	ar	ADP	Simp	_	32	case	_	_
-30	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
-31	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	27	nmod	_	_
+30	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	nmod:poss	_	_
+31	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	27	nmod	_	_
 32	filíochta	filíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	31	nmod	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -2317,7 +2317,7 @@
 13	agus	agus	CCONJ	Coord	_	14	cc	_	_
 14	misneach	misneach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	_
 15	ina	i	ADP	Poss	Poss=Yes	16	case	_	_
-16	ghuth	guth	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
+16	ghuth	guth	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	10	punct	_	_
 
 # sent_id = 99
@@ -2338,7 +2338,7 @@
 14	láthair	láthair	ADP	Cmpd	_	9	obl	_	_
 15	tré	tré	ADP	Simp	_	16	case	_	_
 16	shúile	súil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	9	obl	_	_
-17	Mhairéid	Mhairéid	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	nmod	_	_
+17	Mhairéid	Mhairéid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 18	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	obl	_	_
 19	mhaith	maith	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	18	amod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	9	punct	_	_
@@ -2356,7 +2356,7 @@
 9	thréigean	tréigean	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	nmod:poss	_	_
-12	athair	athair	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
+12	athair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 13	féin	féin	PRON	Ref	Reflex=Yes	12	nmod	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	dhéanfaidh	déan	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	3	acl:relcl	_	_
@@ -2383,7 +2383,7 @@
 14	cúis	cúis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obj	_	_
 15	bhreá	breá	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	amod	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	10	obl	_	SpaceAfter=No
+17	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	10	obl	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 102
@@ -2404,7 +2404,7 @@
 14	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	1	parataxis	_	_
 15	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	14	nsubj	_	_
 16	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	17	case	_	_
-17	chorpán	corpán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	xcomp:pred	_	_
+17	chorpán	corpán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	xcomp:pred	_	_
 18	mharbh	marbh	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	amod	_	_
 19	dá	dá	SCONJ	Subord	_	20	mark	_	_
 20	bar	bar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	advcl	_	_
@@ -2435,7 +2435,7 @@
 16	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	15	nsubj	_	_
 17	chun	chun	ADP	Simp	_	21	case	_	_
 18	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	scíth	scíth	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	obj	_	_
+19	scíth	scíth	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	obj	_	_
 20	a	a	PART	Inf	PartType=Inf	21	mark	_	_
 21	ligean	ligean	NOUN	Noun	VerbForm=Inf	15	xcomp	_	_
 22	ar	ar	ADP	Cmpd	PrepForm=Cmpd	24	case	_	_
@@ -2467,13 +2467,13 @@
 20	,	,	PUNCT	Punct	_	7	punct	_	SpaceAfter=No
 21	'	'	PUNCT	Punct	_	7	punct	_	_
 22	adeir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-23	Darach	Darach	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nsubj	_	SpaceAfter=No
+23	Darach	Darach	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	nsubj	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	22	punct	_	_
 
 # sent_id = 105
 # text = Tharraing Conradh na Gaeilge ollchruinniú agóide ag éileamh go mbeadh an Ghaeilge ar comhchéim leis na teangacha eile sa chóras meánscolaíochta.
 1	Tharraing	tarraing	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Conradh	conradh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Conradh	conradh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 5	ollchruinniú	ollchruinniú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
@@ -2491,7 +2491,7 @@
 17	teangacha	teanga	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	14	nmod	_	_
 18	eile	eile	DET	Det	PronType=Dem	17	det	_	_
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	chóras	córas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
+20	chóras	córas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
 21	meánscolaíochta	meánscolaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2504,13 +2504,13 @@
 5	n-aireofá	airigh	VERB	VT	Form=Ecl|Mood=Cnd|Number=Sing|Person=2	1	ccomp	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	8	nmod:poss	_	_
-8	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+8	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 9	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	5	obj	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
 11	ach	ach	SCONJ	Subord	_	12	mark	_	_
 12	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	1	advcl	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	det	_	_
-14	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	nsubj	_	_
+14	fhios	fios	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	nsubj	_	_
 15	agat	ag	ADP	Prep	Number=Sing|Person=2	12	obl:prep	_	_
 16	dá	de	ADP	Deg	PartType=Deg	12	advmod	_	_
 17	laghad	laghad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	fixed	_	_
@@ -2551,7 +2551,7 @@
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	mark:prt	_	_
 6	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	cóisir	cóisir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	nsubj	_	_
+8	cóisir	cóisir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	nsubj	_	_
 9	thart	thart	ADV	Dir	_	6	xcomp:pred	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2576,13 +2576,13 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	cás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	i	i	ADP	Simp	_	5	case	_	_
-5	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+5	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 6	os	os	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 7	comhair	comhair	ADP	Cmpd	_	6	fixed	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	Bhreithimh	Breitheamh	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	1	obl	_	NamedEntity=Yes
-10	Peter	Peter	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat	_	NamedEntity=Yes
-11	Kelly	Kelly	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
+9	Bhreithimh	Breitheamh	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	NamedEntity=Yes
+10	Peter	Peter	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat	_	NamedEntity=Yes
+11	Kelly	Kelly	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	cheadaigh	ceadaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 14	seisean	seisean	PRON	Pers	Gender=Masc|Number=Sing|Person=3|PronType=Emp	13	nsubj	_	_
@@ -2624,35 +2624,35 @@
 50	n-éistfear	éist	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	42	advcl	_	_
 51	leis	le	ADP	Simp	_	53	case	_	_
 52	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	53	det	_	_
-53	chás	cás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	50	obl	_	_
+53	chás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	50	obl	_	_
 54	iomlán	iomlán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	53	amod	_	_
 55	san	i	ADP	Art	Number=Sing|PronType=Art	56	case	_	_
-56	Ard-Chúirt	Ard-Chúirt	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	50	obl	_	SpaceAfter=No
+56	Ard-Chúirt	Ard-Chúirt	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	50	obl	_	SpaceAfter=No
 57	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 111
 # text = Bhí Tomás Óg bailithe leis go Meiriceá siar, Cáit imithe chun a pósta ar Thomás Ó Maoileoin sa Dún Mór.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Tomás	Tomás	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Tomás	Tomás	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	Óg	óg	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	bailithe	bailithe	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	_
 6	go	go	ADP	Simp	_	7	case	_	_
-7	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	_
+7	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 8	siar	siar	ADV	Dir	_	7	advmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
-10	Cáit	Cáit	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	conj	_	_
+10	Cáit	Cáit	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	conj	_	_
 11	imithe	imithe	ADJ	Adj	VerbForm=Part	10	xcomp:pred	_	_
 12	chun	chun	ADP	Simp	_	14	case	_	_
 13	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	14	nmod:poss	_	_
-14	pósta	pósadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	obl	_	_
+14	pósta	pósadh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 15	ar	ar	ADP	Simp	_	16	case	_	_
-16	Thomás	Tomás	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
+16	Thomás	Tomás	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
 17	Ó	ó	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
-18	Maoileoin	Maoileoin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
+18	Maoileoin	Maoileoin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	Dún	dún	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
-21	Mór	Mór	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	Dún	dún	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+21	Mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	20	amod	_	NamedEntity=Yes|SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 112
@@ -2674,15 +2674,15 @@
 15	foillsíodh	foillsigh	VERB	PastInd	Mood=Ind|Person=0|Tense=Past	12	conj	_	_
 16	ag	ag	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	gComhairle	comhairle	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	_
+18	gComhairle	comhairle	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	_
 19	no	nó	CCONJ	Coord	Typo=Yes	21	cc	_	_
 20	don	do	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
 21	Chomhairle	comhairle	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	conj	_	_
 22	fén	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
+23	alt	alt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 24	so	seo	DET	Det	Dialect=Munster|PronType=Dem	23	det	_	_
 25	den	de	ADP	Art	Number=Sing|PronType=Art	26	case	_	_
-26	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+26	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
 27	de	de	ADP	Simp	_	28	case	_	_
 28	dhochtúirí	dochtúir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	26	nmod	_	_
 29	leighis	leigheas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	_
@@ -2691,10 +2691,10 @@
 32	de	de	ADP	Simp	_	33	case	_	_
 33	thurus	turas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
-35	huaire	uair	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	_
+35	huaire	uair	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	_
 36	ar	ar	ADP	Simp	_	38	case	_	_
 37	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
-38	gclár	clár	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
+38	gclár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
 39	de	de	ADP	Simp	_	40	case	_	_
 40	dhochtúirí	dochtúir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	38	nmod	_	_
 41	leighis	leigheas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	40	nmod	_	_
@@ -2712,7 +2712,7 @@
 53	chóip	cóip	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	51	nsubj	_	_
 54	sin	sin	DET	Det	PronType=Dem	53	det	_	_
 55	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	56	case	_	_
-56	fianaise	fianaise	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	51	xcomp:pred	_	_
+56	fianaise	fianaise	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	51	xcomp:pred	_	_
 57	in	i	ADP	Simp	_	59	case	_	_
 58	aon	aon	DET	Det	PronType=Ind	59	det	_	_
 59	chúirt	cúirt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	51	obl	_	SpaceAfter=No
@@ -2722,18 +2722,18 @@
 63	go	go	PART	Vb	PartType=Cmpl	64	mark:prt	_	_
 64	gcruthófar	cruthaigh	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	51	advcl	_	_
 65	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	66	det	_	_
-66	mhalairt	malairt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	64	obj	_	SpaceAfter=No
+66	mhalairt	malairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	64	obj	_	SpaceAfter=No
 67	,	,	PUNCT	Punct	_	70	punct	_	_
 68	ar	ar	ADP	Simp	_	70	case	_	_
 69	gach	gach	DET	Det	Definite=Def	70	det	_	_
-70	éinne	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	51	obl	_	_
+70	éinne	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	51	obl	_	_
 71	go	go	PART	Vb	PartType=Cmpl	72	mark:prt	_	_
 72	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	70	acl:relcl	_	_
 73	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	74	nmod:poss	_	_
-74	ainm	ainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	72	nsubj	_	_
+74	ainm	ainm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	72	nsubj	_	_
 75	iontrálta	iontráilte	ADJ	Adj	VerbForm=Part	72	xcomp:pred	_	_
 76	sa	i	ADP	Art	Number=Sing|PronType=Art	77	case	_	_
-77	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	75	obl	_	_
+77	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	75	obl	_	_
 78	san	sin	DET	Det	Dialect=Munster|PronType=Dem	77	det	_	_
 79	de	de	ADP	Simp	_	80	case	_	_
 80	dhochtúirí	dochtúir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	77	nmod	_	_
@@ -2742,9 +2742,9 @@
 83	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	70	xcomp	_	_
 84	cláruithe	cláraithe	ADJ	Adj	VerbForm=Part	83	xcomp:pred	_	_
 85	sa	i	ADP	Art	Number=Sing|PronType=Art	86	case	_	_
-86	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	84	obl	_	_
+86	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	84	obl	_	_
 87	fén	faoi	ADP	Art	Number=Sing|PronType=Art	88	case	_	_
-88	Acht	acht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	84	nmod	_	_
+88	Acht	acht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	84	nmod	_	_
 89	so	seo	DET	Det	Dialect=Munster|PronType=Dem	88	det	_	_
 90	agus	agus	CCONJ	Coord	_	70	conj	_	_
 91	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	90	conj	_	_
@@ -2755,10 +2755,10 @@
 96	ná	nach	PART	Vb	Dialect=Munster|PartType=Vb|Polarity=Neg|PronType=Rel	97	obj	_	_
 97	fuil	bí	VERB	PresInd	Mood=Ind|Polarity=Neg|Tense=Pres	95	acl:relcl	_	_
 98	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	99	nmod:poss	_	_
-99	ainm	ainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	97	nsubj	_	_
+99	ainm	ainm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	97	nsubj	_	_
 100	iontrálta	iontráilte	ADJ	Adj	VerbForm=Part	97	xcomp:pred	_	_
 101	sa	i	ADP	Art	Number=Sing|PronType=Art	102	case	_	_
-102	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	100	obl	_	_
+102	chlár	clár	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	100	obl	_	_
 103	san	sin	DET	Det	Dialect=Munster|PronType=Dem	102	det	_	_
 104	de	de	ADP	Simp	_	105	case	_	_
 105	dhochtúirí	dochtúir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	102	nmod	_	_
@@ -2825,21 +2825,21 @@
 # text = Agus ón uair a chuir mé mo chos thar tairseach na Cultúrlainne ag a sé a' chlog tráthnóna, caitheadh go hiontach liom agus mhothaigh mé sa bhaile i measc mo chomhghael Feirsteach.
 1	Agus	agus	CCONJ	Coord	_	20	advmod	_	_
 2	ón	ó	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	20	obl	_	_
+3	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	20	obl	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	obl:tmod	_	_
 5	chuir	cuir	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	acl:relcl	_	_
 6	mé	mé	PRON	Pers	Number=Sing|Person=1	5	nsubj	_	_
 7	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	8	nmod:poss	_	_
-8	chos	cos	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	5	obj	_	_
+8	chos	cos	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	obj	_	_
 9	thar	thar	ADP	Simp	_	10	case	_	_
 10	tairseach	tairseach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Cultúrlainne	Cultúrlainne	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	nmod	_	_
+12	Cultúrlainne	Cultúrlainne	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	_
 13	ag	ag	ADP	Simp	_	17	case	_	_
 14	a	a	PART	Nm	PartType=Num	15	mark:prt	_	_
 15	sé	sé	NUM	Num	NumType=Card	5	obl:tmod	_	_
 16	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	chlog	clog	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
+17	chlog	clog	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 18	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	3	punct	_	_
 20	caitheadh	caith	VERB	PastInd	Mood=Ind|Person=0|Tense=Past	0	root	_	_
@@ -2850,11 +2850,11 @@
 25	mhothaigh	mothaigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	20	conj	_	_
 26	mé	mé	PRON	Pers	Number=Sing|Person=1	25	nsubj	_	_
 27	sa	i	ADP	Art	Number=Sing|PronType=Art	28	case	_	_
-28	bhaile	baile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
+28	bhaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
 29	i	i	ADP	Simp	_	30	case	_	_
 30	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl	_	_
 31	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	32	nmod:poss	_	_
-32	chomhghael	comhghael	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
+32	chomhghael	comhghael	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
 33	Feirsteach	Feirsteach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	32	amod	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	20	punct	_	_
 
@@ -2870,7 +2870,7 @@
 8	comharthaí	comhartha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	nmod	_	_
 9	seó	seó	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	nDún	Dún	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+11	nDún	Dún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	nGall	Gall	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
@@ -2878,11 +2878,11 @@
 16	suite	suite	ADJ	Adj	VerbForm=Part	15	xcomp:pred	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
 18	bhruch	bruach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
-19	Loch	loch	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-20	Dhún	dún	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
-21	Lúiche	Lúiche	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+19	Loch	loch	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+20	Dhún	dún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+21	Lúiche	Lúiche	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	Earagal	Earagal	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obl	_	SpaceAfter=No
+23	Earagal	Earagal	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	obl	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 117
@@ -2982,15 +2982,15 @@
 24	a	a	PART	Vb	PartType=Vb|PronType=Rel	25	mark:prt	_	_
 25	buaileadh	buail	VERB	VTI	Mood=Ind|Person=0|Tense=Past	19	advcl	_	_
 26	ar	ar	ADP	Simp	_	27	case	_	_
-27	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
+27	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
 28	Bán	Bán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	27	flat:name	_	NamedEntity=Yes
 29	ar	ar	ADP	Simp	_	30	case	_	_
 30	Aonach	aonach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
 31	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	NamedEntity=Yes
 32	Phoic	poc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes
 33	i	i	ADP	Simp	_	34	case	_	_
-34	gCill	Cill	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	30	obl	_	NamedEntity=Yes
-35	Orglan	Orglan	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	nmod	_	NamedEntity=Yes
+34	gCill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	30	obl	_	NamedEntity=Yes
+35	Orglan	Orglan	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	NamedEntity=Yes
 36	uair	uair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	25	obl:tmod	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	11	punct	_	_
 
@@ -3011,13 +3011,13 @@
 13	agus	agus	CCONJ	Coord	_	14	cc	_	_
 14	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	chiall	ciall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	nsubj	_	_
+16	chiall	ciall	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	nsubj	_	_
 17	féin	féin	PRON	Ref	Reflex=Yes	16	nmod	_	_
 18	do	do	ADP	Simp	_	20	case	_	_
 19	gach	gach	DET	Det	Definite=Def	20	det	_	_
-20	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	nmod	_	_
+20	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 21	ina	i	ADP	Poss	Poss=Yes	22	case	_	_
-22	thaibhreamh	taibhreamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	xcomp:pred	_	_
+22	thaibhreamh	taibhreamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	xcomp:pred	_	_
 23	féin	féin	PRON	Ref	Reflex=Yes	22	nmod	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3051,7 +3051,7 @@
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
 18	ollscoil	ollscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	_
 19	san	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	oíche	oíche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
+20	oíche	oíche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	13	punct	_	_
 
 # sent_id = 125
@@ -3061,7 +3061,7 @@
 3	ansin	ansin	ADV	Loc	_	1	advmod	_	_
 4	fríd	fríd	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Eastát	eastát	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+6	Eastát	eastát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 7	Tionsclaíocha	tionsclaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing|Typo=Yes	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3073,7 +3073,7 @@
 4	asainn	as	ADP	Prep	Number=Plur|Person=1	1	obl:prep	_	_
 5	agus	agus	SCONJ	Subord	_	7	mark	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	bheirt	beirt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	advcl	_	_
+7	bheirt	beirt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	advcl	_	_
 8	againn	ag	ADP	Prep	Number=Plur|Person=1	7	nmod	_	_
 9	i	i	ADP	Simp	_	10	case	_	_
 10	ndíg	díog	NOUN	Noun	Case=Dat|Form=Ecl|Gender=Fem|Number=Sing	7	nmod	_	_
@@ -3087,7 +3087,7 @@
 1	Ar	ar	ADP	Simp	_	4	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 3	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	4	amod	_	_
-4	dul	dul	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+4	dul	dul	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 5	síos	síos	ADV	Dir	_	4	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	4	punct	_	_
 7	cuireann	cuir	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -3126,10 +3126,10 @@
 1	Níor	níor	PART	Vb	PartType=Vb|Polarity=Neg|Tense=Past	2	advmod	_	_
 2	ghlac	glac	VERB	VT	Form=Len|Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
 3	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
-4	Curdaigh	Curdaigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	Curdaigh	Curdach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	2	nsubj	_	_
 5	leis	le	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	gcinneadh	cinneadh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
+7	gcinneadh	cinneadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
 8	sin	sin	DET	Det	PronType=Dem	7	det	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	leanadar	lean	VERB	VTI	Mood=Ind|Number=Plur|Person=3|Tense=Past	2	conj	_	_
@@ -3146,10 +3146,10 @@
 21	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	10	advcl	_	_
 22	ar	ar	ADP	Simp	_	24	case	_	_
 23	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	24	nmod:poss	_	_
-24	gcinnire	cinnire	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
+24	gcinnire	cinnire	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Mustafa	Mustafa	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	appos	_	NamedEntity=Yes
-27	Barzaní	Barzaní	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+26	Mustafa	Mustafa	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	appos	_	NamedEntity=Yes
+27	Barzaní	Barzaní	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	teicheadh	teitheadh	NOUN	Noun	VerbForm=Inf	21	xcomp	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	2	punct	_	_
@@ -3162,7 +3162,7 @@
 4	agam	ag	ADP	Prep	Number=Sing|Person=1	2	obl:prep	_	_
 5	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
 6	chéad	céad	NUM	Num	Form=Len|NumType=Ord	7	amod	_	_
-7	cheist	ceist	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
+7	cheist	ceist	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
 8	a	a	PART	Inf	PartType=Inf	9	mark	_	_
 9	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	2	xcomp	_	SpaceAfter=No
 10	:	:	PUNCT	Punct	_	11	punct	_	_
@@ -3179,38 +3179,38 @@
 # sent_id = 130
 # text = Do thuairimíocht faoi do chuairt go hIarthar Bhéal Feirste?
 1	Do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	2	nmod:poss	_	_
-2	thuairimíocht	tuairimíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
+2	thuairimíocht	tuairimíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 3	faoi	faoi	ADP	Simp	_	5	case	_	_
 4	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	5	nmod:poss	_	_
-5	chuairt	cuairt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	_
+5	chuairt	cuairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	nmod	_	_
 6	go	go	ADP	Simp	_	7	case	_	_
 7	hIarthar	iarthar	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
-8	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
-9	Feirste	Feirste	PROPN	Noun	_	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
+8	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+9	Feirste	Feirste	PROPN	Noun	Definite=Def	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 10	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 131
 # text = A Dhochtúir Van Helsing, má thagann a chothrom de chaoi i do chomhair agus a tharla i gcás Laoise, beidh mé ag brath ort go bhfágfaidh tú mar shuairc-chuimhne ag m'fhear i gcaitheamh a shaoil gurbh é a dheaslámh féin a shaor a bhanchéile mhuirneach ón mám millteach a bhí uirthi.
 1	A	a	PART	Voc	PartType=Voc	3	case:voc	_	_
-2	Dhochtúir	dochtúir	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	22	vocative	_	NamedEntity=Yes
-3	Van	Van	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat	_	NamedEntity=Yes
-4	Helsing	Helsing	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+2	Dhochtúir	dochtúir	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	vocative	_	NamedEntity=Yes
+3	Van	Van	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	flat	_	NamedEntity=Yes
+4	Helsing	Helsing	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
 6	má	má	SCONJ	Subord	_	7	mark	_	_
 7	thagann	tar	VERB	PresInd	Form=Len|Mood=Ind|Polarity=Neg|Tense=Pres	22	advcl	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	nmod:poss	_	_
-9	chothrom	cothrom	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nsubj	_	_
+9	chothrom	cothrom	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nsubj	_	_
 10	de	de	PART	Pat	PartType=Pat	11	case	_	_
 11	chaoi	caoi	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 12	i	i	ADP	Simp	_	14	case	_	_
 13	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	14	nmod:poss	_	_
-14	chomhair	comhair	NOUN	Subst	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	obl	_	_
+14	chomhair	comhair	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	obl	_	_
 15	agus	agus	SCONJ	Subord	_	17	mark	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	mark:prt	_	_
 17	tharla	tarlaigh	VERB	PastInd	Form=Len|Mood=Ind|Polarity=Neg|Tense=Past	7	xcomp	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
 19	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
-20	Laoise	Laoise	PROPN	Noun	_	19	nmod	_	SpaceAfter=No
+20	Laoise	Laoise	PROPN	Noun	Definite=Def	19	nmod	_	SpaceAfter=No
 21	,	,	PUNCT	Punct	_	7	punct	_	_
 22	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
 23	mé	mé	PRON	Pers	Number=Sing|Person=1	22	nsubj	_	_
@@ -3224,20 +3224,20 @@
 31	shuairc-chuimhne	suairc-chuimhne	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	obl	_	_
 32	ag	ag	ADP	Simp	_	34	case	_	_
 33	m'	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	34	nmod:poss	_	SpaceAfter=No
-34	fhear	fear	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	31	nmod	_	_
+34	fhear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	nmod	_	_
 35	i	i	ADP	Simp	_	36	case	_	_
 36	gcaitheamh	caitheamh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
 37	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	38	nmod:poss	_	_
-38	shaoil	saol	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	36	nmod	_	_
+38	shaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	nmod	_	_
 39	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	42	cop	_	_
 40	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	42	nmod	_	_
 41	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	42	nmod:poss	_	_
-42	dheaslámh	deaslámh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	28	ccomp	_	_
+42	dheaslámh	deaslámh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	28	ccomp	_	_
 43	féin	féin	PRON	Ref	Reflex=Yes	42	nmod	_	_
 44	a	a	PART	Vb	PartType=Vb|PronType=Rel	45	mark:prt	_	_
 45	shaor	saor	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	42	csubj:cleft	_	_
 46	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	47	nmod:poss	_	_
-47	bhanchéile	banchéile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	45	obj	_	_
+47	bhanchéile	banchéile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	45	obj	_	_
 48	mhuirneach	muirneach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	47	amod	_	_
 49	ón	ó	ADP	Art	Number=Sing|PronType=Art	50	case	_	_
 50	mám	mám	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	45	obl	_	_
@@ -3271,7 +3271,7 @@
 20	i	i	ADP	Cmpd	PrepForm=Cmpd	23	case	_	_
 21	ndiaidh	ndiaidh	ADP	Cmpd	Form=Ecl	20	fixed	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+23	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 24	tugtar	tabhair	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 25	athrá	athrá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	obj	_	_
 26	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	24	obl:prep	_	_
@@ -3296,7 +3296,7 @@
 14	ar	ar	ADP	Simp	_	15	case	_	_
 15	chaol	caol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 16	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	17	nmod:poss	_	_
-17	láimhe	lámh	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
+17	láimhe	lámh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 134
@@ -3306,14 +3306,14 @@
 3	chaoi	caoi	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	nsubj	_	_
 5	dtéann	téigh	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Pres	3	acl:relcl	_	_
-6	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	8	nmod:poss	_	_
-7	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	5	nsubj	_	_
+6	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	7	nmod:poss	_	_
+7	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	nsubj	_	_
 8	suíomh	suíomh	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	7	nmod	_	_
 9	chun	chun	ADP	Simp	_	10	case	_	_
 10	tairbhe	tairbhe	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
-11	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	13	nmod:poss	_	_
-12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	10	nmod	_	_
-13	feidhmeanna	feidhm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	12	nmod	_	SpaceAfter=No
+11	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	12	nmod:poss	_	_
+12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	10	nmod	_	_
+13	feidhmeanna	feidhm	NOUN	Noun	Case=Gen|Gender=Fem|Number=Plur	12	nmod	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 135
@@ -3322,7 +3322,7 @@
 2	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
 3	ar	ar	ADP	Simp	_	5	case	_	_
 4	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	nmod:poss	_	_
-5	pholl	poll	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+5	pholl	poll	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 6	thiar	thiar	ADV	Dir	_	5	advmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3337,9 +3337,9 @@
 7	,	,	PUNCT	Punct	_	5	punct	_	_
 8	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 9	pobal	pobal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	_
-10	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
-11	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-12	Feirste	Feirste	PROPN	Noun	_	11	nmod	_	NamedEntity=Yes
+10	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
+11	Bhéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+12	Feirste	Feirste	PROPN	Noun	Definite=Def	11	nmod	_	NamedEntity=Yes
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	obair	obair	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 15	go	go	PART	Ad	PartType=Ad	16	mark:prt	_	_
@@ -3358,15 +3358,15 @@
 3	ach	ach	SCONJ	Subord	_	2	mark:prt	_	_
 4	24	24	NUM	Num	_	2	nsubj	_	_
 5	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	6	case	_	_
-6	gcónaí	cónaí	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	xcomp:pred	_	_
+6	gcónaí	cónaí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	xcomp:pred	_	_
 7	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
 9	1991	1991	NUM	Num	_	2	obl	_	_
 10	ach	ach	SCONJ	Subord	_	11	mark	_	_
 11	bíonn	bí	VERB	PresImp	Aspect=Hab|Mood=Ind|Tense=Pres	2	advcl	_	_
-12	Clann	clann	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	nsubj	_	NamedEntity=Yes
+12	Clann	clann	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	11	nsubj	_	NamedEntity=Yes
 13	Mc	mac	PART	Pat	PartType=Pat	12	flat:name	_	NamedEntity=Yes
-14	Ewen	Ewen	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
+14	Ewen	Ewen	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
 15	ag	ag	ADP	Simp	_	16	case	_	_
 16	déanamh	déanamh	NOUN	Noun	VerbForm=Vnoun	11	xcomp	_	_
 17	fógraíochta	fógraíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	obj	_	_
@@ -3383,14 +3383,14 @@
 # sent_id = 138
 # text = 'File cumasach eile ab ea Dónall Ó Muláin, údar an amhráin úd' An Poc ar Buile ', amhrán go raibh báidh an phobail leis, agus amhrán a chan Gaeilgeoirí le fuinneamh, le scléip agus le gliondar ní hamháin ar fuaid na hÉireann, ach go deimhin ar fuaid an domhain.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	File	File	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+2	File	file	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	cumasach	cumasach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	eile	eile	DET	Det	PronType=Dem	2	det	_	_
 5	ab	is	AUX	Cop	Form=VF|PronType=Rel|Tense=Past|VerbForm=Cop	2	cop	_	_
 6	ea	ea	PRON	Pers	Number=Sing|Person=3	7	nmod	_	_
-7	Dónall	Dónall	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	NamedEntity=Yes
+7	Dónall	Dónall	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	NamedEntity=Yes
 8	Ó	ó	PART	Pat	PartType=Pat	7	flat:name	_	NamedEntity=Yes
-9	Muláin	Muláin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	Muláin	Muláin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
 11	údar	údar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	appos	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
@@ -3449,7 +3449,7 @@
 5	bhreise	breis	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
 6	dúinn	do	ADP	Prep	Number=Plur|Person=1	1	obl:prep	_	_
 7	san	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+8	alt	alt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 9	chéanna	céanna	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	amod	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
 11	cén	cé	PRON	Q	Number=Sing|PronType=Int	1	obl	_	_
@@ -3474,7 +3474,7 @@
 12	siúl	siúl	NOUN	Noun	VerbForm=Inf	10	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	Comhdháil	comhdháil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
-15	Vín	Vín	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
+15	Vín	Vín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	go	go	PART	Vb	PartType=Cmpl	17	mark:prt	_	_
 17	dtuigfí	tuig	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	3	ccomp	_	_
 18	go	go	PART	Vb	PartType=Cmpl	19	mark:prt	_	_
@@ -3495,9 +3495,9 @@
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	tchítear	tchí	VERB	PresInd	Mood=Ind|Person=0|Tense=Pres	9	advcl	_	_
 4	do	do	ADP	Simp	_	5	case	_	_
-5	Sheosamh	Seosamh	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+5	Sheosamh	Seosamh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
 6	Mac	mac	PART	Pat	PartType=Pat	5	flat:name	_	NamedEntity=Yes
-7	Grianna	Grianna	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
+7	Grianna	Grianna	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	obj	_	_
 9	caithfidh	caith	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
@@ -3514,19 +3514,19 @@
 21	chathú	cathú	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
 22	sin	sin	PRON	Dem	PronType=Dem	21	det	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
-24	truaillíochta	truaillíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	obj	_	_
+24	truaillíochta	truaillíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	obj	_	_
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	nsubj	_	_
 26	chuireann	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	24	acl:relcl	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	saol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
 29	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	30	case	_	_
-30	chosán	cosán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
+30	chosán	cosán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
 31	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 142
 # text = 'Troy anseo.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Troy	Troy	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+2	Troy	Troy	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	anseo	anseo	ADV	Loc	_	2	xcomp:pred	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3545,7 +3545,7 @@
 5	,	,	PUNCT	Punct	_	6	punct	_	_
 6	i.e.	i.e.	ADV	Abr	Abbr=Yes	1	advmod	_	_
 7	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	8	case	_	_
-8	éadan	éadan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	_
+8	éadan	éadan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obl	_	_
 9	nuair	nuair	SCONJ	Subord	_	11	mark	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
 11	ghortaítear	gortaigh	VERB	VT	Form=Len|Mood=Ind|Person=0|Tense=Pres	1	advcl	_	_
@@ -3578,15 +3578,15 @@
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	beireann	beir	VERB	VTI	Mood=Ind|Tense=Pres	1	conj	_	_
 9	siad	siad	PRON	Pers	Number=Plur|Person=3	8	nsubj	_	_
-10	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	12	nmod:poss	_	_
-11	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	8	obj	_	_
-12	uibheacha	ubh	NOUN	Noun	Case=Gen|Definite=Ind|Gender=Fem|NounType=Strong|Number=Plur	11	nmod	_	_
+10	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	11	nmod:poss	_	_
+11	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	8	obj	_	_
+12	uibheacha	ubh	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Strong|Number=Plur	11	nmod	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	ghaineamh	gaineamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+14	ghaineamh	gaineamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
 16	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	8	obl	_	_
 17	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	ngoradh	goradh	NOUN	Noun	Form=Ecl|VerbForm=Inf	16	nmod	_	SpaceAfter=No
+18	ngoradh	goradh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	16	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 147
@@ -3642,7 +3642,7 @@
 40	go	go	PART	Ad	PartType=Ad	41	mark:prt	_	_
 41	luath	luath	ADJ	Adj	Degree=Pos	43	advmod	_	_
 42	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	43	det	_	_
-43	mhí	mí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	35	conj	_	_
+43	mhí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	35	conj	_	_
 44	seo	seo	DET	Det	PronType=Dem	43	det	_	_
 45	chugainn	chuig	ADP	Prep	Number=Plur|Person=1	44	fixed	_	SpaceAfter=No
 46	.	.	PUNCT	.	_	2	punct	_	_
@@ -3650,8 +3650,8 @@
 # sent_id = 149
 # text = Dhiúltaigh Johnathan Cape agus cúpla foilsitheoir eile an leabhar a fhoilsiú agus bhí Naomi le ceangal go raibh srian a chur ar a cuid tuairimíochta.
 1	Dhiúltaigh	diúltaigh	VERB	VTI	Form=Len|Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
-2	Johnathan	Johnathan	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-3	Cape	Cape	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+2	Johnathan	Johnathan	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+3	Cape	Cape	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	agus	agus	CCONJ	Coord	_	6	cc	_	_
 5	cúpla	cúpla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	conj	_	_
 6	foilsitheoir	foilsitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	_
@@ -3662,7 +3662,7 @@
 11	fhoilsiú	foilsiú	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
-14	Naomi	Naomi	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	nsubj	_	_
+14	Naomi	Naomi	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
 16	ceangal	ceangal	NOUN	Noun	VerbForm=Inf	13	xcomp:pred	_	_
 17	go	go	PART	Vb	PartType=Cmpl	18	mark:prt	_	_
@@ -3671,8 +3671,8 @@
 20	a	a	PART	Inf	PartType=Inf	21	mark	_	_
 21	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	18	xcomp	_	_
 22	ar	ar	ADP	Simp	_	25	case	_	_
-23	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	25	nmod:poss	_	_
-24	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	obl	_	_
+23	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	24	nmod:poss	_	_
+24	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	obl	_	_
 25	tuairimíochta	tuairimíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	24	nmod	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -3685,12 +3685,12 @@
 5	cuairt	cuairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	mBuailtín	buailtín	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	5	nmod	_	_
+8	mBuailtín	buailtín	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	nmod	_	_
 9	tar	tar	ADP	Cmpd	PrepForm=Cmpd	15	case	_	_
 10	éis	éis	ADP	Cmpd	_	9	fixed	_	_
 11	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	scoilbhliain	scoilbhliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obj	_	_
+13	scoilbhliain	scoilbhliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	chríochnú	críochnú	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
@@ -3705,16 +3705,16 @@
 4	ar	ar	ADP	Simp	_	3	nmod	_	_
 5	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	4	fixed	_	_
 6	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	7	case	_	_
-7	mharú	marú	NOUN	Noun	Form=Len|VerbForm=Inf	2	obl	_	SpaceAfter=No
+7	mharú	marú	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	2	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 152
 # text = Grianghraif le Maidhc Ó Seachnasaí.
 1	Grianghraif	grianghraf	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
 2	le	le	ADP	Simp	_	3	case	_	_
-3	Maidhc	Maidhc	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+3	Maidhc	Maidhc	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	Ó	ó	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Seachnasaí	Seachnasaí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+5	Seachnasaí	Seachnasaí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 153
@@ -3747,9 +3747,9 @@
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	chaitheamh	caitheamh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 16	lena	le	ADP	Poss	Poss=Yes	17	case	_	_
-17	iníon	iníon	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
+17	iníon	iníon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Siobhán	Siobhán	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	appos	_	SpaceAfter=No
+19	Siobhán	Siobhán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	appos	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	19	punct	_	_
 21	agus	agus	CCONJ	Coord	_	24	cc	_	_
 22	leis	le	ADP	Simp	_	24	case	_	_
@@ -3762,7 +3762,7 @@
 1	Meabhraítear	meabhraigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	dhá	dó	NUM	Num	Form=Len|NumType=Card	3	nummod	_	_
 3	arcaitíopa	arcaitíopa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
-4	Mháire	Máire	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
+4	Mháire	Máire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 5	dúinn	do	ADP	Prep	Number=Plur|Person=1	1	obl:prep	_	_
 6	arís	arís	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	9	punct	_	_
@@ -3792,7 +3792,7 @@
 # text = Tá an teicníocht inste a roghnaíonn sé thar a bheith éifeachtach.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	teicníocht	teicníocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+3	teicníocht	teicníocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	inste	inste	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	obj	_	_
 6	roghnaíonn	roghnaigh	VERB	VT	Mood=Ind|Tense=Pres	3	acl:relcl	_	_
@@ -3809,7 +3809,7 @@
 2	leidí	leid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	nsubj	_	_
 3	fánacha	fánach	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	2	amod	_	_
 4	den	de	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	chineál	cineál	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+5	chineál	cineál	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 6	céanna	céanna	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
 8	sonrú	sonrú	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
@@ -3829,14 +3829,14 @@
 22	Mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
 23	Rí	rí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 24	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-25	nDeachmann	deachmann	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
+25	nDeachmann	deachmha	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	22	nmod	_	SpaceAfter=No
 26	'	'	PUNCT	Punct	_	22	punct	_	_
 27	agus	agus	CCONJ	Coord	_	30	cc	_	_
 28	'	'	PUNCT	Punct	_	30	punct	_	SpaceAfter=No
 29	Gan	gan	ADP	Simp	_	30	case	_	_
-30	Murcha	Murcha	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	conj	_	_
+30	Murcha	Murcha	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 31	gan	gan	ADP	Simp	_	32	case	_	_
-32	Manas	Manas	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
+32	Manas	Manas	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
 33	'	'	PUNCT	Punct	_	30	punct	_	_
 34	(	(	PUNCT	Punct	_	36	punct	_	SpaceAfter=No
 35	Idir	idir	ADP	Simp	_	36	case	_	_
@@ -3849,7 +3849,7 @@
 42	'	'	PUNCT	Punct	_	43	punct	_	SpaceAfter=No
 43	Tnúthán	tnúthán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	conj	_	_
 44	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	45	det	_	_
-45	Dúchais	dúchas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	43	nmod	_	SpaceAfter=No
+45	Dúchais	dúchas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	43	nmod	_	SpaceAfter=No
 46	'	'	PUNCT	Punct	_	43	punct	_	_
 47	agus	agus	CCONJ	Coord	_	50	cc	_	_
 48	'	'	PUNCT	Punct	_	50	punct	_	SpaceAfter=No
@@ -3875,12 +3875,12 @@
 6	heol	eol	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	0	root	_	_
 7	dom	do	ADP	Prep	Number=Sing|Person=1	6	obl:prep	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	nmod:poss	_	_
-9	mhacasamhail	macasamhail	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	6	nsubj	_	_
+9	mhacasamhail	macasamhail	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nsubj	_	_
 10	seo	seo	PRON	Dem	PronType=Dem	9	det	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
-12	dhéantús	déantús	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
-13	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	12	xcomp	_	_
-14	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nmod	_	_
+12	dhéantús	déantús	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+13	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	14	case	_	_
+14	linn	linn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	_
 15	ach	ach	SCONJ	Subord	_	17	mark:prt	_	_
 16	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	Bíobla	Bíobla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
@@ -3896,24 +3896,24 @@
 27	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	28	nmod	_	_
 28	Fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	csubj:cop	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
-30	Leabhair	leabhar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	_
+30	Leabhair	leabhar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	_
 31	úd	úd	DET	Det	PronType=Dem	32	det	_	_
-32	Pádraig	Pádraig	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	28	appos	_	NamedEntity=Yes
+32	Pádraig	Pádraig	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	appos	_	NamedEntity=Yes
 33	Ó	ó	PART	Pat	PartType=Pat	32	flat:name	_	NamedEntity=Yes
-34	Fiannachta	Fiannachta	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
+34	Fiannachta	Fiannachta	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
 35	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	28	csubj:cleft	_	_
 36	faoi	faoi	ADP	Simp	_	37	case	_	_
 37	ómós	ómós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	xcomp:pred	_	_
 38	mar	mar	ADP	Simp	_	39	case	_	_
 39	Fhear	fear	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	37	nmod	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
-41	Leabhair	leabhar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	39	nmod	_	_
+41	Leabhair	leabhar	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	39	nmod	_	_
 42	seo	seo	DET	Det	PronType=Dem	41	det	_	_
 43	anois	anois	ADV	Gn	_	35	advmod	_	SpaceAfter=No
 44	:	:	PUNCT	Punct	_	47	punct	_	_
 45	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	47	det	_	_
 46	dara	dara	NUM	Num	NumType=Ord	47	amod	_	_
-47	bíobla	bíobla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	41	appos	_	SpaceAfter=No
+47	bíobla	bíobla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	41	appos	_	SpaceAfter=No
 48	,	,	PUNCT	Punct	_	49	punct	_	_
 49	dá	dá	SCONJ	Subord	_	50	mark	_	_
 50	n-abrainn	abair	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	47	advcl	_	_
@@ -3924,11 +3924,11 @@
 # text = Tagann a ráiteas tar éis don chomhlacht a rá le hoibrithe an iarnróid mí ó shin go raibh sí le dúnadh: 'Chuamar ag cruinniú i mBaile Átha an Rí agus dúirt an bhainistíocht linn ansin go raibh deireadh leis an tseirbhís lasta agus go raibh baol ann dár bpostanna,' a deir Pat McDonagh, oibrí ar an líne le 25 bliain anuas.
 1	Tagann	tar	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
-3	ráiteas	ráiteas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	ráiteas	ráiteas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	tar	tar	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 5	éis	éis	ADP	Cmpd	_	4	fixed	_	_
 6	don	do	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	chomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+7	chomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 8	a	a	PART	Inf	PartType=Inf	9	mark	_	_
 9	rá	rá	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
@@ -3949,8 +3949,8 @@
 25	ag	ag	ADP	Simp	_	26	case	_	_
 26	cruinniú	cruinniú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	xcomp	_	_
 27	i	i	ADP	Simp	_	28	case	_	_
-28	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
-29	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
+28	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
+29	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	NamedEntity=Yes
 31	Rí	rí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
 32	agus	agus	CCONJ	Coord	_	33	cc	_	_
@@ -3972,13 +3972,13 @@
 48	baol	baol	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	47	nsubj	_	_
 49	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	47	xcomp:pred	_	_
 50	dár	do	ADP	Poss	Number=Plur|Person=1|Poss=Yes	51	case	_	_
-51	bpostanna	post	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	47	obl	_	SpaceAfter=No
+51	bpostanna	post	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	47	obl	_	SpaceAfter=No
 52	,	,	PUNCT	Punct	_	24	punct	_	SpaceAfter=No
 53	'	'	PUNCT	Punct	_	24	punct	_	_
 54	a	a	PART	Vb	PartType=Vb|PronType=Rel	55	mark:prt	_	_
 55	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	1	parataxis	_	_
-56	Pat	Pat	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	55	nsubj	_	NamedEntity=Yes
-57	McDonagh	McDonagh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	56	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+56	Pat	Pat	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	55	nsubj	_	NamedEntity=Yes
+57	McDonagh	McDonagh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	56	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 58	,	,	PUNCT	Punct	_	59	punct	_	_
 59	oibrí	oibrí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	57	appos	_	_
 60	ar	ar	ADP	Simp	_	62	case	_	_
@@ -3995,7 +3995,7 @@
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	4	case	_	_
-4	chodladh	codladh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	SpaceAfter=No
+4	chodladh	codladh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 161
@@ -4006,7 +4006,7 @@
 4	thug	tabhair	VERB	VD	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 5	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nsubj	_	_
 6	do	do	ADP	Simp	_	7	case	_	_
-7	Mháire	Máire	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	obl	_	SpaceAfter=No
+7	Mháire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	obl	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 162
@@ -4042,12 +4042,12 @@
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	dlí	dlí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	Burton	Burton	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+11	Burton	Burton	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	iarradh	iarraidh	NOUN	Noun	VerbForm=Inf	7	conj	_	_
 14	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	13	obl:prep	_	_
 15	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	ráiteas	ráiteas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	obj	_	_
+16	ráiteas	ráiteas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	obj	_	_
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
 18	tharraingt	tarraingt	NOUN	Noun	Form=Len|VerbForm=Inf	13	xcomp	_	_
 19	siar	siar	ADV	Dir	_	18	advmod	_	SpaceAfter=No
@@ -4070,9 +4070,9 @@
 13	i	i	ADP	Simp	_	14	case	_	_
 14	rang	rang	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	_
 15	1	1	NUM	Num	_	14	nmod	_	_
-16	Bunscoil	bunscoil	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nmod	_	_
+16	Bunscoil	bunscoil	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	16	nmod	_	NamedEntity=Yes
-18	Reachtain	Reachtain	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
+18	Reachtain	Reachtain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
 19	i	i	ADP	Simp	_	20	case	_	_
 20	mbliana	bliain	NOUN	Noun	Case=Dat|Form=Ecl|Gender=Fem|Number=Sing	9	obl:tmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	_	_
@@ -4082,7 +4082,7 @@
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	2	cop	_	_
 2	leor	leor	ADJ	Adj	Degree=Pos	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	teoiric	teoiric	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nsubj	_	_
+4	teoiric	teoiric	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	seo	seo	DET	Det	PronType=Dem	4	det	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
 7	gcúrsaí	cúrsa	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	4	nmod	_	_
@@ -4148,7 +4148,7 @@
 4	imeacht	imeacht	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 5	isteach	isteach	ADV	Dir	_	4	advmod	_	_
 6	a	a	PART	Voc	PartType=Voc	7	case:voc	_	_
-7	Tom	Tom	PROPN	Noun	Case=Voc|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
+7	Tom	Tom	PROPN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 170
@@ -4160,11 +4160,11 @@
 5	,	,	PUNCT	Punct	_	2	punct	_	_
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	Ball	Ball	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
+8	Ball	ball	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	Oinigh	oineach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	haghaidh	aghaidh	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	8	nmod	_	_
-12	Hartlepoole	Hartlepoole	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
+12	Hartlepoole	Hartlepoole	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	scríobh	scríobh	NOUN	Noun	VerbForm=Vnoun	6	xcomp	_	_
 15	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	14	obl:prep	_	_
@@ -4173,7 +4173,7 @@
 18	faoi	faoi	ADP	Simp	_	19	case	_	_
 19	cheist	ceist	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	_
+21	tuaiscirt	tuaisceart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
 22	san	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	iris	iris	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 24	chlúiteach	clúiteach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	23	amod	_	_
@@ -4230,7 +4230,7 @@
 10	go	go	PART	Vb	PartType=Cmpl	11	mark:prt	_	_
 11	dtuigfí	tuig	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	8	advcl	_	_
 12	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	13	nmod:poss	_	_
-13	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obj	_	SpaceAfter=No
+13	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obj	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 173
@@ -4257,22 +4257,22 @@
 # sent_id = 175
 # text = Molaim a gcuid iarrachtaí sa ghnó fhiúntach sin ach bhí easpa ina gcuid oibre, sa dóigh is gur cuireadh béim láidir ar ghnéithe éagsúla den Eaglais.
 1	Molaim	mol	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
-2	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	4	nmod:poss	_	_
-3	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obj	_	_
-4	iarrachtaí	iarracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	3	nmod	_	_
+2	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	3	nmod:poss	_	_
+3	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obj	_	_
+4	iarrachtaí	iarracht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Plur	3	nmod	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	ghnó	gnó	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	ghnó	gnó	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	fhiúntach	fiúntach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	amod	_	_
 8	sin	sin	DET	Det	PronType=Dem	6	det	_	_
 9	ach	ach	SCONJ	Subord	_	10	mark	_	_
 10	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 11	easpa	easpa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	nsubj	_	_
-12	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	14	case	_	_
-13	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	10	xcomp:pred	_	_
+12	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	13	case	_	_
+13	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	10	xcomp:pred	_	_
 14	oibre	obair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	17	punct	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
-17	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	20	obl	_	_
+17	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	20	obl	_	_
 18	is	agus	SCONJ	Subord	_	20	mark	_	_
 19	gur	gur	PART	Vb	PartType=Vb|Tense=Past	20	mark:prt	_	_
 20	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	10	ccomp	_	_
@@ -4282,7 +4282,7 @@
 24	ghnéithe	gné	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	20	obl	_	_
 25	éagsúla	éagsúil	ADJ	Adj	Case=NomAcc|NounType=Slender|Number=Plur	24	amod	_	_
 26	den	de	ADP	Art	Number=Sing|PronType=Art	27	case	_	_
-27	Eaglais	Eaglais	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	nmod	_	SpaceAfter=No
+27	Eaglais	Eaglais	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	24	nmod	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 176
@@ -4298,24 +4298,24 @@
 3	gur	gur	PART	Vb	PartType=Vb|Tense=Past	4	mark:prt	_	_
 4	fhás	fás	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cop	_	_
 5	drochiontaoibh	drochiontaoibh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
-6	Kitchener	Kitchener	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	_
+6	Kitchener	Kitchener	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 7	-	-	PUNCT	Punct	_	8	punct	_	_
 8	eisean	eisean	PRON	Pers	Gender=Masc|Number=Sing|Person=3|PronType=Emp	6	nmod	_	_
 9	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	case	_	_
-10	Ard-Cheannasaí	ardcheannasaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	xcomp:pred	_	_
+10	Ard-Cheannasaí	ardcheannasaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	xcomp:pred	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
-12	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	conj	_	_
-13	Mharascal	Marascal	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	NamedEntity=Yes
-14	Machaire	Machaire	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
+12	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	13	case	_	_
+13	Mharascal	marascal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	conj	_	NamedEntity=Yes
+14	Machaire	machaire	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	san	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	fheachtas	feachtas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
+16	fheachtas	feachtas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	_
 17	sin	sin	DET	Det	PronType=Dem	16	det	_	_
 18	-	-	PUNCT	Punct	_	20	punct	_	_
 19	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	20	case	_	_
-20	fuath	fuath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	_
+20	fuath	fuath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 21	dearg	dearg	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	20	amod	_	_
 22	do	do	ADP	Simp	_	23	case	_	_
-23	Churchill	Churchill	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
+23	Churchill	Churchill	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	agus	agus	CCONJ	Coord	_	26	cc	_	_
 26	vice	vice	NOUN	Noun	Case=NomAcc|Foreign=Yes|Gender=Fem|Number=Sing	20	conj	_	_
@@ -4334,10 +4334,10 @@
 
 # sent_id = 179
 # text = Duine fíorthuisceanach é Ciarán a thug faoi deara go luath buanna Chaitlín Maude.
-1	Duine	Duine	PROPN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	fíorthuisceanach	fíorthuisceanach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nmod	_	_
-4	Ciarán	Ciarán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+4	Ciarán	Ciarán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	acl:relcl	_	_
 7	faoi	faoi	ADP	Simp	_	8	case	_	_
@@ -4346,7 +4346,7 @@
 10	luath	luath	ADJ	Adj	Degree=Pos	6	advmod	_	_
 11	buanna	bua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	6	obj	_	_
 12	Chaitlín	Caitlín	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	NamedEntity=Yes
-13	Maude	Maude	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+13	Maude	Maude	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 180
@@ -4377,10 +4377,10 @@
 # text = Chuir an Síneach isteach sa chomhrá go tapa.
 1	Chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	Síneach	Síneach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	Síneach	Síneach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	isteach	isteach	ADV	Dir	_	1	advmod	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chomhrá	comhrá	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	chomhrá	comhrá	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	go	go	PART	Ad	PartType=Ad	8	mark:prt	_	_
 8	tapa	tapa	ADJ	Adj	Degree=Pos	1	advmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	_	_
@@ -4390,11 +4390,11 @@
 1	Ghlac	glac	VERB	VT	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	aintín	aintín	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	máthar	máthair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
+4	máthar	máthair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Bean	Bean	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
+6	Bean	Bean	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
 7	Uí	uí	PART	Pat	PartType=Pat	6	flat:name	_	NamedEntity=Yes
-8	Eidhin	Eidhin	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+8	Eidhin	Eidhin	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	11	punct	_	_
 10	as	as	ADP	Simp	_	11	case	_	_
 11	Sráid	sráid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nmod	_	_
@@ -4403,7 +4403,7 @@
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	Co.	contae	NOUN	Abr	Abbr=Yes	11	nmod	_	NamedEntity=Yes
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	NamedEntity=Yes
-17	Chláir	Chláir	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
+17	Chláir	Clár	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	cúram	cúram	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
@@ -4418,14 +4418,14 @@
 2	tús	tús	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	leis	le	ADP	Simp	_	5	case	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	ranganna	rang	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obl	_	_
+5	ranganna	rang	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 6	ag	ag	ADP	Simp	_	8	case	_	_
 7	Bishopsgate	Bishopsgate	X	Foreign	Foreign=Yes	5	nmod	_	NamedEntity=Yes
 8	Institute	Institute	X	Foreign	Foreign=Yes	7	flat:foreign	_	NamedEntity=Yes
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	7	7	NUM	Num	_	1	obl:tmod	_	NamedEntity=Yes
-11	Deireadh	Deireadh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
-12	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
+11	Deireadh	Deireadh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
+12	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 186
@@ -4436,9 +4436,9 @@
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 5	aithne	aithne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obj	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
-7	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+7	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
 8	Ó	ó	PART	Pat	PartType=Pat	7	flat:name	_	NamedEntity=Yes
-9	hEithir	Eithir	PROPN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	7	flat:name	_	NamedEntity=Yes
+9	hEithir	Eithir	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	7	flat:name	_	NamedEntity=Yes
 10	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	11	advmod	_	_
 11	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
 12	aon	aon	DET	Det	PronType=Ind	13	det	_	_
@@ -4447,23 +4447,23 @@
 15	cainte	caint	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
 16	orthu	ar	ADP	Prep	Number=Plur|Person=3	11	obl:prep	_	_
 17	-	-	PUNCT	Punct	_	18	punct	_	_
-18	Sonny	Sonny	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	parataxis	_	_
+18	Sonny	Sonny	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	parataxis	_	_
 19	ag	ag	ADP	Simp	_	20	case	_	_
 20	fiafraí	fiafraí	NOUN	Noun	VerbForm=Vnoun	18	xcomp	_	_
 21	de	de	ADP	Simp	_	22	case	_	_
-22	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
+22	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	_
 23	an	an	PART	Vb	PartType=Vb	24	mark:prt	_	_
 24	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	20	ccomp	_	_
 25	aithne	aithne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	nsubj	_	_
 26	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	24	obl:prep	_	_
 27	ar	ar	ADP	Simp	_	29	case	_	_
 28	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
-29	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	obl	_	_
+29	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	24	obl	_	_
 30	seo	seo	PRON	Dem	PronType=Dem	29	det	_	_
 31	nó	nó	CCONJ	Coord	_	32	cc	_	_
 32	siúd	siúd	PRON	Dem	PronType=Dem	30	conj	_	_
 33	agus	agus	CCONJ	Coord	_	34	cc	_	_
-34	Breandán	Breandán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	conj	_	_
+34	Breandán	Breandán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	conj	_	_
 35	ag	ag	ADP	Simp	_	36	case	_	_
 36	inseacht	insint	NOUN	Noun	VerbForm=Vnoun	34	xcomp	_	_
 37	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	36	obl:prep	_	SpaceAfter=No
@@ -4475,9 +4475,9 @@
 43	i	i	ADP	Simp	_	44	case	_	_
 44	gCathú	cathú	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	41	obl	_	_
 45	seanchairde	seanchara	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	39	obj	_	_
-46	Bhreandáin	Breandáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	45	nmod	_	_
+46	Bhreandáin	Breandáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	45	nmod	_	_
 47	i	i	ADP	Simp	_	48	case	_	_
-48	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	45	nmod	_	_
+48	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	45	nmod	_	_
 49	le	le	ADP	Simp	_	50	case	_	_
 50	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	39	obl	_	_
 51	agus	agus	CCONJ	Coord	_	52	cc	_	_
@@ -4491,7 +4491,7 @@
 59	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	58	acl:relcl	_	_
 60	luaite	luaite	ADJ	Adj	VerbForm=Part	59	xcomp:pred	_	_
 61	sa	i	ADP	Art	Number=Sing|PronType=Art	62	case	_	_
-62	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	60	nmod	_	_
+62	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	60	nmod	_	_
 63	ach	ach	CCONJ	Coord	_	64	cc	_	_
 64	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	59	conj	_	_
 65	imithe	imithe	ADJ	Adj	VerbForm=Part	64	xcomp:pred	_	_
@@ -4512,7 +4512,7 @@
 9	meas	meas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obj	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	bhfocal	focal	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
+12	bhfocal	focal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
 13	scríofa	scríofa	ADJ	Adj	VerbForm=Part	12	xcomp:pred	_	_
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
@@ -4534,8 +4534,8 @@
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 5	dTaoiseach	taoiseach	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	2	nmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	Bertie	Bertie	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	appos	_	NamedEntity=Yes
-8	Ahern	Ahern	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+7	Bertie	Bertie	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	appos	_	NamedEntity=Yes
+8	Ahern	Ahern	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	tamall	tamall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obj	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
@@ -4543,10 +4543,10 @@
 13	a	a	PART	Inf	PartType=Inf	14	mark	_	_
 14	chaitheamh	caitheamh	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 15	san	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	óstán	óstán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
+16	óstán	óstán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 17	seo	seo	DET	Det	PronType=Dem	16	det	_	_
 18	gach	gach	DET	Det	Definite=Def	19	det	_	_
-19	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	obl:tmod	_	_
+19	bliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	obl:tmod	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
 22	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	_
@@ -4589,8 +4589,8 @@
 4	mé	mé	PRON	Pers	Number=Sing|Person=1	3	nsubj	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	Ancient	Ancient	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
-8	Mariner	Mariner	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Ancient	Ancient	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+8	Mariner	Mariner	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	nó	nó	CCONJ	Coord	_	10	cc	_	_
 10	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	conj	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
@@ -4604,14 +4604,14 @@
 # sent_id = 191
 # text = Bhíodh Conall Ó Dochartaigh ag airneál ag an mháistir go mion is go minic.
 1	Bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	0	root	_	_
-2	Conall	Conall	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
+2	Conall	Conall	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	Ó	ó	PART	Pat	PartType=Pat	2	flat:name	_	NamedEntity=Yes
-4	Dochartaigh	Dochartaigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+4	Dochartaigh	Dochartaigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 5	ag	ag	ADP	Simp	_	6	case	_	_
 6	airneál	airneál	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 7	ag	ag	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	mháistir	máistir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
+9	mháistir	máistir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 10	go	go	PART	Ad	PartType=Ad	11	mark:prt	_	_
 11	mion	mion	ADJ	Adj	Degree=Pos	6	advmod	_	_
 12	is	agus	CCONJ	Coord	_	14	cc	_	_
@@ -4635,7 +4635,7 @@
 # sent_id = 193
 # text = Sa meathdhorchadas sin d'fhéadas an stáitse a dhéanamh amach ar éigean faoina shoilse fanna néoin.
 1	Sa	i	ADP	Art	Number=Sing|PronType=Art	2	case	_	_
-2	meathdhorchadas	meathdhorchadas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
+2	meathdhorchadas	meathdhorchadas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	sin	sin	DET	Det	PronType=Dem	2	det	_	_
 4	d'	do	PART	Vb	PartType=Vb	5	mark:prt	_	SpaceAfter=No
 5	fhéadas	féad	VERB	VTI	Form=Len|Mood=Ind|PronType=Rel|Tense=Pres	0	root	_	_
@@ -4647,7 +4647,7 @@
 11	ar	ar	ADP	Simp	_	12	case	_	_
 12	éigean	éigean	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nmod	_	_
 13	faoina	faoi	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	case	_	_
-14	shoilse	solas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	5	obl	_	_
+14	shoilse	solas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	5	obl	_	_
 15	fanna	fann	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	14	amod	_	_
 16	néoin	néon	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	5	punct	_	_
@@ -4682,13 +4682,13 @@
 1	Chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	teangeolaíocht	teangeolaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
+4	teangeolaíocht	teangeolaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
 6	gcoitinne	coitinne	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	4	nmod	_	_
 7	chun	chun	ADP	Simp	_	8	case	_	_
 8	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	obl	_	_
 9	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+10	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 11	seo	seo	DET	Det	PronType=Dem	10	det	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4700,9 +4700,9 @@
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	nsubj	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	acl:relcl	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
-7	Seosamh	Seosamh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
+7	Seosamh	Seosamh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
 8	Ó	ó	PART	Pat	PartType=Pat	7	flat:name	_	NamedEntity=Yes
-9	Cearbhaill	Cearbhaill	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
+9	Cearbhaill	Cearbhaill	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
 10	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	3	obl:prep	_	_
 11	gruaim	gruaim	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
@@ -4726,7 +4726,7 @@
 3	fhathach	fathach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 4	isteach	isteach	ADV	Dir	_	1	advmod	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chúige	cúige	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	chúige	cúige	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 9	siad	siad	PRON	Pers	Number=Plur|Person=3	8	nsubj	_	_
@@ -4808,9 +4808,9 @@
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	obl	_	_
 9	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	5	acl:relcl	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Rose	Rose	PROPN	Noun	_	9	nsubj	_	NamedEntity=Yes
+11	Rose	Rose	X	Foreign	Foreign=Yes	9	nsubj	_	NamedEntity=Yes
 12	of	of	X	Foreign	Foreign=Yes	11	flat:foreign	_	NamedEntity=Yes
-13	Mooncoin	Mooncoin	PROPN	Foreign	Foreign=Yes	11	flat:foreign	_	NamedEntity=Yes
+13	Mooncoin	Mooncoin	X	Foreign	Foreign=Yes	11	flat:foreign	_	NamedEntity=Yes
 14	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -4823,12 +4823,12 @@
 5	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	3	acl:relcl	_	_
 6	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	5	nsubj	_	_
 7	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	8	case	_	_
-8	cónaí	cónaí	NOUN	Noun	VerbForm=Inf	5	xcomp:pred	_	_
+8	cónaí	cónaí	NOUN	Noun	Definite=Def|VerbForm=Inf	5	xcomp:pred	_	_
 9	inti	i	ADP	Prep	Gender=Fem|Number=Sing|Person=3	8	obl:prep	_	_
 10	-	-	PUNCT	Punct	_	11	punct	_	_
-11	Anaconda-	Anaconda-	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
+11	Anaconda-	Anaconda-	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 12	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	13	nmod:poss	_	_
-13	hainm	ainm	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	1	obj	_	_
+13	hainm	ainm	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Sing	1	obj	_	_
 14	ón	ó	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
 15	nathair	nathair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 16	nimhe	nimh	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	_
@@ -4851,7 +4851,7 @@
 6	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	gcainteoir	cainteoir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
+9	gcainteoir	cainteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
 10	ba	is	PART	Sup	PartType=Sup	11	mark:prt	_	_
 11	chruthaithí	cruthaitheach	ADJ	Adj	Degree=Cmp,Sup|Form=Len	9	amod	_	_
 12	dá	dá	PART	Rel	PronType=Rel	13	obl	_	_
@@ -4862,10 +4862,10 @@
 17	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	obl:prep	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
 19	i	i	ADP	Simp	_	20	case	_	_
-20	mBéarla	Béarla	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
+20	mBéarla	Béarla	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
 21	nó	nó	CCONJ	Coord	_	23	cc	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	20	conj	_	SpaceAfter=No
+23	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	20	conj	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 206
@@ -4873,7 +4873,7 @@
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nmod	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	difríocht	difríocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
+4	difríocht	difríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 5	is	is	PART	Sup	PartType=Sup	6	mark:prt	_	_
 6	suntasaí	suntasach	ADJ	Adj	Degree=Cmp,Sup	4	amod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	9	punct	_	_
@@ -4899,12 +4899,12 @@
 27	i	i	ADP	Simp	_	28	case	_	_
 28	gcomhthéacs	comhthéacs	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
-30	ilteangachais	ilteangachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	_
+30	ilteangachais	ilteangachas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	_
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	obj	_	_
 32	chothaigh	cothaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	30	acl:relcl	_	_
 33	athréimniú	athréimniú	NOUN	Noun	VerbForm=Inf	32	nsubj	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
-35	hEabhraise	Eabhrais	PROPN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
+35	hEabhraise	Eabhrais	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 207
@@ -4912,14 +4912,14 @@
 1	De	de	ADP	Simp	_	2	case	_	_
 2	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	nmod	_	_
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
+4	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
 6	éirionn	éirigh	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	teannas	teannas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	idir	idir	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	saighdiúirí	saighdiúir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	8	nmod	_	_
+11	saighdiúirí	saighdiúir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	bunadh	bunadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	conj	_	_
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
@@ -4938,7 +4938,7 @@
 27	cosúlacht	cosúlacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	nmod	_	_
 28	níl	bí	VERB	PresInd	Mood=Ind|Polarity=Neg|Tense=Pres	6	parataxis	_	_
 29	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	30	nmod:poss	_	_
-30	dhath	dath	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	28	nsubj	_	_
+30	dhath	dath	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	nsubj	_	_
 31	le	le	ADP	Simp	_	32	case	_	_
 32	déanamh	déanamh	NOUN	Noun	VerbForm=Inf	28	xcomp	_	_
 33	agatsa	ag	ADP	Prep	Number=Sing|Person=2|PronType=Emp	32	obl:prep	_	_
@@ -4946,12 +4946,12 @@
 35	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	28	xcomp	_	_
 36	i	i	ADP	Simp	_	38	case	_	_
 37	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	38	det	_	_
-38	shuí	suí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	35	xcomp:pred	_	_
+38	shuí	suí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	xcomp:pred	_	_
 39	ansin	ansin	ADV	Loc	_	35	advmod	_	_
 40	ag	ag	ADP	Simp	_	41	case	_	_
 41	leathnú	leathnú	NOUN	Noun	VerbForm=Vnoun	35	xcomp	_	_
 42	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	43	det	_	_
-43	thóin	tóin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	41	obj	_	_
+43	thóin	tóin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	41	obj	_	_
 44	agus	agus	CCONJ	Coord	_	46	cc	_	_
 45	ag	ag	ADP	Simp	_	46	case	_	_
 46	cuimhniú	cuimhniú	NOUN	Noun	VerbForm=Vnoun	41	conj	_	_
@@ -4982,13 +4982,13 @@
 19	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	17	mark:prt	_	_
 20	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	10	csubj:cleft	_	_
 21	sa	i	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
-22	chumann	cumann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	20	xcomp:pred	_	_
+22	chumann	cumann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	xcomp:pred	_	_
 23	-	-	PUNCT	Punct	_	24	punct	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
 25	cothú	cothú	NOUN	Noun	VerbForm=Vnoun	20	xcomp	_	_
 26	cluichí	cluiche	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	25	obj	_	_
 27	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	gclub	club	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	26	nmod	_	_
+28	gclub	club	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	26	nmod	_	_
 29	agus	agus	CCONJ	Coord	_	31	cc	_	_
 30	ag	ag	ADP	Simp	_	31	case	_	_
 31	riaradh	riaradh	NOUN	Noun	VerbForm=Vnoun	25	conj	_	_
@@ -5018,7 +5018,7 @@
 1	Coincleach	coincleach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	parataxis	_	_
 2	Rinneadh	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 3	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	4	det	_	_
-4	taifeadtaí	taifead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	obj	_	_
+4	taifeadtaí	taifead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	2	obj	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	shorcóirí	sorcóir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	2	obl	_	_
 7	céire	céir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
@@ -5026,26 +5026,26 @@
 9	i	i	ADP	Simp	_	10	case	_	_
 10	mbaol	baol	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	xcomp:pred	_	_
 11	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	12	nmod:poss	_	_
-12	scriosta	scriosadh	NOUN	Noun	Case=Gen|VerbForm=Inf	10	xcomp	_	_
+12	scriosta	scriosadh	NOUN	Noun	Case=Gen|Definite=Def|VerbForm=Inf	10	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	coincleach	coincleach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
 16	fhásann	fás	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	14	acl:relcl	_	_
 17	ar	ar	ADP	Simp	_	19	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
-19	gcéir	céir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	SpaceAfter=No
+19	gcéir	céir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	ach	ach	SCONJ	Subord	_	22	mark	_	_
 22	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	2	advcl	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	fisiceoir	fisiceoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	nsubj	_	_
-25	Mike	Mike	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	appos	_	NamedEntity=Yes
-26	Redfern	Redfern	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+25	Mike	Mike	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	appos	_	NamedEntity=Yes
+26	Redfern	Redfern	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
 28	go	go	PART	Vb	PartType=Cmpl	29	mark:prt	_	_
 29	bhféadfaí	féad	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	22	ccomp	_	_
 30	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	31	det	_	_
-31	taifeadtaí	taifead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	33	obj	_	_
+31	taifeadtaí	taifead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	33	obj	_	_
 32	a	a	PART	Inf	PartType=Inf	33	mark	_	_
 33	shábháil	sábháil	NOUN	Noun	Form=Len|VerbForm=Inf	29	xcomp	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
@@ -5071,17 +5071,17 @@
 2	dearadh	dearadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	fisiciúil	fisiciúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	stáitse	stát	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+5	stáitse	stát	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
 7	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 8	leis	le	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+10	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 212
 # text = Seán.
-1	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+1	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 213
@@ -5111,13 +5111,13 @@
 4	BÁN	bán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	SpaceAfter=No
 5	:	:	PUNCT	Punct	_	7	punct	_	_
 6	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	fhírinne	fírinne	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
+7	fhírinne	fírinne	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
 8	choíche	choíche	ADV	Gn	_	7	advmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	7	punct	_	_
 10	deirim	abair	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	3	parataxis	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	fhírinne	fírinne	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
+13	fhírinne	fírinne	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
 14	choíche	choíche	ADV	Gn	_	13	advmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -5154,16 +5154,16 @@
 6	,	,	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 7	'	'	PUNCT	Punct	_	2	punct	_	_
 8	adúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-9	Jóín	Jóín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
-10	Joe	Joe	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
-11	Labhráis	Labhrás	PROPN	Noun	Case=Gen|Gender=Masc	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	Jóín	Jóín	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
+10	Joe	Joe	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+11	Labhráis	Labhrás	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	brú	brú	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 15	isteach	isteach	ADV	Dir	_	14	advmod	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	18	det	_	_
-18	gcúl	cúl	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	14	obl	_	_
+18	gcúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	obl	_	_
 19	chois	cois	NOUN	Noun	Case=Dat|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
 21	chlaí	claí	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
@@ -5182,13 +5182,13 @@
 9	hóglaigh	óglach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	6	obl	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
 11	gcomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
-12	Champabasso	Champabasso	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
+12	Champabasso	Champabasso	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	_
 13	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	14	cop	_	_
 14	olc	olc	ADJ	Adj	Degree=Pos	6	ccomp	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
 16	chuireadar	cuir	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=3|Tense=Past	14	csubj:cleft	_	_
 17	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obj	_	_
+18	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	16	obj	_	_
 19	airgid	airgead	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -5218,7 +5218,7 @@
 22	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	19	advcl	_	_
 23	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	22	nsubj	_	_
 24	dhá	do	ADP	Poss	Form=Len|Person=3|Poss=Yes	25	case	_	_
-25	coinneáil	coinneáil	NOUN	Noun	VerbForm=Inf	22	xcomp:pred	_	_
+25	coinneáil	coinneáil	NOUN	Noun	Definite=Def|VerbForm=Inf	22	xcomp:pred	_	_
 26	dúinte	dúinte	ADJ	Adj	VerbForm=Part	25	xcomp:pred	_	_
 27	le	le	ADP	Simp	_	28	case	_	_
 28	foréigean	foréigean	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
@@ -5240,7 +5240,7 @@
 8	ag	ag	ADP	Simp	_	9	case	_	_
 9	ligean	ligean	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 10	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	11	nmod:poss	_	_
-11	uillinne	uillinn	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	obj	_	_
+11	uillinne	uillinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	obj	_	_
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	chathaoir	cathaoir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
@@ -5255,7 +5255,7 @@
 23	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	26	cop	_	_
 24	ar	ar	ADP	Simp	_	26	case	_	_
 25	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	26	nmod:poss	_	_
-26	ghlúine	glúin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	22	ccomp	_	_
+26	ghlúine	glúin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	22	ccomp	_	_
 27	a	a	PART	Vb	PartType=Vb|PronType=Rel	28	mark:prt	_	_
 28	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	26	csubj:cleft	_	_
 29	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	28	nsubj	_	SpaceAfter=No
@@ -5270,7 +5270,7 @@
 38	dtuigfí	tuig	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	24	conj	_	_
 39	nach	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	41	cop	_	_
 40	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	41	case	_	_
-41	shuí	suí	NOUN	Noun	Form=Len|VerbForm=Inf	38	ccomp	_	_
+41	shuí	suí	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	38	ccomp	_	_
 42	a	a	PART	Vb	PartType=Vb|PronType=Rel	43	mark:prt	_	_
 43	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	41	csubj:cleft	_	_
 44	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	43	nsubj	_	SpaceAfter=No
@@ -5289,18 +5289,18 @@
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	togha	togha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
-12	bia	bia	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
+12	bia	bia	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 13	agus	agus	CCONJ	Coord	_	5	nsubj	_	_
 14	rogha	rogha	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
 15	gach	gach	DET	Det	Definite=Def	16	det	_	_
-16	dí	deoch	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
+16	dí	deoch	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	acu	ag	ADP	Prep	Number=Plur|Person=3	5	obl:prep	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	saol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 21	ar	ar	ADP	Simp	_	23	case	_	_
 22	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	mianta	mian	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	20	nmod	_	_
+23	mianta	mian	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	20	nmod	_	_
 24	féin	féin	PRON	Ref	Reflex=Yes	23	nmod	_	_
 25	acu	ag	ADP	Prep	Number=Plur|Person=3	5	obl:prep	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	5	punct	_	_
@@ -5309,9 +5309,9 @@
 # text = Ba í Dearbhla Ní Bhrolacháin a léirigh an seó agus dar ndóigh tá aithne mhaith ar Dhearbhla mar amhránaí den scoth agus is cuimhin linn ar fad an dlúthdhiosca blasta a d'eisigh sí roinnt blianta ó shin.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	3	nmod	_	_
-3	Dearbhla	Dearbhla	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	Dearbhla	Dearbhla	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	Ní	ní	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
-5	Bhrolacháin	Brolachán	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
+5	Bhrolacháin	Brolachán	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	mark:prt	_	_
 7	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
@@ -5323,11 +5323,11 @@
 14	aithne	aithne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nsubj	_	_
 15	mhaith	maith	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	amod	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
-17	Dhearbhla	Dearbhla	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	13	obl	_	_
+17	Dhearbhla	Dearbhla	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	obl	_	_
 18	mar	mar	ADP	Simp	_	19	case	_	_
 19	amhránaí	amhránaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	_
 20	den	de	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
-21	scoth	scoth	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	nmod	_	_
+21	scoth	scoth	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	agus	agus	CCONJ	Coord	_	24	cc	_	_
 23	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	24	cop	_	_
 24	cuimhin	cuimhin	NOUN	Subst	Case=NomAcc|Number=Sing	13	conj	_	_
@@ -5355,14 +5355,14 @@
 4	ar	ar	ADP	Simp	_	3	nmod	_	_
 5	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	4	fixed	_	_
 6	den	de	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	nua-aimsearthacht	nua-aimsearthacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	nmod	_	_
+7	nua-aimsearthacht	nua-aimsearthacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 8	bhréagach	bréagach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	amod	_	_
 9	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	7	acl:relcl	_	_
 10	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	case	_	_
-11	shantú	santú	NOUN	Noun	Form=Len|VerbForm=Inf	9	xcomp	_	_
+11	shantú	santú	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	9	xcomp	_	_
 12	ag	ag	ADP	Simp	_	13	case	_	_
-13	Béal	Béal	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
-14	Feirste	Feirste	PROPN	Noun	_	13	nmod	_	NamedEntity=Yes
+13	Béal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
+14	Feirste	Feirste	PROPN	Noun	Definite=Def	13	nmod	_	NamedEntity=Yes
 15	le	le	SCONJ	Subord	_	17	mark	_	_
 16	go	go	SCONJ	Subord	_	15	fixed	_	_
 17	dtig	tar	VERB	VI	Form=Ecl|Mood=Ind|Tense=Pres	2	advcl	_	_
@@ -5372,9 +5372,9 @@
 21	ar	ar	ADP	Simp	_	22	case	_	_
 22	chomhchéim	comhchéim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	20	xcomp:pred	_	_
 23	le	le	ADP	Simp	_	24	case	_	_
-24	Quartier	Quartier	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
-25	Latin	Latin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
-26	Phárais	Páras	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
+24	Quartier	Quartier	X	Foreign	Foreign=Yes	22	nmod	_	NamedEntity=Yes
+25	Latin	Latin	X	Foreign	Foreign=Yes	24	flat:foreign	_	NamedEntity=Yes
+26	Phárais	Páras	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 225
@@ -5388,7 +5388,7 @@
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	dó	dó	NOUN	Noun	VerbForm=Vnoun	5	conj	_	_
 9	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
-10	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	8	obj	_	_
+10	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	8	obj	_	_
 11	loirgne	lorga	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	10	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	ach	ach	SCONJ	Subord	_	14	mark	_	_
@@ -5397,7 +5397,7 @@
 16	íslithe	íslithe	ADJ	Adj	VerbForm=Part	14	xcomp:pred	_	_
 17	síos	síos	ADV	Dir	_	16	advmod	_	_
 18	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obl	_	SpaceAfter=No
+19	measc	measc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	obl	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	mar	mar	ADP	Simp	_	14	advmod	_	_
 22	sin	sin	PRON	Dem	PronType=Dem	21	fixed	_	_
@@ -5419,23 +5419,23 @@
 11	a	a	PART	Inf	PartType=Inf	12	mark	_	_
 12	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	7	xcomp	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	_
+14	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	_
 15	seo	seo	DET	Det	PronType=Dem	14	det	_	_
 16	go	go	ADP	Cmpd	PrepForm=Cmpd	19	case	_	_
 17	dtí	dtí	ADP	Cmpd	Form=Ecl	16	fixed	_	_
 18	go	go	PART	Vb	PartType=Cmpl	19	mark:prt	_	_
 19	dtiocfaidh	tar	VERB	VI	Form=Ecl|Mood=Ind|Tense=Fut	7	advcl	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	nsubj	_	_
+21	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	nsubj	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	obl:tmod	_	_
 23	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	21	acl:relcl	_	_
 24	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	NamedEntity=Yes
 25	Páirtí	páirtí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	NamedEntity=Yes
-26	Glas	Glas	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
+26	Glas	Glas	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	25	amod	_	NamedEntity=Yes
 27	i	i	ADP	Simp	_	28	case	_	_
 28	gcomhrialtas	comhrialtas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	23	xcomp:pred	_	_
 29	sa	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
-30	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	obl	_	_
+30	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	obl	_	_
 31	seo	seo	DET	Det	PronType=Dem	30	det	_	SpaceAfter=No
 32	?	?	PUNCT	?	_	1	punct	_	_
 
@@ -5452,7 +5452,7 @@
 # text = Tá an teilifís 'mínádúrtha'.
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	teilifís	teilifís	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+3	teilifís	teilifís	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	'	'	PUNCT	Punct	_	5	punct	_	SpaceAfter=No
 5	mínádúrtha	mínádúrtha	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	SpaceAfter=No
 6	'	'	PUNCT	Punct	_	5	punct	_	SpaceAfter=No
@@ -5476,9 +5476,9 @@
 14	ar	ar	ADP	Simp	_	15	case	_	_
 15	chlár	clár	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 16	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	17	nmod:poss	_	_
-17	éadain	éadan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	_
+17	éadain	éadan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	_
 18	A	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
+19	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	dislocated	_	_
 20	fola	fuil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
 21	is	agus	CCONJ	Coord	_	22	cc	_	_
 22	allais	allas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	conj	_	SpaceAfter=No
@@ -5526,7 +5526,7 @@
 24	le	le	ADP	Simp	_	25	case	_	_
 25	fórsaí	fórsa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	23	obl	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-27	Breataine	Breatain	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
+27	Breataine	Breatain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 231
@@ -5545,10 +5545,10 @@
 3	saoránach	saoránach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 4	Éireannach	Éireannach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	óna	ó	ADP	Poss	Poss=Yes	6	case	_	_
-6	bhreith	breith	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
+6	bhreith	breith	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 7	no	nó	CCONJ	Coord	Typo=Yes	9	cc	_	_
 8	óna	ó	ADP	Poss	Poss=Yes	9	case	_	_
-9	breith	breith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
+9	breith	breith	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	conj	_	_
 10	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	_
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	obj	_	_
 12	bheirtear	beir	VERB	PresInd	Form=Len|Mood=Ind|Person=0|Tense=Pres	10	acl:relcl	_	_
@@ -5659,7 +5659,7 @@
 81	-e	-e	NOUN	Noun	_	80	obj	_	_
 82	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	80	obl:prep	_	_
 83	sna	i	ADP	Art	Number=Plur|PronType=Art	84	case	_	_
-84	foirmeacha	foirm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	80	obl	_	_
+84	foirmeacha	foirm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	80	obl	_	_
 85	comparáide	comparáid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	84	nmod	_	SpaceAfter=No
 86	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -5667,7 +5667,7 @@
 # text = 'San áireamh: Cearta daonna Bunú comhlachtaí deonacha Cúiteamh timpiste Comhairle do scoileanna Gaeilge Tí Chulainn Co. Ard Mhacha.
 1	'	'	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 2	San	i	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	áireamh	áireamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+3	áireamh	áireamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 4	:	:	PUNCT	Punct	_	5	punct	_	_
 5	Cearta	ceart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	parataxis	_	_
 6	daonna	daonna	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	5	amod	_	_
@@ -5679,12 +5679,12 @@
 12	Comhairle	comhairle	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	list	_	_
 13	do	do	ADP	Simp	_	14	case	_	_
 14	scoileanna	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	12	nmod	_	_
-15	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
+15	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 16	Tí	tí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
-17	Chulainn	Culann	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+17	Chulainn	Culann	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	Co.	contae	NOUN	Abr	Abbr=Yes	17	nmod	_	NamedEntity=Yes
-19	Ard	Ard	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-20	Mhacha	Mhacha	PROPN	Noun	_	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
+19	Ard	Ard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+20	Mhacha	Mhacha	PROPN	Noun	Definite=Def	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 235
@@ -5699,12 +5699,12 @@
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	rialachán	rialachán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 10	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	_
+11	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 12	sin	sin	DET	Det	PronType=Dem	11	det	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	3	punct	_	_
 14	cuirfidh	cuir	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	Coimisiún	Coimisiún	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
+16	Coimisiún	Coimisiún	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 17	tograí	togra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	14	obj	_	_
 18	eile	eile	DET	Det	PronType=Dem	17	det	_	_
 19	(	(	PUNCT	Punct	_	20	punct	_	SpaceAfter=No
@@ -5715,13 +5715,13 @@
 24	chun	chun	ADP	Simp	_	25	case	_	_
 25	úsáid	úsáid	NOUN	Noun	VerbForm=Inf	31	obj	_	_
 26	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-27	leithreasaí	leithreas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	25	nmod	_	_
+27	leithreasaí	leithreas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	_
 28	lena	le	PART	Rel	PronType=Rel	29	obl	_	_
 29	mbaineann	bain	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Pres	27	acl:relcl	_	_
 30	a	a	PART	Inf	PartType=Inf	31	mark	_	_
 31	áirithiú	áirithiú	NOUN	Noun	VerbForm=Inf	14	xcomp	_	_
 32	sa	i	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
-33	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	31	obl	_	_
+33	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	31	obl	_	_
 34	airgeadais	airgeadas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	33	compound	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	14	punct	_	_
 
@@ -5730,16 +5730,16 @@
 1	Foilsíodh	foilsigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 3	chéad	céad	NUM	Num	Form=Len|NumType=Ord	4	amod	_	_
-4	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
+4	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
 5	den	de	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	sraith	sraith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nmod	_	_
+6	sraith	sraith	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 7	cartún	cartún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	compound	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
 9	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 10	1983	1983	NUM	Num	_	9	nmod	_	_
 11	agus	agus	CCONJ	Coord	_	15	mark	_	_
 12	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	mbliain	bliain	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	_
+13	mbliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	_
 14	1993	1993	NUM	Num	_	13	nmod	_	_
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 16	sé	sé	NUM	Num	NumType=Card	17	nummod	_	_
@@ -5785,7 +5785,7 @@
 4	fho-alt	fo-alt	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|NounType=Weak|Number=Plur	3	nmod	_	_
 5	(3)	(3)	NUM	Item	_	4	nmod	_	_
 6	den	de	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	_
+7	alt	alt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 8	seo	seo	DET	Det	PronType=Dem	7	det	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	3	punct	_	_
 10	is	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	11	cop	_	_
@@ -5794,7 +5794,7 @@
 13	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	11	acl:relcl	_	_
 14	ar	ar	ADP	Simp	_	16	case	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	mBuanchoiste	buanchoiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	13	obl	_	NamedEntity=Yes
+16	mBuanchoiste	buanchoiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	13	obl	_	NamedEntity=Yes
 17	Eolaíochta	eolaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	cibé	cibé	DET	Det	PronType=Ind	19	det	_	_
 19	líon	líon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nsubj	_	_
@@ -5803,19 +5803,19 @@
 22	cuí	cuí	ADJ	Adj	Degree=Pos	19	acl:relcl	_	_
 23	leis	le	ADP	Simp	_	25	case	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
-25	gCoimisiún	coimisiún	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	22	obl	_	_
+25	gCoimisiún	coimisiún	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	22	obl	_	_
 26	agus	agus	CCONJ	Coord	_	27	mark	_	_
 27	féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	11	advcl	_	_
 28	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	34	obj	_	_
 29	nach	is	AUX	Cop	Polarity=Neg|PronType=Rel|Tense=Pres|VerbForm=Cop	30	cop	_	_
 30	comhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	28	acl:relcl	_	_
 31	den	de	ADP	Art	Number=Sing|PronType=Art	32	case	_	_
-32	Choimisiún	coimisiún	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
+32	Choimisiún	coimisiún	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	_
 33	a	a	PART	Inf	PartType=Inf	34	mark	_	_
 34	áireamh	áireamh	NOUN	Noun	VerbForm=Inf	27	xcomp	_	_
 35	ar	ar	ADP	Simp	_	37	case	_	_
 36	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	37	nmod:poss	_	_
-37	chomhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	34	obl	_	SpaceAfter=No
+37	chomhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	34	obl	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	11	punct	_	_
 
 # sent_id = 239
@@ -5825,7 +5825,7 @@
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
 4	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	2	acl:relcl	_	_
 5	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	6	case	_	_
-6	gcomhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	4	xcomp:pred	_	_
+6	gcomhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	4	xcomp:pred	_	_
 7	de	de	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	coistí	coiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
@@ -5860,9 +5860,9 @@
 13	aon	aon	DET	Det	PronType=Ind	14	det	_	_
 14	rialachán	rialachán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obj	_	_
 15	arna	ar	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	case	_	_
-16	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	14	nmod	_	_
+16	dhéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	14	nmod	_	_
 17	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obl	_	_
+18	alt	alt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	obl	_	_
 19	seo	seo	DET	Det	PronType=Dem	18	det	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	féadfaidh	féad	VERB	VTI	Mood=Ind|Tense=Fut	5	parataxis	_	_
@@ -5923,7 +5923,7 @@
 22	liosta	liosta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	obj	_	_
 23	sin	sin	DET	Det	PronType=Dem	22	det	_	_
 24	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	25	case	_	_
-25	iomláine	iomláine	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
+25	iomláine	iomláine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 243
@@ -5946,7 +5946,7 @@
 7	éis	éis	ADP	Cmpd	_	6	fixed	_	_
 8	do	do	ADP	Simp	_	9	case	_	_
 9	Chonradh	conradh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	11	nsubj	_	NamedEntity=Yes
-10	Amstardam	Amstardam	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+10	Amstardam	Amstardam	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	teacht	teacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	xcomp	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	bhfeidhm	feidhm	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	11	nmod	_	SpaceAfter=No
@@ -5955,7 +5955,7 @@
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	Chomhairle	comhairle	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nsubj	_	_
 18	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	19	det	_	_
-19	bearta	beart	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	obj	_	_
+19	bearta	beart	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	15	obj	_	_
 20	seo	seo	DET	Det	PronType=Dem	19	det	_	_
 21	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	nsubj	_	_
 22	leanas	lean	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Past	19	acl:relcl	_	SpaceAfter=No
@@ -5997,9 +5997,9 @@
 58	bíodh	bí	VERB	Imper	Mood=Imp|Number=Sing|Person=3	52	parataxis	_	_
 59	siad	siad	PRON	Pers	Number=Plur|Person=3	58	nsubj	_	_
 60	ina	i	ADP	Poss	Poss=Yes	61	case	_	_
-61	saoránaigh	saoránach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	58	xcomp:pred	_	_
+61	saoránaigh	saoránach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	58	xcomp:pred	_	_
 62	den	de	ADP	Art	Number=Sing|PronType=Art	63	case	_	_
-63	Aontas	aontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	61	nmod	_	_
+63	Aontas	aontas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	61	nmod	_	_
 64	nó	nó	CCONJ	Coord	_	65	cc	_	_
 65	ina	i	ADP	Poss	Poss=Yes	61	conj	_	_
 66	náisiúnaigh	náisiúnach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	65	nmod	_	_
@@ -6020,7 +6020,7 @@
 81	teorainneacha	teorainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	86	obj	_	_
 82	seachtracha	seachtrach	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	81	amod	_	_
 83	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	84	det	_	_
-84	mBallstát	ballstát	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	81	nmod	_	_
+84	mBallstát	ballstát	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	81	nmod	_	_
 85	a	a	PART	Inf	PartType=Inf	86	mark	_	_
 86	thrasnú	trasnú	NOUN	Noun	Form=Len|VerbForm=Inf	78	xcomp	_	_
 87	a	a	PART	Vb	PartType=Vb|PronType=Rel	88	obj	_	_
@@ -6038,7 +6038,7 @@
 99	agus	agus	CCONJ	Coord	_	100	mark	_	_
 100	seiceálacha	seiceáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	102	obj	_	_
 101	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	102	case	_	_
-102	ndéanamh	déanamh	NOUN	Noun	Form=Ecl|VerbForm=Inf	96	advcl	_	_
+102	ndéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	96	advcl	_	_
 103	acu	ag	ADP	Prep	Number=Plur|Person=3	102	obl:prep	_	_
 104	ar	ar	ADP	Simp	_	105	case	_	_
 105	dhaoine	duine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	102	nmod	_	_
@@ -6070,17 +6070,17 @@
 131	liosta	liosta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	128	obj	_	_
 132	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	134	det	_	_
 133	dtríú	trí	NUM	Num	Form=Ecl|NumType=Ord	134	amod	_	_
-134	tíortha	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	131	nmod	_	_
+134	tíortha	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	131	nmod	_	_
 135	a	a	PART	Vb	PartType=Vb|PronType=Rel	136	nsubj	_	_
 136	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	134	acl:relcl	_	_
 137	ar	ar	ADP	Simp	_	142	case	_	_
 138	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	139	nmod:poss	_	_
-139	náisiúnaigh	náisiúnach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	142	obj	_	_
+139	náisiúnaigh	náisiúnach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	142	obj	_	_
 140	víosaí	víosa	NOUN	Noun	Case=NomAcc|Gender=Fem|NounType=Strong|Number=Plur	139	nmod	_	_
 141	a	a	PART	Inf	PartType=Inf	142	mark	_	_
 142	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	136	xcomp	_	_
 143	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	144	case	_	_
-144	seilbh	seilbh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	142	xcomp:pred	_	_
+144	seilbh	seilbh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	142	xcomp:pred	_	_
 145	acu	ag	ADP	Prep	Number=Plur|Person=3	144	obl:prep	_	_
 146	ar	ar	ADP	Simp	_	147	case	_	_
 147	thrasnú	trasnú	NOUN	Noun	Form=Len|VerbForm=Inf	142	obl	_	_
@@ -6091,14 +6091,14 @@
 152	liosta	liosta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	131	conj	_	_
 153	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	155	det	_	_
 154	dtríú	trí	NUM	Num	Form=Ecl|NumType=Ord	155	amod	_	_
-155	tíortha	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	152	nmod	_	_
+155	tíortha	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	152	nmod	_	_
 156	a	a	PART	Vb	PartType=Vb|PronType=Rel	157	nsubj	_	_
 157	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	155	acl:relcl	_	_
 158	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	159	nmod:poss	_	_
-159	náisiúnaigh	náisiúnach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	157	nsubj	_	_
+159	náisiúnaigh	náisiúnach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	157	nsubj	_	_
 160	saor	saor	ADJ	Adj	Case=NomAcc|NounType=Weak|Number=Sing	157	xcomp:pred	_	_
 161	ón	ó	ADP	Art	Number=Sing|PronType=Art	162	case	_	_
-162	gceanglas	ceanglas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	160	obl	_	_
+162	gceanglas	ceanglas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	160	obl	_	_
 163	sin	sin	DET	Det	PronType=Dem	162	det	_	SpaceAfter=No
 164	;	;	PUNCT	Punct	_	167	punct	_	_
 165	(ii)	(ii)	NUM	Item	_	167	list	_	_
@@ -6134,7 +6134,7 @@
 195	leagan	leagan	NOUN	Noun	VerbForm=Vnoun	193	xcomp	_	_
 196	amach	amach	ADV	Dir	_	195	advmod	_	_
 197	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	198	det	_	_
-198	gcoinníollacha	coinníoll	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	195	obj	_	_
+198	gcoinníollacha	coinníoll	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	195	obj	_	_
 199	faoina	faoi	PART	Rel	PronType=Rel	200	obl	_	_
 200	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	198	acl:relcl	_	_
 201	saoirse	saoirse	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	200	nsubj	_	_
@@ -6162,17 +6162,17 @@
 1	Má	má	SCONJ	Subord	_	2	mark	_	_
 2	bhreathnaítear	breathnaigh	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	8	advcl	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	Ghaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
+4	Ghaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
 6	dtosach	tosach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	2	punct	_	_
 8	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-9	Michael	Michael	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
-10	Crimmins	Crimmins	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
+9	Michael	Michael	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
+10	Crimmins	Crimmins	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	ar	ar	ADV	Dir	_	8	advmod	_	_
 12	ais	ais	ADV	Dir	_	11	fixed	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	gcúl	cúl	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	xcomp:pred	_	SpaceAfter=No
+14	gcúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	8	xcomp:pred	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 246
@@ -6182,74 +6182,74 @@
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 5	(	(	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
-6	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-7	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
-8	Cliath	Cliath	PROPN	Noun	_	7	nmod	_	NamedEntity=Yes|SpaceAfter=No
+6	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+7	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
+8	Cliath	Cliath	PROPN	Noun	Definite=Def	7	nmod	_	NamedEntity=Yes|SpaceAfter=No
 9	)	)	PUNCT	Punct	_	6	punct	_	_
 10	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	Ceoláras	ceoláras	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 12	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	11	amod	_	NamedEntity=Yes
 13	(	(	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
-14	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
-15	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
-16	Cliath	Cliath	PROPN	Noun	_	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
+14	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+15	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+16	Cliath	Cliath	PROPN	Noun	Definite=Def	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 17	)	)	PUNCT	Punct	_	14	punct	_	_
 18	Gailearaí	gailearaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 19	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	18	amod	_	NamedEntity=Yes
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	NamedEntity=Yes
 21	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	18	nmod	_	NamedEntity=Yes
 22	(	(	PUNCT	Punct	_	23	punct	_	SpaceAfter=No
-23	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-24	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
-25	Cliath	Cliath	PROPN	Noun	_	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
+23	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+24	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
+25	Cliath	Cliath	PROPN	Noun	Definite=Def	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 26	)	)	PUNCT	Punct	_	23	punct	_	_
-27	Músaem	músaem	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+27	Músaem	músaem	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 28	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	NamedEntity=Yes
 29	Staire	stair	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	NamedEntity=Yes
 30	Nádúrtha	nádúrtha	ADJ	Adj	Degree=Pos	29	amod	_	NamedEntity=Yes
 31	(	(	PUNCT	Punct	_	32	punct	_	SpaceAfter=No
-32	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
-33	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	32	nmod	_	NamedEntity=Yes
-34	Cliath	Cliath	PROPN	Noun	_	33	nmod	_	NamedEntity=Yes|SpaceAfter=No
+32	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
+33	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	NamedEntity=Yes
+34	Cliath	Cliath	PROPN	Noun	Definite=Def	33	nmod	_	NamedEntity=Yes|SpaceAfter=No
 35	)	)	PUNCT	Punct	_	32	punct	_	_
 36	Leabharlann	leabharlann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	list	_	NamedEntity=Yes
 37	Náisiúnta	náisiúnta	ADJ	Adj	Degree=Pos	36	amod	_	NamedEntity=Yes
 38	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	39	det	_	NamedEntity=Yes
 39	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	36	nmod	_	NamedEntity=Yes
 40	(	(	PUNCT	Punct	_	41	punct	_	SpaceAfter=No
-41	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	36	nmod	_	NamedEntity=Yes
-42	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	41	nmod	_	NamedEntity=Yes
-43	Cliath	Cliath	PROPN	Noun	_	42	nmod	_	NamedEntity=Yes|SpaceAfter=No
+41	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	nmod	_	NamedEntity=Yes
+42	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	41	nmod	_	NamedEntity=Yes
+43	Cliath	Cliath	PROPN	Noun	Definite=Def	42	nmod	_	NamedEntity=Yes|SpaceAfter=No
 44	)	)	PUNCT	Punct	_	41	punct	_	_
-45	Ard-Mhúsaem	Ard-Mhúsaem	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+45	Ard-Mhúsaem	Ard-Mhúsaem	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 46	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	47	det	_	NamedEntity=Yes
 47	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	45	nmod	_	NamedEntity=Yes|SpaceAfter=No
 48	,	,	PUNCT	Punct	_	49	punct	_	_
 49	Dún	dún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	nmod	_	NamedEntity=Yes
 50	Uí	uí	PART	Pat	PartType=Pat	49	nmod	_	NamedEntity=Yes
-51	Choileáin	Coileáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
+51	Choileáin	Coileáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
 52	(	(	PUNCT	Punct	_	53	punct	_	SpaceAfter=No
-53	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	49	nmod	_	NamedEntity=Yes
-54	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	53	nmod	_	NamedEntity=Yes
-55	Cliath	Cliath	PROPN	Noun	_	54	nmod	_	NamedEntity=Yes|SpaceAfter=No
+53	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	49	nmod	_	NamedEntity=Yes
+54	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	53	nmod	_	NamedEntity=Yes
+55	Cliath	Cliath	PROPN	Noun	Definite=Def	54	nmod	_	NamedEntity=Yes|SpaceAfter=No
 56	)	)	PUNCT	Punct	_	53	punct	_	_
-57	Ard-Mhúsaem	Ard-Mhúsaem	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+57	Ard-Mhúsaem	Ard-Mhúsaem	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 58	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	59	det	_	NamedEntity=Yes
 59	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	57	nmod	_	NamedEntity=Yes|SpaceAfter=No
 60	,	,	PUNCT	Punct	_	61	punct	_	_
-61	Sráid	sráid	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	57	nmod	_	NamedEntity=Yes
-62	Chill	Cill	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	61	nmod	_	NamedEntity=Yes
-63	Dara	Dara	PROPN	Noun	_	62	nmod	_	NamedEntity=Yes
+61	Sráid	sráid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	57	nmod	_	NamedEntity=Yes
+62	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	61	nmod	_	NamedEntity=Yes
+63	Dara	Dara	PROPN	Noun	Definite=Def	62	nmod	_	NamedEntity=Yes
 64	(	(	PUNCT	Punct	_	65	punct	_	SpaceAfter=No
-65	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	61	nmod	_	NamedEntity=Yes
-66	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	65	nmod	_	NamedEntity=Yes
-67	Cliath	Cliath	PROPN	Noun	_	66	nmod	_	NamedEntity=Yes|SpaceAfter=No
+65	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	61	nmod	_	NamedEntity=Yes
+66	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	65	nmod	_	NamedEntity=Yes
+67	Cliath	Cliath	PROPN	Noun	Definite=Def	66	nmod	_	NamedEntity=Yes|SpaceAfter=No
 68	)	)	PUNCT	Punct	_	65	punct	_	_
 69	National	National	PROPN	Noun	Case=NomAcc|Foreign=Yes|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 70	Photographic	photographic	NOUN	Noun	Case=NomAcc|Foreign=Yes|Gender=Fem|Number=Sing	69	flat:foreign	_	NamedEntity=Yes
 71	Archive	Archive	PROPN	Noun	Case=NomAcc|Foreign=Yes|Gender=Masc|Number=Sing	70	flat:foreign	_	NamedEntity=Yes
 72	(	(	PUNCT	Punct	_	73	punct	_	SpaceAfter=No
-73	Dublin	Dublin	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	69	nmod	_	NamedEntity=Yes|SpaceAfter=No
+73	Dublin	Dublin	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	69	nmod	_	NamedEntity=Yes|SpaceAfter=No
 74	)	)	PUNCT	Punct	_	73	punct	_	SpaceAfter=No
 75	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -6291,7 +6291,7 @@
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	tíre	tír	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	_
 36	san	i	ADP	Art	Number=Sing|PronType=Art	37	case	_	_
-37	iomlán	iomlán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	obl	_	SpaceAfter=No
+37	iomlán	iomlán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	obl	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 248
@@ -6318,7 +6318,7 @@
 7	nach	nach	PART	Vb	PartType=Cmpl|Polarity=Neg	8	mark:prt	_	_
 8	loitfí	loit	VERB	VT	Mood=Cnd|Person=0	5	ccomp	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	timpeallacht	timpeallacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	obj	_	_
+10	timpeallacht	timpeallacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	obj	_	_
 11	nádúrtha	nádúrtha	ADJ	Adj	Degree=Pos	10	amod	_	_
 12	le	le	ADP	Cmpd	PrepForm=Cmpd	20	case	_	_
 13	linn	linn	ADP	Cmpd	_	12	fixed	_	_
@@ -6350,7 +6350,7 @@
 13	beo	beo	ADJ	Adj	Degree=Pos	12	xcomp:pred	_	_
 14	roimh	roimh	ADP	Simp	_	16	case	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	anró	anró	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	nmod	_	_
+16	anró	anró	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	_
 17	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	16	acl:relcl	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
 19	ndán	dán	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	xcomp:pred	_	_
@@ -6359,7 +6359,7 @@
 22	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	2	advcl	_	_
 23	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	22	nsubj	_	_
 24	sa	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	bpobal	pobal	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	22	xcomp:pred	_	SpaceAfter=No
+25	bpobal	pobal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	22	xcomp:pred	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	28	punct	_	_
 27	i	i	ADP	Simp	_	28	case	_	_
 28	nglaise	glaise	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	22	obl	_	SpaceAfter=No
@@ -6369,7 +6369,7 @@
 32	gclochar	clochar	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	conj	_	_
 33	Dar	dar	ADP	Simp	_	35	case	_	_
 34	m'	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	35	nmod:poss	_	SpaceAfter=No
-35	fhocal	focal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	22	obl	_	_
+35	fhocal	focal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	obl	_	_
 36	dhaoibh	do	ADP	Prep	Form=Len|Number=Plur|Person=3	35	obl:prep	_	SpaceAfter=No
 37	,	,	PUNCT	Punct	_	38	punct	_	_
 38	cuirfead	cuir	VERB	VT	Mood=Ind|Number=Sing|Person=1|Tense=Fut	22	advcl	_	_
@@ -6415,7 +6415,7 @@
 15	faoi	faoi	ADP	Simp	_	16	case	_	_
 16	chaibidil	caibidil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	xcomp:pred	_	_
 17	sa	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	dírbheathaisnéis	dírbheathaisnéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	nmod	_	_
+18	dírbheathaisnéis	dírbheathaisnéis	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 19	caitear	caith	VERB	PresInd	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
 21	caidreamh	caidreamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	obj	_	_
@@ -6432,15 +6432,15 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Chabhraigh	cabhraigh	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	leon	leon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	leon	leon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	le	le	ADP	Simp	_	6	case	_	_
-6	Micí	Micí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
+6	Micí	Micí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 7	chun	chun	ADP	Simp	_	8	case	_	_
 8	dul	dul	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 9	suas	suas	ADV	Dir	_	8	advmod	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	nmod:poss	_	_
-12	dhroim	droim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+12	dhroim	droim	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 13	agus	agus	CCONJ	Coord	_	15	cc	_	_
 14	d'	do	PART	Vb	PartType=Vb	15	mark:prt	_	SpaceAfter=No
 15	eitil	eitil	VERB	VI	Mood=Ind|Tense=Past	2	conj	_	_
@@ -6467,11 +6467,11 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Dar	dar	VERB	PresInd	Mood=Ind|Tense=Pres	7	parataxis	_	_
 3	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	4	nmod:poss	_	_
-4	choinsias	coinsias	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
+4	choinsias	coinsias	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 6	'	'	PUNCT	Punct	_	2	punct	_	_
 7	arsa	arsa	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
-8	Deirdre	Deirdre	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
+8	Deirdre	Deirdre	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	11	punct	_	_
 10	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
 11	Thréig	tréig	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	parataxis	_	_
@@ -6479,14 +6479,14 @@
 13	sibh	sibh	PRON	Pers	Number=Plur|Person=2	11	obj	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	16	punct	_	_
 15	a	a	PART	Voc	PartType=Voc	16	case:voc	_	_
-16	mhaca	mac	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Plur	11	vocative	_	_
-17	Uisnigh	Uisneach	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
+16	mhaca	mac	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	11	vocative	_	_
+17	Uisnigh	Uisneach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	agus	agus	CCONJ	Coord	_	21	cc	_	_
 20	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	21	cop	_	_
 21	róchosúil	róchosúil	ADJ	Adj	Degree=Pos	11	conj	_	_
 22	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
-23	athair	athair	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	obl	_	_
+23	athair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	obl	_	_
 24	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	7	punct	_	_
 
@@ -6515,7 +6515,7 @@
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	14	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nmod	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	difríocht	difríocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nsubj	_	_
+4	difríocht	difríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	nsubj	_	_
 5	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	idir	idir	ADP	Simp	_	7	case	_	_
 7	bogadhmaid	bogadhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
@@ -6567,7 +6567,7 @@
 17	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	12	xcomp	_	_
 18	as	as	ADP	Simp	_	20	case	_	_
 19	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	20	nmod:poss	_	_
-20	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obl	_	_
+20	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	17	obl	_	_
 21	d'	de	ADP	Simp	_	22	case	_	SpaceAfter=No
 22	airgead	airgead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	6	punct	_	_
@@ -6645,18 +6645,18 @@
 47	caiteachais	caiteachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	46	nmod	_	_
 48	chaipitiúil	caipitiúil	ADJ	Adj	Form=Len|Number=Sing	47	amod	_	_
 49	arna	ar	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	50	obl	_	_
-50	thabhú	tabhú	NOUN	Noun	Form=Len|VerbForm=Inf	47	acl:relcl	_	_
+50	thabhú	tabhú	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	47	acl:relcl	_	_
 51	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	53	det	_	_
 52	3ú	3	NUM	Num	NumType=Ord	53	amod	_	_
-53	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	50	obl:tmod	_	_
+53	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	50	obl:tmod	_	_
 54	de	de	ADP	Simp	_	55	case	_	_
-55	Nollaig	Nollaig	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	53	nmod	_	SpaceAfter=No
+55	Nollaig	Nollaig	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	53	nmod	_	SpaceAfter=No
 56	,	,	PUNCT	Punct	_	57	punct	_	_
 57	1997	1997	NUM	Num	_	55	nmod	_	SpaceAfter=No
 58	,	,	PUNCT	Punct	_	61	punct	_	_
 59	nó	nó	CCONJ	Coord	_	61	mark	_	_
 60	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	61	case	_	_
-61	éis	éis	NOUN	Subst	Number=Sing	25	nmod	_	SpaceAfter=No
+61	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	25	nmod	_	SpaceAfter=No
 62	,	,	PUNCT	Punct	_	64	punct	_	_
 63	ar	ar	ADP	Simp	_	64	case	_	_
 64	fhoirgneamh	foirgneamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
@@ -6667,10 +6667,10 @@
 69	go	go	PART	Vb	PartType=Cmpl	70	mark:prt	_	_
 70	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	8	conj	_	_
 71	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	72	det	_	_
-72	liúntas	liúntas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	70	nsubj	_	_
+72	liúntas	liúntas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	70	nsubj	_	_
 73	nó	nó	CCONJ	Coord	_	75	cc	_	_
 74	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	75	det	_	_
-75	liúntais	liúntas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	72	conj	_	_
+75	liúntais	liúntas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	72	conj	_	_
 76	sin	sin	DET	Det	PronType=Dem	75	det	_	_
 77	le	le	ADP	Simp	_	78	case	_	_
 78	tabhairt	tabhairt	NOUN	Noun	VerbForm=Inf	70	xcomp	_	_
@@ -6684,7 +6684,7 @@
 86	a	a	PART	Inf	PartType=Inf	87	mark	_	_
 87	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	78	xcomp	_	_
 88	á	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	89	case	_	_
-89	cur	cur	NOUN	Noun	VerbForm=Inf	87	xcomp	_	_
+89	cur	cur	NOUN	Noun	Definite=Def|VerbForm=Inf	87	xcomp	_	_
 90	faoi	faoi	ADP	Simp	_	91	case	_	_
 91	cháin	cáin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	89	obl	_	SpaceAfter=No
 92	,	,	PUNCT	Punct	_	93	punct	_	_
@@ -6695,13 +6695,13 @@
 97	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	96	nsubj	_	SpaceAfter=No
 98	,	,	PUNCT	Punct	_	100	punct	_	_
 99	sa	i	ADP	Art	Number=Sing|PronType=Art	100	case	_	_
-100	bhonntréimhse	bonntréimhse	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	87	obl	_	_
+100	bhonntréimhse	bonntréimhse	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	87	obl	_	_
 101	don	do	ADP	Art	Number=Sing|PronType=Art	102	case	_	_
-102	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	100	nmod	_	_
+102	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	100	nmod	_	_
 103	mheasúnachta	measúnacht	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	102	nmod	_	_
 104	ar	ar	ADP	Simp	_	107	obl	_	_
 105	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	106	case	_	_
-106	leith	leith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	102	obl	_	_
+106	leith	leith	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	102	obl	_	_
 107	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	106	acl:relcl	_	_
 108	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	109	det	_	_
 109	liúntas	liúntas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	107	nsubj	_	_
@@ -6719,7 +6719,7 @@
 121	ndáil	dáil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	118	nmod	_	_
 122	leis	le	ADP	Simp	_	124	case	_	_
 123	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	124	det	_	_
-124	trádáil	trádáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	121	nmod	_	_
+124	trádáil	trádáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	121	nmod	_	_
 125	chomhpháirtíochta	comhpháirtíocht	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	124	nmod	_	_
 126	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	127	det	_	_
 127	phearsa	pearsa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	118	nsubj	_	_
@@ -6733,7 +6733,7 @@
 135	nó	nó	CCONJ	Coord	_	136	cc	_	_
 136	liúntas	liúntas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	134	conj	_	_
 137	den	de	ADP	Art	Number=Sing|PronType=Art	138	case	_	_
-138	sórt	sórt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	134	nmod	_	_
+138	sórt	sórt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	134	nmod	_	_
 139	sin	sin	DET	Det	PronType=Dem	138	det	_	_
 140	a	a	PART	Vb	PartType=Vb|PronType=Rel	141	nsubj	_	_
 141	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	134	acl:relcl	_	_
@@ -6753,7 +6753,7 @@
 155	de	de	ADP	Cmpd	PrepForm=Cmpd	158	case	_	_
 156	réir	réir	ADP	Cmpd	_	155	fixed	_	_
 157	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	158	det	_	_
-158	foirmle	foirmle	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	154	obl	_	_
+158	foirmle	foirmle	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	154	obl	_	_
 159	A	a	X	Abr	Abbr=Yes	158	nmod	_	_
 160	plus	plus	X	Foreign	Foreign=Yes	159	flat:foreign	_	_
 161	IRP25,000	IRP25,000	NUM	Num	_	159	flat:foreign	_	_
@@ -6772,7 +6772,7 @@
 174	pearsan	pearsa	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	171	nmod	_	_
 175	aonair	aonar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	174	nmod	_	_
 176	sa	i	ADP	Art	Number=Sing|PronType=Art	177	case	_	_
-177	bhliain	bliain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	174	nmod	_	_
+177	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	174	nmod	_	_
 178	chaillteanais	caillteanas	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	177	nmod	_	_
 179	sula	sula	SCONJ	Subord	_	180	mark	_	_
 180	gcuirtear	cuir	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	165	advcl	_	_
@@ -6790,12 +6790,12 @@
 3	rogha	rogha	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	advcl	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	coitiantachta	coitiantacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
-6	Tiobraid	Tiobraid	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	nsubj	_	NamedEntity=Yes
-7	Árann	Árann	PROPN	Noun	_	6	nmod	_	NamedEntity=Yes
+6	Tiobraid	Tiobraid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	nsubj	_	NamedEntity=Yes
+7	Árann	Árann	PROPN	Noun	Definite=Def	6	nmod	_	NamedEntity=Yes
 8	chun	chun	ADP	Simp	_	13	case	_	_
 9	craobh	craobh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obj	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
+11	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
 13	thógáil	tógáil	NOUN	Noun	Form=Len|VerbForm=Inf	3	csubj:cop	_	_
 14	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	15	cop	_	_
@@ -6804,23 +6804,23 @@
 17	idir	idir	ADP	Simp	_	20	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 19	dhá	dó	NUM	Num	Form=Len|NumType=Card	20	nummod	_	_
-20	fhoireann	foireann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	16	xcomp:pred	_	_
+20	fhoireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	xcomp:pred	_	_
 21	agus	agus	CCONJ	Coord	_	23	cc	_	_
 22	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
 23	cinnte	cinnte	ADJ	Adj	Degree=Pos	15	conj	_	_
 24	go	go	PART	Vb	PartType=Cmpl	25	mark:prt	_	_
 25	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	23	csubj:cop	_	_
-26	Nicky	Nicky	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	nsubj	_	NamedEntity=Yes
-27	English	English	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes
+26	Nicky	Nicky	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	nsubj	_	NamedEntity=Yes
+27	English	English	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes
 28	ag	ag	ADP	Simp	_	29	case	_	_
 29	cur	cur	NOUN	Noun	VerbForm=Vnoun	25	xcomp	_	_
 30	go	go	PART	Ad	PartType=Ad	31	mark:prt	_	_
 31	mór	mór	ADJ	Adj	Degree=Pos	29	advmod	_	_
 32	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	33	case	_	_
-33	luí	luí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	obl	_	_
+33	luí	luí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	obl	_	_
 34	ar	ar	ADP	Simp	_	36	case	_	_
 35	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
-36	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	29	nmod	_	_
+36	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	29	nmod	_	_
 37	fear	fear	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	36	nmod	_	_
 38	cé	cé	SCONJ	Subord	_	40	advmod	_	_
 39	chomh	chomh	ADV	Its	_	38	fixed	_	_
@@ -6828,13 +6828,13 @@
 41	a	a	PART	Vb	PartType=Vb|PronType=Rel	43	mark:prt	_	_
 42	d'	do	PART	Vb	PartType=Vb	43	mark:prt	_	SpaceAfter=No
 43	imir	imir	VERB	VTI	Mood=Ind|Tense=Past	29	advcl	_	_
-44	Luimneach	Luimneach	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	43	nsubj	_	_
+44	Luimneach	Luimneach	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	43	nsubj	_	_
 45	in	in	ADP	Cmpd	PrepForm=Cmpd	47	case	_	_
 46	aghaidh	aghaidh	ADP	Cmpd	_	45	fixed	_	_
-47	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	43	obl	_	_
+47	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	43	obl	_	_
 48	sa	i	ADP	Art	Number=Sing|PronType=Art	50	case	_	_
 49	chéad	céad	NUM	Num	Form=Len|NumType=Ord	50	amod	_	_
-50	bhabhta	babhta	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	43	obl	_	_
+50	bhabhta	babhta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	43	obl	_	_
 51	den	de	ADP	Art	Number=Sing|PronType=Art	52	case	_	_
 52	chraobh	craobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	50	nmod	_	_
 53	agus	agus	CCONJ	Coord	_	55	cc	_	_
@@ -6842,8 +6842,8 @@
 55	cluiche	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	50	conj	_	_
 56	in	in	ADP	Cmpd	PrepForm=Cmpd	58	case	_	_
 57	aghaidh	aghaidh	ADP	Cmpd	_	56	fixed	_	_
-58	Phort	Port	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	55	nmod	_	NamedEntity=Yes
-59	Láirge	Láirge	PROPN	Noun	_	58	nmod	_	NamedEntity=Yes
+58	Phort	Port	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	55	nmod	_	NamedEntity=Yes
+59	Láirge	Láirge	PROPN	Noun	Definite=Def	58	nmod	_	NamedEntity=Yes
 60	dha	dó	NUM	Num	Form=Len|NumType=Card|Typo=Yes	61	nummod	_	_
 61	sheachtain	seachtain	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	43	obl:tmod	_	_
 62	ó	ó	ADP	Simp	_	63	case	_	_
@@ -6855,7 +6855,7 @@
 1	Ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	2	advmod	_	_
 2	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
-4	dhath	dath	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	dhath	dath	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	agam	ag	ADP	Prep	Number=Sing|Person=1	2	obl:prep	_	_
 6	anois	anois	ADV	Gn	_	2	advmod	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	obl	_	_
@@ -6866,7 +6866,7 @@
 12	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	obl:prep	_	_
 13	ach	ach	SCONJ	Subord	_	15	mark:prt	_	_
 14	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	15	nmod:poss	_	_
-15	shlat	slat	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	advcl	_	_
+15	shlat	slat	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	advcl	_	_
 16	iascaireachta	iascaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	compound	_	_
 17	agus	agus	CCONJ	Coord	_	19	cc	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
@@ -6876,12 +6876,12 @@
 # sent_id = 267
 # text = A Phádraig Uí Chaiticín beirim an sbhae duit Ar a bhfaca mé féin de bhádóirín fóill Le féile, le hoineach, le tuiscint is le méin mhaith Is ní fhaca mé féin do shárú go fóill.
 1	A	a	PART	Voc	PartType=Voc	2	case:voc	_	_
-2	Phádraig	Pádraig	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc	5	vocative	_	NamedEntity=Yes
+2	Phádraig	Pádraig	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	5	vocative	_	NamedEntity=Yes
 3	Uí	uí	PART	Pat	PartType=Pat	2	flat:name	_	NamedEntity=Yes
-4	Chaiticín	Caiticín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
+4	Chaiticín	Caiticín	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 5	beirim	beir	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	sbhae	svae	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
+7	sbhae	svae	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obj	_	_
 8	duit	do	ADP	Prep	Number=Sing|Person=2	5	obl:prep	_	_
 9	Ar	ar	ADP	Simp	_	11	obl	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
@@ -6909,7 +6909,7 @@
 32	mé	mé	PRON	Pers	Number=Sing|Person=1	31	nsubj	_	_
 33	féin	féin	PRON	Ref	Reflex=Yes	32	nmod	_	_
 34	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	35	nmod:poss	_	_
-35	shárú	sárú	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	31	obj	_	_
+35	shárú	sárú	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	obj	_	_
 36	go	go	PART	Ad	PartType=Ad	37	mark:prt	_	_
 37	fóill	fóill	ADJ	Adj	Degree=Pos	31	advmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	5	punct	_	_
@@ -6944,7 +6944,7 @@
 7	chloig	clog	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	nmod	_	_
 8	taisteal	taisteal	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 9	ó	ó	ADP	Simp	_	10	case	_	_
-10	Leamhchán	Leamhcán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	8	obl	_	_
+10	Leamhchán	Leamhcán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	8	obl	_	_
 11	go	go	ADP	Cmpd	PrepForm=Cmpd	13	case	_	_
 12	dtí	dtí	ADP	Cmpd	Form=Ecl	11	fixed	_	_
 13	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
@@ -6963,7 +6963,7 @@
 26	ón	ó	ADP	Art	Number=Sing|PronType=Art	27	case	_	_
 27	lár	lár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	_
 28	go	go	ADP	Simp	_	29	case	_	_
-29	Leamhchán	Leamhcán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	27	nmod	_	SpaceAfter=No
+29	Leamhchán	Leamhcán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	27	nmod	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 271
@@ -6975,25 +6975,25 @@
 5	freisin	freisin	ADV	Gn	_	2	advmod	_	_
 6	gur	gur	PART	Vb	PartType=Vb|Tense=Past	7	mark:prt	_	_
 7	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	2	ccomp	_	_
-8	Garret	Garret	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
+8	Garret	Garret	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	os	os	ADP	Cmpd	PrepForm=Cmpd	12	case	_	_
 10	comhair	comhair	ADP	Cmpd	_	9	fixed	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	Bhinse	binse	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	7	obl	_	NamedEntity=Yes
+12	Bhinse	binse	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	obl	_	NamedEntity=Yes
 13	Fiosraithe	fiosrú	NOUN	Noun	Case=Gen|VerbForm=Inf	12	nmod	_	NamedEntity=Yes
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl:tmod	_	_
 16	céanna	céanna	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	15	amod	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	nsubj	_	_
 18	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	15	acl:relcl	_	_
-19	Bill	Bill	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nsubj	_	NamedEntity=Yes
-20	Clinton	Clinton	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes
+19	Bill	Bill	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	NamedEntity=Yes
+20	Clinton	Clinton	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes
 21	ar	ar	ADP	Simp	_	22	case	_	_
 22	cuairt	cuairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	obl	_	_
 23	go	go	ADP	Simp	_	24	case	_	_
-24	Baile	Baile	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
-25	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
-26	Cliath	Cliath	PROPN	Noun	_	25	nmod	_	NamedEntity=Yes|SpaceAfter=No
+24	Baile	Baile	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
+25	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
+26	Cliath	Cliath	PROPN	Noun	Definite=Def	25	nmod	_	NamedEntity=Yes|SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 272
@@ -7001,7 +7001,7 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	4	xcomp	_	_
-4	gcothú	cothú	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	xcomp	_	_
+4	gcothú	cothú	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	xcomp	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	cuileoga	cuileog	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	_
@@ -7010,11 +7010,11 @@
 10	siad	siad	PRON	Pers	Number=Plur|Person=3	9	nsubj	_	_
 11	sin	sin	PRON	Dem	PronType=Dem	10	det	_	_
 12	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	13	case	_	_
-13	ndíothú	díothú	NOUN	Noun	Form=Ecl|VerbForm=Inf	9	xcomp	_	_
+13	ndíothú	díothú	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	9	xcomp	_	_
 14	go	go	PART	Ad	PartType=Ad	15	mark:prt	_	_
 15	mear	mear	ADJ	Adj	Degree=Pos	13	advmod	_	_
 16	dá	de	ADP	Poss	Poss=Yes	17	case	_	_
-17	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
+17	cheann	ceann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	_
 18	sin	sin	PRON	Dem	PronType=Dem	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
 20	bíodh	bí	VERB	Imper	Mood=Imp|Number=Sing|Person=3	1	parataxis	_	_
@@ -7028,9 +7028,9 @@
 28	thuilleadh	tuilleadh	NOUN	Subst	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	27	fixed	_	_
 29	isteach	isteach	ADV	Dir	_	26	advmod	_	_
 30	sa	i	ADP	Art	Number=Sing|PronType=Art	31	case	_	_
-31	seomra	seomra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	obl	_	_
+31	seomra	seomra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
 32	lena	le	ADP	Poss	Poss=Yes	33	case	_	_
-33	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	26	nmod	_	_
+33	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	nmod	_	_
 34	féin	féin	PRON	Ref	Reflex=Yes	33	nmod	_	_
 35	bia	bia	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	1	punct	_	_
@@ -7066,12 +7066,12 @@
 21	seoil	seol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	_
 22	ar	ar	ADP	Simp	_	24	case	_	_
 23	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	24	nmod:poss	_	_
-24	mbealach	bealach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
+24	mbealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
 25	le	le	ADP	Simp	_	26	case	_	_
 26	lucht	lucht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	nmod	_	_
 27	imirce	imirce	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	26	compound	_	_
 28	go	go	ADP	Simp	_	29	case	_	_
-29	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
+29	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	ag	ag	ADP	Simp	_	32	case	_	_
 32	faire	faire	NOUN	Noun	VerbForm=Vnoun	11	xcomp	_	_
@@ -7093,7 +7093,7 @@
 48	Oileán	oileán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	obl	_	_
 49	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	51	det	_	_
 50	dá	dó	NUM	Num	Definite=Def|NumType=Card	51	nummod	_	_
-51	Bhrannóg	Bhrannóg	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	48	nmod	_	SpaceAfter=No
+51	Bhrannóg	Bhrannóg	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	nmod	_	SpaceAfter=No
 52	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 275
@@ -7111,7 +7111,7 @@
 11	ag	ag	ADP	Simp	_	12	case	_	_
 12	éirí	éirí	NOUN	Noun	VerbForm=Vnoun	10	xcomp	_	_
 13	ón	ó	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	bhord	bord	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
+14	bhord	bord	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 276
@@ -7122,8 +7122,8 @@
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	chumas	cumas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
-7	Fhinn	Fionn	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	10	obj	_	NamedEntity=Yes
-8	Diarmaid	Diarmaid	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
+7	Fhinn	Fionn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	10	obj	_	NamedEntity=Yes
+8	Diarmaid	Diarmaid	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
 9	a	a	PART	Inf	PartType=Inf	10	mark	_	_
 10	leigheas	leigheas	NOUN	Noun	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
@@ -7156,7 +7156,7 @@
 3	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	_
 4	bogadh	bogadh	NOUN	Noun	VerbForm=Inf	7	xcomp	_	_
 5	go	go	ADP	Simp	_	6	case	_	_
-6	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obl	_	_
+6	Meiriceá	Meiriceá	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 7	dhein	dein	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 8	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	7	nsubj	_	_
 9	an-chuid	an-chuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obj	_	_
@@ -7166,7 +7166,7 @@
 13	ar	ar	ADP	Simp	_	14	case	_	_
 14	cheol	ceol	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 15	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	nGael	Gael	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	14	nmod	_	_
+16	nGael	Gael	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	14	nmod	_	_
 17	thall	thall	ADV	Dir	_	7	advmod	_	_
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	bhain	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	conj	_	_
@@ -7177,10 +7177,10 @@
 
 # sent_id = 278
 # text = Iúil - Meán Fómhair.
-1	Iúil	Iúil	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
+1	Iúil	Iúil	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 2	-	-	PUNCT	Punct	_	1	punct	_	_
-3	Meán	Meán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-4	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes|SpaceAfter=No
+3	Meán	Meán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+4	Fómhair	Fómhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes|SpaceAfter=No
 5	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 279
@@ -7207,7 +7207,7 @@
 20	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	nsubj	_	_
 21	iomláine	iomláine	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	25	obj	_	_
 22	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
-23	trialach	triail	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	21	nmod	_	_
+23	trialach	triail	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	21	nmod	_	_
 24	a	a	PART	Inf	PartType=Inf	25	mark	_	_
 25	choinneáil	coinneáil	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
 26	le	le	ADP	Simp	_	27	case	_	_
@@ -7249,8 +7249,8 @@
 # sent_id = 281
 # text = 'Helena McMahon, duine a bhfuil baint aici le healaín phobail i Luimneach.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Helena	Helena	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
-3	McMahon	McMahon	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+2	Helena	Helena	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	McMahon	McMahon	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	appos	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	nsubj	_	_
@@ -7261,7 +7261,7 @@
 11	healaín	ealaín	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	7	obl	_	_
 12	phobail	pobal	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	Luimneach	Luimneach	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+14	Luimneach	Luimneach	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 282
@@ -7274,7 +7274,7 @@
 6	chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	acl:relcl	_	_
 7	mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	fhir	fear	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
+9	fhir	fear	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 283
@@ -7282,14 +7282,14 @@
 1	Dar	dar	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	leis	le	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	Uasal	uasal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+4	Uasal	uasal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 5	Ó	ó	PART	Pat	PartType=Pat	4	flat	_	NamedEntity=Yes
-6	Murchú	Murchú	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+6	Murchú	Murchú	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	tUasal	uasal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
-11	Collins	Collins	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
+11	Collins	Collins	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	in	i	ADP	Simp	_	13	case	_	_
 13	iúl	iúl	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	_
 14	go	go	PART	Vb	PartType=Cmpl	15	mark:prt	_	_
@@ -7306,7 +7306,7 @@
 25	agus	agus	CCONJ	Coord	_	28	cc	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 27	'	'	PUNCT	Punct	_	28	punct	_	SpaceAfter=No
-28	mháthair-chomhlacht	máthairchomhlacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	24	conj	_	SpaceAfter=No
+28	mháthair-chomhlacht	máthairchomhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	conj	_	SpaceAfter=No
 29	'	'	PUNCT	Punct	_	28	punct	_	_
 30	in	i	ADP	Simp	_	31	case	_	_
 31	RTÉ	RTÉ	PROPN	Abr	Abbr=Yes	28	nmod	_	SpaceAfter=No
@@ -7321,7 +7321,7 @@
 5	fiacaile	fiacail	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
 6	in	i	ADP	Simp	_	7	case	_	_
 7	Uachtar	uachtar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	xcomp:pred	_	NamedEntity=Yes
-8	Achaidh	Achaidh	PROPN	Noun	Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
+8	Achaidh	Achaidh	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	conj	_	_
 11	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nsubj	_	_
@@ -7333,7 +7333,7 @@
 17	níos	níos	PART	Cmp	PartType=Comp	18	mark:prt	_	_
 18	cóngaraí	cóngarach	ADJ	Adj	Degree=Cmp,Sup	14	amod	_	_
 19	don	do	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	reilig	reilig	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	obl	_	_
+20	reilig	reilig	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	obl	_	_
 21	tráth	tráth	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl:tmod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
 23	ach	ach	SCONJ	Subord	_	25	mark	_	_
@@ -7349,13 +7349,13 @@
 33	amach	amach	ADV	Dir	_	31	advmod	_	_
 34	arís	arís	ADV	Gn	_	31	advmod	_	_
 35	san	i	ADP	Art	Number=Sing|PronType=Art	36	case	_	_
-36	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	31	obl	_	_
+36	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	31	obl	_	_
 37	ina	i	PART	Rel	PronType=Rel	38	obl	_	_
 38	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	36	acl:relcl	_	_
 39	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	38	nsubj	_	_
 40	anois	anois	ADV	Gn	_	38	advmod	_	_
 41	(	(	PUNCT	Punct	_	42	punct	_	SpaceAfter=No
-42	Logan	Logan	PROPN	Noun	_	25	parataxis	_	SpaceAfter=No
+42	Logan	Logan	PROPN	Noun	Definite=Def	25	parataxis	_	SpaceAfter=No
 43	,	,	PUNCT	Punct	_	44	punct	_	_
 44	1980	1980	NUM	Num	_	42	nmod	_	SpaceAfter=No
 45	,	,	PUNCT	Punct	_	46	punct	_	_
@@ -7371,7 +7371,7 @@
 2	gearán	gearán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	déanta	déanta	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
-5	Unison	Unison	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+5	Unison	Unison	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	ceardchumann	ceardchumann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	appos	_	_
 8	lucht	lucht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -7381,15 +7381,15 @@
 12	,	,	PUNCT	Punct	_	15	punct	_	_
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	gCoimisiún	coimisiún	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+15	gCoimisiún	coimisiún	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
 16	um	um	ADP	Simp	_	17	case	_	NamedEntity=Yes
-17	Comhionannas	comhionannas	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Comhionannas	comhionannas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
 18	Ciníoch	ciníoch	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	17	amod	_	_
 19	thall	thall	ADV	Dir	_	17	advmod	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	conj	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	Coimisiún	Coimisiún	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nsubj	_	_
+23	Coimisiún	Coimisiún	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	nsubj	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
 25	rá	rá	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 26	go	go	PART	Vb	PartType=Cmpl	27	mark:prt	_	_
@@ -7417,29 +7417,29 @@
 3	déanaí	déanach	ADJ	Adj	Degree=Cmp,Sup	1	amod	_	_
 4	áfach	áfach	ADV	Gn	_	5	advmod	_	_
 5	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	0	root	_	_
-6	John	John	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
+6	John	John	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	8	nmod:poss	_	_
-8	dhiongbháilteacht	diongbháilteacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	5	obj	_	_
+8	dhiongbháilteacht	diongbháilteacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	5	obj	_	_
 9	nuair	nuair	SCONJ	Subord	_	11	mark	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
 11	rith	rith	VERB	VTI	Mood=Ind|Tense=Past	5	advcl	_	_
 12	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	11	nsubj	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
 14	5,000	5,000	NUM	Num	_	15	nummod	_	_
-15	m	m	NOUN	Item	_	11	obl	_	_
+15	m	m	NOUN	Abr	Abbr=Yes	11	obl	_	_
 16	-	-	PUNCT	Punct	_	17	punct	_	_
 17	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	5	parataxis	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
 20	cheathrú	ceathair	NUM	Num	Form=Len|NumType=Ord	21	amod	_	_
-21	háit	áit	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	17	obl	_	_
+21	háit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	17	obl	_	_
 22	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
-23	dhreas	dreas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
+23	dhreas	dreas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	agus	agus	CCONJ	Coord	_	28	cc	_	_
 26	sa	i	ADP	Art	Number=Sing|PronType=Art	28	case	_	_
 27	cheathrú	ceathair	NUM	Num	Form=Len|NumType=Ord	28	amod	_	_
-28	háit	áit	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	21	conj	_	_
+28	háit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	21	conj	_	_
 29	sa	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
 30	rás	rás	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	_
 31	leathcheannais	leathcheannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	nmod	_	_
@@ -7448,7 +7448,7 @@
 34	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	33	nsubj	_	_
 35	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	37	det	_	_
 36	400	400	NUM	Num	_	37	nummod	_	_
-37	m	m	NOUN	Item	_	33	obj	_	_
+37	m	m	NOUN	Abr	Abbr=Yes	33	obj	_	_
 38	deiridh	deireadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	37	nmod	_	_
 39	i	i	ADP	Simp	_	41	case	_	_
 40	55	55	NUM	Num	_	41	nummod	_	_
@@ -7459,11 +7459,11 @@
 # text = I seó Abábú, beidh Máire Andrews ag insint scéalta difriúla trí mheán an cheoil agus na gluaiseachta.
 1	I	I	ADP	Simp	_	2	case	_	_
 2	seó	seó	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
-3	Abábú	Abábú	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
+3	Abábú	Abábú	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
-6	Máire	Máire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
-7	Andrews	Andrews	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
+6	Máire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
+7	Andrews	Andrews	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes
 8	ag	ag	ADP	Simp	_	9	case	_	_
 9	insint	insint	NOUN	Noun	VerbForm=Vnoun	5	xcomp	_	_
 10	scéalta	scéal	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	9	obj	_	_
@@ -7492,9 +7492,9 @@
 11	seo	seo	DET	Det	PronType=Dem	10	det	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	nmod:poss	_	_
-14	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+14	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	chluiche	cluiche	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+16	chluiche	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 17	ceannais	ceannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	compound	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -7506,14 +7506,14 @@
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	shaíocht	saíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Sean-Ghréige	Sean-Ghréige	PROPN	Noun	Case=Gen|Gender=Fem	5	nmod	_	_
+7	Sean-Ghréige	Sean-Ghréige	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	5	nmod	_	_
 8	ná	nach	PART	Vb	PartType=Vb|Polarity=Neg|PronType=Rel	9	mark:prt	_	_
 9	fuair	faigh	VERB	VT	Mood=Ind|Tense=Past	1	ccomp	_	_
 10	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	9	obj	_	_
 11	ná	ná	CCONJ	Coord	_	12	cc	_	_
 12	fáilte	fáilte	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	conj	_	_
 13	óna	ó	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	case	_	_
-14	scoláirí	scoláire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	9	obl	_	_
+14	scoláirí	scoláire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	9	obl	_	_
 15	traidisiúnta	traidisiúnta	ADJ	Adj	Degree=Pos	14	amod	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -7559,7 +7559,7 @@
 6	páirtíocht	páirtíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
 7	acu	ag	ADP	Prep	Number=Plur|Person=3	5	obl:prep	_	_
 8	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	case	_	_
-9	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
+9	chéile	céile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	13	punct	_	_
 11	thar	thar	ADP	Simp	_	13	case	_	_
 12	mar	mar	SCONJ	Subord	_	13	mark	_	_
@@ -7568,7 +7568,7 @@
 15	féin	féin	PRON	Ref	Reflex=Yes	14	nmod	_	_
 16	leis	le	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	Mhuircheartach	Muircheartach	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
+18	Mhuircheartach	Muircheartach	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 293
@@ -7585,14 +7585,14 @@
 10	mian	mian	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	acl:relcl	_	_
 11	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	10	obl:prep	_	_
 12	ón	ó	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	dán	dán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
+13	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 14	sin	sin	DET	Det	PronType=Dem	13	det	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 294
 # text = Leanann Ramadan ar feadh seachtaine 4.
 1	Leanann	lean	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-2	Ramadan	Ramadan	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Ramadan	Ramadan	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ar	ar	ADP	Cmpd	PrepForm=Cmpd	5	case	_	_
 4	feadh	feadh	ADP	Cmpd	_	3	fixed	_	_
 5	seachtaine	seachtain	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	obl:tmod	_	_
@@ -7616,20 +7616,20 @@
 1	Agus	agus	CCONJ	Coord	_	5	advmod	_	_
 2	ar	ar	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	drochuair	drochuair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
+4	drochuair	drochuair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 5	thit	tit	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	5	nsubj	_	_
 7	féin	féin	PRON	Ref	Reflex=Yes	6	nmod	_	_
 8	as	as	ADP	Simp	_	10	case	_	_
 9	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
-10	seasamh	seasamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
+10	seasamh	seasamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
 12	bproinnteach	proinnteach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
 13	agus	agus	CCONJ	Coord	_	14	mark	_	_
 14	iad	iad	PRON	Pers	Number=Plur|Person=3	5	conj	_	_
 15	ar	ar	ADP	Simp	_	17	case	_	_
 16	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	17	nmod:poss	_	_
-17	mbealach	bealach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
+17	mbealach	bealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
 18	ó	ó	ADP	Simp	_	17	advmod	_	_
 19	dheas	deas	ADJ	Adj	Form=Len|Number=Sing	18	fixed	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	5	punct	_	_
@@ -7640,16 +7640,16 @@
 2	toirt	toirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	in	i	ADP	Simp	_	5	case	_	_
 4	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	5	det	_	_
-5	phóca	póca	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+5	phóca	póca	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 6	nó	nó	CCONJ	Coord	_	7	cc	_	_
 7	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	1	conj	_	_
 8	snaidhm	snaidhm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nsubj	_	_
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	snaidhm	snaidhm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nmod	_	_
+11	snaidhm	snaidhm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	putógaí	putóg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	7	xcomp:pred	_	SpaceAfter=No
+14	putógaí	putóg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	7	xcomp:pred	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 298
@@ -7657,38 +7657,38 @@
 1	I	I	ADP	Simp	_	2	case	_	_
 2	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	n-aíonna	aoi	NOUN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	2	nmod	_	_
+4	n-aíonna	aoi	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	2	nmod	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	4	acl:relcl	_	_
 7	i	i	ADP	Cmpd	PrepForm=Cmpd	6	xcomp:pred	_	_
 8	láthair	láthair	ADP	Cmpd	_	7	fixed	_	_
 9	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	0	root	_	_
-10	Aiden	Aiden	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	NamedEntity=Yes
-11	Coffey	Coffey	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+10	Aiden	Aiden	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	NamedEntity=Yes
+11	Coffey	Coffey	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
-13	Jackie	Jackie	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
-14	Daly	Daly	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+13	Jackie	Jackie	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+14	Daly	Daly	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
-16	Máire	Máire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	conj	_	NamedEntity=Yes
+16	Máire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	conj	_	NamedEntity=Yes
 17	O	o	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
-18	Keefe	Keefe	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+18	Keefe	Keefe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
-20	Séamus	Séamus	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
-21	Creagh	Creagh	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+20	Séamus	Séamus	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+21	Creagh	Creagh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
-23	Tony	Tony	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
-24	Linnane	Linnane	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+23	Tony	Tony	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+24	Linnane	Linnane	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Breándán	Breándán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+26	Breándán	Breándán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
 27	Ó	ó	PART	Pat	PartType=Pat	26	flat:name	_	NamedEntity=Yes
-28	Beaglaoich	Beaglaoich	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+28	Beaglaoich	Beaglaoich	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	30	punct	_	_
-30	Denis	Denis	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
-31	Doody	Doody	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+30	Denis	Denis	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+31	Doody	Doody	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
 33	agus	agus	CCONJ	Coord	_	34	cc	_	_
-34	Eamonn	Eamonn	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
-35	Coyne	Coyne	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	34	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+34	Eamonn	Eamonn	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	NamedEntity=Yes
+35	Coyne	Coyne	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	34	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 36	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 299
@@ -7699,20 +7699,20 @@
 4	a	a	PART	Nm	PartType=Num	5	mark:prt	_	_
 5	hocht	ocht	NUM	Num	Form=HPref|NumType=Card	2	obl	_	_
 6	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	chlog	clog	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	nmod	_	_
+7	chlog	clog	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	nmod	_	_
 8	chuaigh	téigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	tAire	aire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
-11	Sláinte	sláinte	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
-12	Bairbre	Bairbre	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	appos	_	NamedEntity=Yes
+10	tAire	aire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
+11	Sláinte	sláinte	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+12	Bairbre	Bairbre	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	appos	_	NamedEntity=Yes
 13	de	de	PART	Pat	PartType=Pat	12	flat:name	_	NamedEntity=Yes
-14	Brún	Brún	PROPN	Noun	Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
+14	Brún	Brún	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	flat:name	_	NamedEntity=Yes
 15	chun	chun	ADP	Simp	_	16	case	_	_
 16	tosaigh	tosach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	obl	_	_
 17	le	le	ADP	Simp	_	18	case	_	_
 18	labhairt	labhairt	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
 19	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	ghalar	galar	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+20	ghalar	galar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	marfach	marfach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	20	amod	_	_
 22	SEIF	SEIF	PROPN	Abr	Abbr=Yes	20	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	8	punct	_	_
@@ -7739,7 +7739,7 @@
 # sent_id = 302
 # text = Na néaróga fós go dona.
 1	Na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	2	det	_	_
-2	néaróga	néaróg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
+2	néaróga	néaróg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	0	root	_	_
 3	fós	fós	ADV	Gn	_	2	advmod	_	_
 4	go	go	PART	Ad	PartType=Ad	5	mark:prt	_	_
 5	dona	dona	ADJ	Adj	Degree=Pos	2	advmod	_	SpaceAfter=No
@@ -7772,7 +7772,7 @@
 23	,	,	PUNCT	Punct	_	2	punct	_	_
 24	caithfidh	caith	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
-26	múinteoir	múinteoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	nsubj	_	_
+26	múinteoir	múinteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	_
 27	spéis	spéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	29	obj	_	_
 28	a	a	PART	Inf	PartType=Inf	29	mark	_	_
 29	léiriú	léiriú	NOUN	Noun	VerbForm=Inf	24	xcomp	_	SpaceAfter=No
@@ -7795,7 +7795,7 @@
 46	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	42	conj	_	_
 47	as	as	ADP	Simp	_	49	case	_	_
 48	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	49	det	_	_
-49	straitéisí	straitéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	46	obl	_	_
+49	straitéisí	straitéis	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	46	obl	_	_
 50	uilig	uile	DET	Det	_	49	det	_	_
 51	a	a	PART	Vb	PartType=Vb|PronType=Rel	52	obl	_	_
 52	dtig	tar	VERB	VI	Form=Ecl|Mood=Ind|Tense=Pres	49	acl:relcl	_	_
@@ -7811,35 +7811,35 @@
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	bpéintéireacht	péintéireacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	_
+6	bpéintéireacht	péintéireacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	_
 7	mar	mar	ADP	Simp	_	8	case	_	_
 8	shlí	slí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
 9	bheatha	beatha	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	8	compound	_	_
 10	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 11	clú	clú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nsubj	_	_
 12	ar	ar	ADP	Simp	_	13	case	_	_
-13	John	John	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl	_	NamedEntity=Yes
-14	Fisher	Fisher	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
+13	John	John	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	NamedEntity=Yes
+14	Fisher	Fisher	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
 15	mar	mar	ADP	Simp	_	16	case	_	_
 16	éadaitheoir	éadaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
 17	olla	olann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	Liobartaí	Liobartaí	PROPN	Noun	_	10	obl	_	_
-20	Bhaile	Baile	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
-21	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
-22	Cliath	Cliath	PROPN	Noun	_	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
+19	Liobartaí	Liobartaí	PROPN	Noun	Definite=Def	10	obl	_	_
+20	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
+22	Cliath	Cliath	PROPN	Noun	Definite=Def	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
 24	gar	gar	ADJ	Adj	Degree=Pos	20	amod	_	_
 25	do	do	ADP	Simp	_	26	case	_	_
 26	Theampall	teampall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	24	obl	_	NamedEntity=Yes
-27	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	26	nmod	_	NamedEntity=Yes|SpaceAfter=No
+27	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	26	nmod	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	parataxis	_	_
 30	annamh	annamh	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	29	amod	_	_
 31	ag	ag	ADP	Simp	_	32	case	_	_
 32	ealaíontóir	ealaíontóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	_
 33	san	i	ADP	Art	Number=Sing|PronType=Art	34	case	_	_
-34	aois	aois	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	29	nmod	_	_
+34	aois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	29	nmod	_	_
 35	sin	sin	DET	Det	PronType=Dem	34	det	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	10	punct	_	_
 
@@ -7893,7 +7893,7 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	t-airgead	airgead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
-5	Seán	Seán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+5	Seán	Seán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 308
@@ -7906,9 +7906,9 @@
 6	ar	ar	ADP	Simp	_	7	case	_	_
 7	fáil	fáil	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
 8	don	do	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	aoi	aoi	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+9	aoi	aoi	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	phálás	pálás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+11	phálás	pálás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 12	ríoga	ríoga	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	11	amod	_	_
 13	seo	seo	DET	Det	PronType=Dem	11	det	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
@@ -7920,20 +7920,20 @@
 3	ceist	ceist	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obj	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	6	nmod:poss	_	_
-6	mháthair	máthair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
+6	mháthair	máthair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
 7	cad	cad	PRON	Q	PronType=Int	9	nsubj	_	_
 8	ba	is	AUX	Cop	PronType=Rel|Tense=Past|VerbForm=Cop	9	cop	_	_
 9	bhun	bun	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	ccomp	_	_
 10	leis	le	ADP	Simp	_	12	case	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	scréachach	scréachach	NOUN	Noun	VerbForm=Inf	9	obl	_	_
+12	scréachach	scréachach	NOUN	Noun	Definite=Def|VerbForm=Inf	9	obl	_	_
 13	mar	mar	SCONJ	Subord	_	14	mark	_	_
 14	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	advcl	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	fhios	fios	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	nsubj	_	_
+16	fhios	fios	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nsubj	_	_
 17	agam	ag	ADP	Prep	Number=Sing|Person=1	14	obl:prep	_	_
 18	cén	cé	PRON	Q	Number=Sing|PronType=Int	14	ccomp	_	_
-19	freagra	freagra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nsubj	_	_
+19	freagra	freagra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nsubj	_	_
 20	a	a	PART	Vb	PartType=Vb|PronType=Rel	21	obj	_	_
 21	thabharfadh	tabhair	VERB	VTI	Form=Len|Mood=Cnd	19	acl:relcl	_	_
 22	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	21	nsubj	_	_
@@ -7945,10 +7945,10 @@
 28	seo	seo	PRON	Dem	PronType=Dem	26	det	_	_
 29	anois	anois	ADV	Gn	_	26	advmod	_	_
 30	a	a	PART	Voc	PartType=Voc	31	case:voc	_	_
-31	pheaitín	peata	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	26	vocative	_	_
+31	pheaitín	peata	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	vocative	_	_
 32	bán	bán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	31	amod	_	_
 33	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	34	nmod:poss	_	_
-34	chroí	croí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	31	nmod	_	SpaceAfter=No
+34	chroí	croí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	nmod	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 310
@@ -7974,13 +7974,13 @@
 9	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	12	cop	_	_
 10	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	12	nmod	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	smaointiú	smaointiú	NOUN	Noun	VerbForm=Inf	0	root	_	_
+12	smaointiú	smaointiú	NOUN	Noun	Definite=Def|VerbForm=Inf	0	root	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	nsubj	_	_
 14	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	12	acl:relcl	_	_
 15	chugam	chuig	ADP	Prep	Number=Sing|Person=1	14	obl:prep	_	_
 16	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	18	cop	_	_
 17	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nsubj	_	_
+18	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nsubj	_	_
 19	seo	seo	PRON	Dem	PronType=Dem	18	det	_	_
 20	de	de	ADP	Simp	_	21	case	_	_
 21	lorg	lorg	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
@@ -7990,29 +7990,29 @@
 25	fhágfadh	fág	VERB	VTI	Form=Len|Mood=Cnd	21	acl:relcl	_	_
 26	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	nsubj	_	_
 27	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	case	_	_
-28	dhiaidh	diaidh	NOUN	Subst	Form=Len|Number=Sing	25	obl	_	_
+28	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	25	obl	_	_
 29	a	a	PART	Vb	PartType=Vb|PronType=Rel	30	nsubj	_	_
 30	nochtfadh	nocht	VERB	VTI	Mood=Cnd	18	acl:relcl	_	_
 31	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
-32	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	30	obj	_	_
+32	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	30	obj	_	_
 33	peacaí	peaca	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	32	nmod	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
 35	hart	hart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	obl	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
-37	dathadóra	dathadóir	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
+37	dathadóra	dathadóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	12	punct	_	_
 
 # sent_id = 312
 # text = (a) Ospideul meán-suidhte chun cásanna chun Leighis agus Máin-liaghais do leigheas.
 1	(a)	(a)	NUM	Item	_	2	list	_	_
-2	Ospideul	Ospideul	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+2	Ospideul	ospideul	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	meán-suidhte	meán-suidhte	ADJ	Adj	VerbForm=Part	2	xcomp:pred	_	_
 4	chun	chun	ADP	Simp	_	5	case	_	_
 5	cásanna	cás	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
 6	chun	chun	ADP	Simp	_	7	case	_	_
 7	Leighis	leigheas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
-9	Máin-liaghais	Máin-liaghais	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	conj	_	_
+9	Máin-liaghais	máin-liaghas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	conj	_	_
 10	do	do	ADP	Simp	_	11	case	_	_
 11	leigheas	leigheas	NOUN	Noun	VerbForm=Inf	7	nmod	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	_	_
@@ -8024,7 +8024,7 @@
 3	mhuirear	muirear	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	mbuiséad	buiséad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+6	mbuiséad	buiséad	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	caiteachas	caiteachas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 9	riaracháin	riarachán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
@@ -8039,20 +8039,20 @@
 18	Chonartha	conradh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 19	ar	ar	ADP	Simp	_	21	case	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	Aontas	aontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+21	Aontas	aontas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
 22	Eorpach	Eorpach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	21	amod	_	NamedEntity=Yes
 23	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	nsubj	_	_
 24	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	18	acl:relcl	_	_
 25	leis	le	ADP	Simp	_	27	case	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	gcomhbheartas	comhbheartas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	24	obl	_	_
+27	gcomhbheartas	comhbheartas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	24	obl	_	_
 28	eachtrach	eachtrach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	27	amod	_	_
 29	agus	agus	CCONJ	Coord	_	30	cc	_	_
 30	slándála	slándáil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	27	conj	_	_
 31	agus	agus	CCONJ	Coord	_	34	cc	_	_
 32	leis	le	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	gcomhar	comhar	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	27	conj	_	_
+34	gcomhar	comhar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	27	conj	_	_
 35	i	i	ADP	Simp	_	36	case	_	_
 36	réimsí	réimse	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	24	obl	_	_
 37	ceartais	ceartas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	36	nmod	_	_
@@ -8063,18 +8063,18 @@
 
 # sent_id = 314
 # text = Chas m'athair air sa tábhairne, O' Shea's i nDomhnach Broc - tá aithne ar an áit anois mar Madigan's agus bhí Bhreandán ag caitheamh a chuid airgid 'wet-time' ann.
-1	Chas	Cas	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
+1	Chas	cas	VERB	_	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	m'	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	3	nmod:poss	_	SpaceAfter=No
-3	athair	athair	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	athair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	tábhairne	tábhairne	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
+6	tábhairne	tábhairne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	O'	O'	PART	Pat	PartType=Pat	6	appos	_	NamedEntity=Yes
-9	Shea's	Shea's	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	flat:name	_	NamedEntity=Yes
+9	Shea's	Shea's	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	flat:name	_	NamedEntity=Yes
 10	i	i	ADP	Simp	_	11	case	_	_
-11	nDomhnach	Domhnach	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-12	Broc	Broc	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+11	nDomhnach	Domhnach	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+12	Broc	Broc	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	-	-	PUNCT	Punct	_	14	punct	_	_
 14	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 15	aithne	aithne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nsubj	_	_
@@ -8083,14 +8083,14 @@
 18	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	_
 19	anois	anois	ADV	Gn	_	14	advmod	_	_
 20	mar	mar	ADP	Simp	_	21	case	_	_
-21	Madigan's	Madigan's	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
+21	Madigan's	Madigan's	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 22	agus	agus	CCONJ	Coord	_	23	cc	_	_
 23	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	14	conj	_	_
-24	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	23	nsubj	_	_
+24	Bhreandán	Breandán	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nsubj	_	_
 25	ag	ag	ADP	Simp	_	26	case	_	_
 26	caitheamh	caitheamh	NOUN	Noun	VerbForm=Vnoun	23	xcomp	_	_
 27	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	nmod:poss	_	_
-28	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	26	obj	_	_
+28	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obj	_	_
 29	airgid	airgead	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	_
 30	'	'	PUNCT	Punct	_	31	punct	_	SpaceAfter=No
 31	wet-time	wet-time	X	Foreign	Foreign=Yes	29	nmod	_	SpaceAfter=No
@@ -8104,12 +8104,12 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	Tearmann	tearmann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	Aodh	Aodh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-6	Rua	Rua	PROPN	Adj	Case=NomAcc|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
+5	Aodh	Aodh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+6	Rua	Rua	PROPN	Adj	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	flat:name	_	NamedEntity=Yes
 7	as	as	ADP	Simp	_	8	case	_	_
-8	Béal	béal	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
-9	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-10	Seanaidh	Seanaidh	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
+8	Béal	béal	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
+9	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
+10	Seanaidh	Seanaidh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	fosta	fosta	ADV	Gn	_	10	advmod	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -8119,7 +8119,7 @@
 2	cigilt	cigilt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	fhaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 4	im	i_mo	ADP	Det	Number=Sing|Person=1|Poss=Yes	5	case	_	_
-5	chnámha	cnámh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
+5	chnámha	cnámh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 317
@@ -8144,7 +8144,7 @@
 1	Ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	2	cop	_	_
 2	fios	fios	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	cén	cé	PRON	Q	Number=Sing|PronType=Int	2	csubj:cop	_	_
-4	toradh	toradh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	_
+4	toradh	toradh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	4	acl:relcl	_	_
 7	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	obl:prep	_	SpaceAfter=No
@@ -8160,7 +8160,7 @@
 17	-	-	PUNCT	Punct	_	20	punct	_	_
 18	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	20	cop	_	_
 19	sna	i	ADP	Art	Number=Plur|PronType=Art	20	case	_	_
-20	cúirteanna	cúirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	13	ccomp	_	_
+20	cúirteanna	cúirt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	13	ccomp	_	_
 21	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	mark:prt	_	_
 22	chríochnóidh	críochnaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	20	csubj:cleft	_	_
 23	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	22	nsubj	_	SpaceAfter=No
@@ -8203,20 +8203,20 @@
 12	chlabhsúr	clabhsúr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 13	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
 14	chéad	céad	NUM	Num	Form=Len|NumType=Ord	15	amod	_	_
-15	chaibidlíochta	caibidlíocht	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
+15	chaibidlíochta	caibidlíocht	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
 16	aontachais	aontachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 322
 # text = Bhí Éamonn ag obair go lánaimsireach i gCollchoill idir 1928 agus 1936 agus d'éirigh chomh maith sin leo go raibh an phlandlann i gCollchoill ar an gceann ba rathúla sa tír, cés moite de Watson's i gCill Iníon Léinín.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Éamonn	Éamonn	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Éamonn	Éamonn	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	obair	obair	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 5	go	go	PART	Ad	PartType=Ad	6	mark:prt	_	_
 6	lánaimsireach	lánaimsireach	ADJ	Adj	Degree=Pos	4	advmod	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	gCollchoill	Collchoill	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+8	gCollchoill	Collchoill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 9	idir	idir	ADP	Simp	_	10	case	_	_
 10	1928	1928	NUM	Num	_	1	obl	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
@@ -8231,25 +8231,25 @@
 20	go	go	PART	Vb	PartType=Cmpl	21	mark:prt	_	_
 21	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	15	ccomp	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	phlandlann	plandlann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	21	nsubj	_	_
+23	phlandlann	plandlann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	21	nsubj	_	_
 24	i	i	ADP	Simp	_	25	case	_	_
-25	gCollchoill	Collchoill	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	23	nmod	_	_
+25	gCollchoill	Collchoill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	23	nmod	_	_
 26	ar	ar	ADP	Simp	_	28	case	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
-28	gceann	ceann	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
+28	gceann	ceann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
 29	ba	is	PART	Sup	PartType=Sup	30	mark:prt	_	_
 30	rathúla	rathúil	ADJ	Adj	Degree=Cmp,Sup	28	amod	_	_
 31	sa	i	ADP	Art	Number=Sing|PronType=Art	32	case	_	_
-32	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	nmod	_	SpaceAfter=No
+32	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	28	nmod	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	34	punct	_	_
 34	cés	cés	SCONJ	Subord	_	28	nmod	_	_
 35	moite	moite	SCONJ	Subord	_	34	fixed	_	_
 36	de	de	ADP	Simp	_	37	case	_	_
-37	Watson's	Watson's	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	nmod	_	_
+37	Watson's	Watson's	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
 38	i	i	ADP	Simp	_	39	case	_	_
-39	gCill	Cill	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	34	nmod	_	NamedEntity=Yes
-40	Iníon	iníon	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	39	nmod	_	NamedEntity=Yes
-41	Léinín	Léinín	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	40	nmod	_	NamedEntity=Yes|SpaceAfter=No
+39	gCill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	34	nmod	_	NamedEntity=Yes
+40	Iníon	iníon	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	39	nmod	_	NamedEntity=Yes
+41	Léinín	Léinín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	40	nmod	_	NamedEntity=Yes|SpaceAfter=No
 42	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 323
@@ -8271,15 +8271,15 @@
 15	bhailigh	bailigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	conj	_	_
 16	isteach	isteach	ADV	Dir	_	15	advmod	_	_
 17	san	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	halla	halla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obl	_	_
+18	halla	halla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obl	_	_
 19	ag	ag	ADP	Simp	_	20	case	_	_
-20	Óstán	óstán	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-21	Ghaoth	gaoth	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes
-22	Dobhair	dobhar	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	Óstán	óstán	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
+21	Ghaoth	gaoth	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes
+22	Dobhair	dobhar	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
 24	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl:tmod	_	_
-25	Dé	Dé	PROPN	Subst	Number=Sing	24	nmod	_	NamedEntity=Yes
-26	Sathairn	Satharn	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes|SpaceAfter=No
+25	Dé	Dé	PROPN	Subst	Definite=Def|Number=Sing	24	nmod	_	NamedEntity=Yes
+26	Sathairn	Satharn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes|SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
 28	ar	ar	ADP	Simp	_	29	case	_	_
 29	mhaithe	maithe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
@@ -8293,11 +8293,11 @@
 # text = I mí Eanáir, thuairisc na taighdeoirí céanna go raibh dath turcaide uirthi.
 1	I	I	ADP	Simp	_	2	case	_	_
 2	mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl:tmod	_	_
-3	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
+3	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	2	punct	_	_
 5	thuairisc	tuairisc	VERB	_	Mood=Ind|Tense=Past	0	root	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
-7	taighdeoirí	taighdeoir	NOUN	Noun	Case=NomAcc|Gender=Masc|NounType=Strong|Number=Plur	5	nsubj	_	_
+7	taighdeoirí	taighdeoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	5	nsubj	_	_
 8	céanna	céanna	ADJ	Adj	Degree=Pos	7	amod	_	_
 9	go	go	PART	Vb	PartType=Cmpl	10	mark:prt	_	_
 10	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	5	ccomp	_	_
@@ -8311,9 +8311,9 @@
 1	Bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	suí	suí	NOUN	Noun	VerbForm=Inf	1	xcomp:pred	_	_
+4	suí	suí	NOUN	Noun	Definite=Def|VerbForm=Inf	1	xcomp:pred	_	_
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	mbaic	baic	NOUN	Subst	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+6	mbaic	baic	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	coinneáil	coinneáil	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 9	coic	coic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	obj	_	_
@@ -8328,7 +8328,7 @@
 18	féar	féar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	_
 19	i	i	ADP	Simp	_	21	case	_	_
 20	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	21	nmod:poss	_	_
-21	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
+21	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	obl	_	_
 22	seafóideach	seafóideach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	21	amod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -8372,13 +8372,13 @@
 
 # sent_id = 327
 # text = Cúba a bhí chun tosaigh sa dornálaíocht agus bonn éigin ag iomaitheoirí na tíre sin i 10 n-aicme as 11, agus 6 bhonn óir ina measc san!
-1	Cúba	Cúba	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Cúba	Cúba	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 4	chun	chun	ADP	Simp	_	5	case	_	_
 5	tosaigh	tosach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	xcomp:pred	_	_
 6	sa	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	dornálaíocht	dornálaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obl	_	_
+7	dornálaíocht	dornálaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	obl	_	_
 8	agus	agus	CCONJ	Coord	_	9	mark	_	_
 9	bonn	bonn	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	advcl	_	_
 10	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	9	amod	_	_
@@ -8398,7 +8398,7 @@
 24	bhonn	bonn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
 25	óir	ór	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	24	nmod	_	_
 26	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	27	case	_	_
-27	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	nmod	_	_
+27	measc	measc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	_
 28	san	sin	DET	Det	Dialect=Munster|PronType=Dem	27	det	_	SpaceAfter=No
 29	!	!	PUNCT	!	_	1	punct	_	_
 
@@ -8420,14 +8420,14 @@
 7	lárnach	lárnach	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	6	amod	_	_
 8	sin	sin	DET	Det	PronType=Dem	6	det	_	_
 9	ón	ó	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	Ollamh	ollamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
+10	Ollamh	ollamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
 11	Ó	ó	PART	Pat	PartType=Pat	10	flat	_	NamedEntity=Yes
-12	Néill	Néill	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+12	Néill	Néill	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	chualathas	clois	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Past	1	parataxis	_	_
 15	sainléacht	sainléacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	obj	_	_
-16	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
-17	Nicholls	Nicholls	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+16	Kenneth	Kenneth	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Nicholls	Nicholls	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
 19	Léachtóir	léachtóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	_
 20	le	le	ADP	Simp	_	21	case	_	_
@@ -8435,14 +8435,14 @@
 22	i	i	ADP	Simp	_	23	case	_	_
 23	gColáiste	coláiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	nmod	_	_
 24	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-25	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
+25	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	27	punct	_	_
-27	Corcaigh	Corcaigh	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
+27	Corcaigh	Corcaigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	ar	ar	ADP	Simp	_	31	case	_	_
 30	'	'	PUNCT	Punct	_	31	punct	_	SpaceAfter=No
 31	The	the	X	Foreign	Foreign=Yes	14	obl	_	_
-32	Limerick	Limerick	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	flat:foreign	_	_
+32	Limerick	Limerick	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
 33	/	/	PUNCT	Punct	_	34	punct	_	_
 34	Cork	Cork	PROPN	Foreign	Foreign=Yes	31	flat:foreign	_	_
 35	Border	Border	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
@@ -8476,19 +8476,19 @@
 3	mar	mar	ADP	Simp	_	4	case	_	_
 4	iar-iománaí	iariománaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
 5	den	de	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	scoth	scoth	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
+6	scoth	scoth	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	4	punct	_	_
 8	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	9	cop	_	SpaceAfter=No
 9	iontach	iontach	ADJ	Adj	Degree=Pos	0	root	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
+11	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
 13	thugadh	tabhair	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	11	acl:relcl	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 15	d'	do	ADP	Simp	_	16	case	_	SpaceAfter=No
 16	Iníon	iníon	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	NamedEntity=Yes
 17	Nic	nic	PART	Pat	PartType=Pat	16	flat	_	NamedEntity=Yes
-18	Suibhne	Suibhne	PROPN	Noun	Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
+18	Suibhne	Suibhne	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	le	le	ADP	Simp	_	20	case	_	_
 20	traenáil	traenáil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
@@ -8503,7 +8503,7 @@
 30	féin	féin	PRON	Ref	Reflex=Yes	29	nmod	_	_
 31	sa	i	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
 32	chéad	céad	NUM	Num	Form=Len|NumType=Ord	33	amod	_	_
-33	líne	líne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	xcomp:pred	_	SpaceAfter=No
+33	líne	líne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	28	xcomp:pred	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 332
@@ -8541,17 +8541,17 @@
 4	agus	agus	CCONJ	Coord	_	5	mark	_	_
 5	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	advcl	_	_
 6	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	7	case	_	_
-7	uachtarán	uachtarán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	xcomp:pred	_	_
+7	uachtarán	uachtarán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	xcomp:pred	_	_
 8	ar	ar	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	gcomhluadar	comhluadar	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	7	nmod	_	_
+10	gcomhluadar	comhluadar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	7	nmod	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
-12	Mhainistir	mainistir	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
-13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Gender=Masc	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
+12	Mhainistir	mainistir	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	Co.	contae	NOUN	Abr	Abbr=Yes	12	nmod	_	NamedEntity=Yes
-16	Chill	Cill	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
-17	Dara	Dara	PROPN	Noun	_	16	nmod	_	NamedEntity=Yes
+16	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Dara	Dara	PROPN	Noun	Definite=Def	16	nmod	_	NamedEntity=Yes
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	7	conj	_	_
 20	phríomhoide	príomhoide	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
@@ -8576,7 +8576,7 @@
 6	i	i	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 7	ndiaidh	ndiaidh	ADP	Cmpd	Form=Ecl	6	fixed	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
-9	gcainteanna	caint	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Plur	1	obl	_	SpaceAfter=No
+9	gcainteanna	caint	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	1	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 335
@@ -8603,7 +8603,7 @@
 1	'	'	PUNCT	Punct	_	7	punct	_	SpaceAfter=No
 2	Ag	ag	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+4	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 5	céanna	céanna	ADJ	Adj	Degree=Pos	4	amod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	4	punct	_	_
 7	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
@@ -8617,7 +8617,7 @@
 15	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
 16	tríd	trí	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	gcóras	córas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	_
+18	gcóras	córas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	_
 19	oideachais	oideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	_
 20	ag	ag	ADP	Simp	_	21	case	_	_
 21	trá	trá	NOUN	Noun	VerbForm=Vnoun	7	xcomp:pred	_	_
@@ -8636,24 +8636,24 @@
 7	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	6	amod	_	_
 8	ar	ar	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	Sapa	Sapa	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
-11	Inca	Inca	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+10	Sapa	Sapa	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
+11	Inca	Inca	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	roghnaíodh	roghnaigh	VERB	VT	Aspect=Imp|Tense=Past	5	conj	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	chúirt	cúirt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
+16	chúirt	cúirt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	19	punct	_	_
 18	a	a	PART	Inf	PartType=Inf	19	nmod:poss	_	_
 19	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	16	conj	_	_
 20	riarthóirí	riarthóir	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	19	nmod	_	_
 21	agus	agus	CCONJ	Coord	_	23	cc	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	chomharba	comharba	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	16	conj	_	_
+23	chomharba	comharba	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	conj	_	_
 24	féin	féin	PRON	Ref	Reflex=Yes	23	nmod	_	_
 25	as	as	ADP	Simp	_	27	case	_	_
 26	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	27	nmod:poss	_	_
-27	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
+27	measc	measc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 338
@@ -8669,10 +8669,10 @@
 9	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	5	acl:relcl	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
+12	gcuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
 13	sin	sin	DET	Det	PronType=Dem	12	det	_	_
 14	dá	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	15	case	_	_
-15	corp	corp	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	nmod	_	_
+15	corp	corp	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	nsubj	_	_
 17	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	12	acl:relcl	_	_
 18	clúdaithe	clúdaithe	ADJ	Adj	VerbForm=Part	17	xcomp:pred	_	_
@@ -8688,8 +8688,8 @@
 28	geansaí	geansaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	conj	_	_
 29	a	a	PART	Vb	PartType=Vb|PronType=Rel	30	obl	_	_
 30	raibh	bí	VERB	VI	Mood=Ind|Tense=Past	28	acl:relcl	_	_
-31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	33	det	_	_
-32	oiread	oiread	NOUN	Subst	Number=Sing	30	nsubj	_	_
+31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
+32	oiread	oiread	NOUN	Subst	Definite=Def|Number=Sing	30	nsubj	_	_
 33	poll	poll	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	32	nmod	_	_
 34	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	30	xcomp:pred	_	_
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
@@ -8708,7 +8708,7 @@
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	sheandaoine	seanduine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	3	obl	_	_
 7	sa	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obl	_	_
+8	tír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	3	obl	_	_
 9	seo	seo	DET	Det	PronType=Dem	8	det	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
 11	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obl:tmod	_	_
@@ -8722,7 +8722,7 @@
 1	Rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	tEaspag	easpag	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
-4	Comiskey	Comiskey	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
+4	Comiskey	Comiskey	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
 5	neamart	neamart	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 6	ceart	ceart	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	5	amod	_	_
 7	den	de	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
@@ -8748,24 +8748,24 @@
 4	go	go	PART	Vb	PartType=Cmpl	5	mark:prt	_	_
 5	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	3	csubj:cop	_	_
 6	eagla	eagla	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
-7	orainn	ar	ADP	Prep	Number=Plur|Person=1	5	obl:prep	_	_
+7	orainn	ar	ADP	Prep	Number=Plur|Person=1	5	xcomp:pred	_	_
 8	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	9	nmod:poss	_	_
-9	lorg	lorg	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
+9	lorg	lorg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obj	_	_
 10	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 11	a	a	PART	Inf	PartType=Inf	12	mark	_	_
 12	fhágáil	fágáil	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	timpeallacht	timpeallacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	obl	_	_
-16	agus	agus	CCONJ	Coord	_	17	cc	_	_
-17	ailtireacht	ailtireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	conj	_	_
+15	timpeallacht	timpeallacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	obl	_	_
+16	agus	agus	CCONJ	Coord	_	24	cc	_	_
+17	ailtireacht	ailtireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	obj	_	_
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	nsubj	_	_
-19	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	15	acl:relcl	_	_
-20	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	24	case	_	_
-21	n-aimsir	aimsir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	24	obj	_	_
+19	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	17	acl:relcl	_	_
+20	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	21	case	_	_
+21	n-aimsir	aimsir	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	19	obl	_	_
 22	féin	féin	PRON	Ref	Reflex=Yes	21	nmod	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
-24	fhorbairt	forbairt	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	SpaceAfter=No
+24	fhorbairt	forbairt	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	12	conj	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 342
@@ -8791,16 +8791,16 @@
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	cónaí	cónaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	Cháit	Cáit	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+4	Cháit	Cáit	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 5	agus	agus	CCONJ	Coord	_	8	cc	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	8	nmod:poss	_	_
-8	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	conj	_	SpaceAfter=No
+8	fear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	conj	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
-10	Donncha	Donncha	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
+10	Donncha	Donncha	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	13	punct	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
-13	gCluain	cluain	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	NamedEntity=Yes
+13	gCluain	cluain	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	NamedEntity=Yes
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	NamedEntity=Yes
 15	hAbhann	abhainn	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
@@ -8809,7 +8809,7 @@
 19	mhíle	míle	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
 20	siar	siar	ADV	Dir	_	19	advmod	_	_
 21	ón	ó	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
-22	mbaile	baile	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
+22	mbaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 344
@@ -8836,12 +8836,12 @@
 # text = Nílim á rá gur chloígh gach aon duine leis na rialacha i gcónaí - agus ar chaoi ar bith b'fhurusta cead eisceachta a fháil de bharr easláinte, nó sclábhaíocht throm nó a leithéid - ach bhí dlí choitianta an troscaidh ceangailte ar gach uile Chaitliceach idir a seacht mbliana agus trí scór bliain d'aois.
 1	Nílim	bí	VERB	PresInd	Mood=Ind|Number=Sing|Person=1|Polarity=Neg|Tense=Pres	0	root	_	_
 2	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	case	_	_
-3	rá	rá	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
+3	rá	rá	NOUN	Noun	Definite=Def|VerbForm=Inf	1	xcomp	_	_
 4	gur	gur	PART	Vb	PartType=Vb|Tense=Past	5	mark:prt	_	_
 5	chloígh	cloígh	VERB	VT	Form=Len|Mood=Ind|Tense=Past	1	ccomp	_	_
 6	gach	gach	DET	Det	Definite=Def	8	det	_	_
 7	aon	aon	DET	Det	PronType=Ind	8	det	_	_
-8	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
+8	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
 11	rialacha	riail	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	5	obl	_	_
@@ -8868,14 +8868,14 @@
 32	throm	trom	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	31	amod	_	_
 33	nó	nó	CCONJ	Coord	_	35	cc	_	_
 34	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	35	nmod:poss	_	_
-35	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	conj	_	_
+35	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	28	conj	_	_
 36	-	-	PUNCT	Punct	_	37	punct	_	_
 37	ach	ach	SCONJ	Subord	_	38	mark	_	_
 38	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 39	dlí	dlí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	38	nsubj	_	_
 40	choitianta	coitianta	ADJ	Adj	Degree=Pos|Form=Len	39	amod	_	_
 41	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	42	det	_	_
-42	troscaidh	troscadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	39	nmod	_	_
+42	troscaidh	troscadh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	39	nmod	_	_
 43	ceangailte	ceangailte	ADJ	Adj	VerbForm=Part	38	xcomp:pred	_	_
 44	ar	ar	ADP	Simp	_	47	case	_	_
 45	gach	gach	DET	Det	Definite=Def	46	det	_	_
@@ -8922,12 +8922,12 @@
 25	de	de	ADP	Cmpd	PrepForm=Cmpd	28	case	_	_
 26	réir	réir	ADP	Cmpd	_	25	fixed	_	_
 27	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	nmod:poss	_	_
-28	chéile	céile	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	29	nmod	_	_
+28	chéile	céile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	29	nmod	_	_
 29	chuir	cur	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	1	advcl	_	_
 30	siad	siad	PRON	Pers	Number=Plur|Person=3	29	nsubj	_	_
 31	sin	sin	PRON	Dem	PronType=Dem	30	det	_	_
 32	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	33	nmod:poss	_	_
-33	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	29	obj	_	_
+33	gcás	cás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	29	obj	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
 35	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	29	nmod	_	_
 36	ar	ar	ADP	Cmpd	PrepForm=Cmpd	38	case	_	_
@@ -8955,7 +8955,7 @@
 58	tuairim	tuairim	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	64	obj	_	_
 59	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	61	det	_	_
 60	'	'	PUNCT	Punct	_	61	punct	_	SpaceAfter=No
-61	saorthrádála	saorthrádáil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	58	nmod	_	SpaceAfter=No
+61	saorthrádála	saorthrádáil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	58	nmod	_	SpaceAfter=No
 62	'	'	PUNCT	Punct	_	61	punct	_	_
 63	a	a	PART	Inf	PartType=Inf	64	mark	_	_
 64	spreagadh	spreagadh	NOUN	Noun	VerbForm=Inf	55	xcomp	_	_
@@ -9028,9 +9028,9 @@
 # sent_id = 347
 # text = Labhair Éire le Donn ansin.
 1	Labhair	labhair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
-2	Éire	Éire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
+2	Éire	Éire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	le	le	ADP	Simp	_	4	case	_	_
-4	Donn	Donn	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
+4	Donn	Donn	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 5	ansin	ansin	ADV	Loc	_	1	advmod	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -9056,7 +9056,7 @@
 18	meastar	meas	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	6	parataxis	_	_
 19	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	21	cop	_	_
 20	in	i	ADP	Simp	_	21	case	_	_
-21	Éirinn	Éire	PROPN	Noun	Case=Dat|Gender=Fem|Number=Sing	18	ccomp	_	_
+21	Éirinn	Éire	PROPN	Noun	Case=Dat|Definite=Def|Gender=Fem|Number=Sing	18	ccomp	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	mark:prt	_	_
 23	lonnaítear	lonnaigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	21	csubj:cleft	_	_
 24	timpeall	timpeall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nsubj	_	_
@@ -9082,7 +9082,7 @@
 7	faoi	faoi	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	obl:prep	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	10	case	_	_
-10	adhradh	adhradh	NOUN	Noun	VerbForm=Inf	4	xcomp	_	_
+10	adhradh	adhradh	NOUN	Noun	Definite=Def|VerbForm=Inf	4	xcomp	_	_
 11	atáid	bí	VERB	VI	Mood=Ind|Number=Plur|Person=3|PronType=Rel|Tense=Pres	10	acl:relcl	_	_
 12	anois	anois	ADV	Gn	_	11	advmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
@@ -9093,7 +9093,7 @@
 2	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	obl:tmod	_	_
 4	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	2	acl:relcl	_	_
-5	Butt	Butt	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	SpaceAfter=No
+5	Butt	Butt	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	obj	_	SpaceAfter=No
 6	...	...	PUNCT	...	_	2	punct	_	_
 
 # sent_id = 351
@@ -9129,7 +9129,7 @@
 4	thiar	thiar	ADV	Dir	_	3	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	7	punct	_	_
 6	a	a	PART	Voc	PartType=Voc	7	case:voc	_	_
-7	Sheáin	Seán	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc	1	vocative	_	SpaceAfter=No
+7	Sheáin	Seán	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	1	vocative	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 355
@@ -9183,7 +9183,7 @@
 5	)	)	PUNCT	Punct	_	4	punct	_	_
 6	ina	i	PART	Rel	PronType=Rel	7	obl	_	_
 7	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	1	acl:relcl	_	_
-8	Nuachló	Nuachló	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
+8	Nuachló	Nuachló	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	leagan	leagan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
 11	3.00	3.00	NUM	Num	_	10	nmod	_	SpaceAfter=No
@@ -9237,7 +9237,7 @@
 1	Go	go	PART	Ad	PartType=Ad	2	mark:prt	_	_
 2	háirithe	áirithe	ADJ	Adj	Degree=Pos|Form=HPref	0	root	_	_
 3	san	i	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
-4	oíche	oíche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
+4	oíche	oíche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 363
@@ -9287,7 +9287,7 @@
 30	N'	N	NOUN	Abr	Abbr=Yes	26	conj	_	_
 31	leis	le	ADP	Simp	_	33	case	_	_
 32	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	33	det	_	_
-33	gcolún	colún	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	22	obl	_	_
+33	gcolún	colún	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	22	obl	_	_
 34	ar	ar	ADP	Simp	_	35	case	_	_
 35	dheis	deis	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	2	punct	_	_
@@ -9310,7 +9310,7 @@
 14	amach	amach	ADV	Dir	_	9	xcomp:pred	_	_
 15	romhainn	roimh	ADP	Prep	Number=Plur|Person=1	14	obl:prep	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
-17	bpáirc	páirc	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
+17	bpáirc	páirc	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
 18	Ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	19	advmod	_	_
 19	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	9	parataxis	_	_
 20	aon	aon	DET	Det	PronType=Ind	21	det	_	_
@@ -9329,7 +9329,7 @@
 33	timpeall	timpeall	ADV	Dir	_	31	advmod	_	_
 34	leis	le	ADP	Simp	_	36	case	_	_
 35	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
-36	ngalra	galra	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	_
+36	ngalra	galra	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	_
 37	cam	cam	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	36	amod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -9365,34 +9365,34 @@
 18	chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	12	advcl	_	_
 19	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	18	nsubj	_	_
 20	nach	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	21	cop	_	_
-21	Gaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	18	ccomp	_	_
+21	Gaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	ccomp	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	mark:prt	_	_
 23	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	21	csubj:cleft	_	_
 24	sa	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	scríbhinn	scríbhinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	23	xcomp:pred	_	_
+25	scríbhinn	scríbhinn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	xcomp:pred	_	_
 26	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	23	obl:prep	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	28	punct	_	_
 28	ná	ná	SCONJ	Coord	_	29	mark	_	_
 29	fiú	fiú	NOUN	Subst	Number=Sing	30	nmod	_	_
-30	Gaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	orphan	_	_
+30	Gaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	orphan	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
-32	Béarla	Béarla	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	conj	_	SpaceAfter=No
+32	Béarla	Béarla	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	30	conj	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	34	punct	_	_
 34	ach	ach	SCONJ	Subord	_	35	mark:prt	_	_
-35	Béarla	Béarla	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nmod	_	_
+35	Béarla	Béarla	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
 36	amháin	amháin	ADJ	Adj	Degree=Pos	35	amod	_	_
 37	(	(	PUNCT	Punct	_	38	punct	_	SpaceAfter=No
 38	cé	cé	SCONJ	Subord	_	21	parataxis	_	_
 39	is	is	SCONJ	Subord	_	38	fixed	_	_
 40	moite	moite	SCONJ	Subord	_	38	fixed	_	_
 41	den	de	ADP	Art	Number=Sing|PronType=Art	42	case	_	_
-42	leasainm	leasainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	38	nmod	_	_
+42	leasainm	leasainm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	38	nmod	_	_
 43	nó	nó	CCONJ	Coord	_	44	cc	_	_
 44	ainm	ainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	42	conj	_	_
 45	cleite	cleite	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	44	compound	_	_
 46	'	'	PUNCT	Punct	_	48	punct	_	SpaceAfter=No
 47	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
-48	Craoibhín	craobh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	38	nmod	_	_
+48	Craoibhín	craoibhín	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	38	nmod	_	_
 49	Aoibhinn	aoibhinn	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	48	nmod	_	SpaceAfter=No
 50	'	'	PUNCT	Punct	_	48	punct	_	SpaceAfter=No
 51	)	)	PUNCT	Punct	_	38	punct	_	SpaceAfter=No
@@ -9419,14 +9419,14 @@
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	raidió	raidió	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	in	i	ADP	Simp	_	8	case	_	_
-8	Éirinn	Éire	PROPN	Noun	Case=Dat|Gender=Fem|Number=Sing	6	nmod	_	_
+8	Éirinn	Éire	PROPN	Noun	Case=Dat|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 9	le	le	ADP	Simp	_	11	case	_	_
 10	75	75	NUM	Num	_	11	nummod	_	_
 11	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	obl:tmod	_	_
 12	anuas	anuas	ADV	Dir	_	11	advmod	_	_
 13	os	os	ADP	Simp	_	15	case	_	_
 14	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	15	nmod:poss	_	_
-15	gcomhair	comhair	NOUN	Subst	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+15	gcomhair	comhair	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 16	sa	i	ADP	Art	Number=Sing|PronType=Art	17	case	_	_
 17	taispeántas	taispeántas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
@@ -9454,7 +9454,7 @@
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	mark:prt	_	_
 5	shroicheamar	sroich	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=1|Tense=Past	8	advcl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	stad	stad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
+7	stad	stad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obj	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 9	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nsubj	_	_
 10	óg	óg	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	9	amod	_	_
@@ -9464,7 +9464,7 @@
 14	dtí	dtí	ADP	Cmpd	Form=Ecl	13	fixed	_	_
 15	muid	muid	PRON	Pers	Number=Plur|Person=1	12	obl	_	_
 16	lenár	le	ADP	Poss	Number=Plur|Person=1|Poss=Yes	17	case	_	_
-17	dtrealamh	trealamh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	20	obj	_	_
+17	dtrealamh	trealamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	20	obj	_	_
 18	bagáiste	bagáiste	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	nmod	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
 20	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	15	xcomp	_	_
@@ -9484,7 +9484,7 @@
 9	chaoinfeas	caoin	VERB	FutInd	Form=Len|Mood=Ind|PronType=Rel|Tense=Fut	4	acl:relcl	_	_
 10	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	9	nsubj	_	_
 11	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	nmod:poss	_	_
-12	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
+12	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
 13	siléige	siléig	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
 14	chúns	chomh_fada_is	SCONJ	Subord	_	16	mark	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
@@ -9492,7 +9492,7 @@
 17	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	16	nsubj	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	scoil	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	xcomp:pred	_	_
+20	scoil	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	xcomp:pred	_	_
 21	seo	seo	DET	Det	PronType=Dem	20	det	_	_
 22	againne	ag	ADP	Prep	Number=Plur|Person=1|PronType=Emp	16	obl:prep	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	3	punct	_	_
@@ -9515,13 +9515,13 @@
 14	tÉirí	éirí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	NamedEntity=Yes
 15	Amach	amach	ADV	Dir	_	14	amod	_	NamedEntity=Yes
 16	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	xcomp:pred	_	_
-17	Domhnach	Domhnach	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl:tmod	_	NamedEntity=Yes
-18	Cásca	Cáisc	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	NamedEntity=Yes
+17	Domhnach	Domhnach	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl:tmod	_	NamedEntity=Yes
+18	Cásca	Cáisc	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	ar	ar	ADP	Simp	_	23	case	_	_
 20	a	a	PART	Nm	PartType=Num	21	mark:prt	_	_
 21	seacht	seacht	NUM	Num	NumType=Card	23	nummod	_	_
 22	a	an	DET	Art	Number=Sing|PronType=Art	23	det	_	_
-23	chlog	clog	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+23	chlog	clog	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 24	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -9552,18 +9552,18 @@
 # sent_id = 375
 # text = Chas Marcas 'Trup, trup, a Chapaillín' agus dhamhsaigh Dónall a bhíodh ag freastal ar Scoil Dhamhsa Uí Chorragáin cornphíopa agus thionlaic sé féin é le port béil, rud a chur na gasúir faoi dhraíocht.
 1	Chas	Cas	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Marcas	Marcas	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Marcas	Marcas	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	'	'	PUNCT	Punct	_	4	punct	_	SpaceAfter=No
 4	Trup	trup	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
 6	trup	trup	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	9	punct	_	_
 8	a	a	PART	Voc	PartType=Voc	9	case:voc	_	_
-9	Chapaillín	capaillín	NOUN	Noun	Case=Voc|Form=Len|Gender=Masc|Number=Sing	4	vocative	_	SpaceAfter=No
+9	Chapaillín	capaillín	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	vocative	_	SpaceAfter=No
 10	'	'	PUNCT	Punct	_	4	punct	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
 12	dhamhsaigh	damhsaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
-13	Dónall	Dónall	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	nsubj	_	_
+13	Dónall	Dónall	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	13	acl:relcl	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
@@ -9572,7 +9572,7 @@
 19	Scoil	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obl	_	NamedEntity=Yes
 20	Dhamhsa	damhsa	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Uí	uí	PART	Pat	PartType=Pat	19	nmod	_	NamedEntity=Yes
-22	Chorragáin	Corragáin	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	21	flat:name	_	NamedEntity=Yes
+22	Chorragáin	Corragáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	21	flat:name	_	NamedEntity=Yes
 23	cornphíopa	cornphíopa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
 24	agus	agus	CCONJ	Coord	_	25	mark	_	_
 25	thionlaic	tionlaic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
@@ -9587,7 +9587,7 @@
 34	a	a	PART	Vb	PartType=Vb|PronType=Rel	35	nsubj	_	_
 35	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	33	acl:relcl	_	_
 36	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	37	det	_	_
-37	gasúir	gasúr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	35	obj	_	_
+37	gasúir	gasúr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	35	obj	_	_
 38	faoi	faoi	ADP	Simp	_	39	case	_	_
 39	dhraíocht	draíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	35	obl	_	SpaceAfter=No
 40	.	.	PUNCT	.	_	1	punct	_	_
@@ -9624,7 +9624,7 @@
 6	roinnt	roinnt	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 7	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	9	case	_	_
 8	dhá	dó	NUM	Num	Form=Len|NumType=Card	9	nummod	_	_
-9	gcineál	cineál	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
+9	gcineál	cineál	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	idir	idir	ADP	Simp	_	12	case	_	_
 12	acmhainní	acmhainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	6	nmod	_	_
@@ -9644,7 +9644,7 @@
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	diabhal	diabhal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 8	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	9	nmod:poss	_	_
-9	bhóthar	bóthar	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obj	_	SpaceAfter=No
+9	bhóthar	bóthar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obj	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	5	punct	_	_
 11	imigh	imigh	VERB	VI	Mood=Imp|Number=Sing|Person=2	0	root	_	_
 12	leat	le	ADP	Prep	Number=Sing|Person=2	11	obl:prep	_	_
@@ -9663,12 +9663,12 @@
 5	agat	ag	ADP	Prep	Number=Sing|Person=2	3	obl:prep	_	SpaceAfter=No
 6	'	'	PUNCT	Punct	_	3	punct	_	_
 7	adeir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-8	Páraic	Páraic	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
+8	Páraic	Páraic	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	Mise	mise	PRON	Pers	Number=Sing|Person=1|PronType=Emp	7	parataxis	_	_
 11	agus	agus	CCONJ	Coord	_	14	cc	_	_
 12	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	13	nmod:poss	_	_
-13	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	conj	_	_
+13	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	conj	_	_
 14	clabaireachta	clabaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	7	punct	_	_
 
@@ -9683,7 +9683,7 @@
 7	scríofa	scríofa	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	_
 8	ar	ar	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	_
+10	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 11	seo	seo	DET	Det	PronType=Dem	10	det	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	agus	agus	CCONJ	Coord	_	14	cc	_	_
@@ -9716,24 +9716,24 @@
 6	Cuimhní	cuimhne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 7	Cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	ar	ar	ADP	Simp	_	9	case	_	_
-9	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+9	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 10	Ó	ó	PART	Pat	PartType=Pat	9	flat:name	_	NamedEntity=Yes
-11	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	9	flat:name	_	NamedEntity=Yes
+11	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	9	flat:name	_	NamedEntity=Yes
 12	Foilsithe	foilsithe	ADJ	Adj	VerbForm=Part	6	xcomp:pred	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	Coiste	coiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	NamedEntity=Yes
 15	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	15	nmod	_	_
+17	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	15	nmod	_	_
 18	Teoranta	teoranta	ADJ	Adj	Degree=Pos	17	amod	_	_
-19	Euro	Euro	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	nmod	_	_
+19	Euro	Euro	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	_
 20	5	5	NUM	Num	_	19	nmod	_	_
 21	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
 22	iad	iad	PRON	Pers	Number=Plur|Person=3	23	nmod	_	_
 23	Coiste	coiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	parataxis	_	NamedEntity=Yes
 24	Dhaonscoil	daonscoil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	NamedEntity=Yes
-26	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	23	nmod	_	NamedEntity=Yes
+26	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	23	nmod	_	NamedEntity=Yes
 27	a	a	PART	Vb	PartType=Vb|PronType=Rel	28	mark:prt	_	_
 28	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	23	csubj:cleft	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	30	det	_	_
@@ -9741,13 +9741,13 @@
 31	cuimhneacháin	cuimhneachán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	30	nmod	_	_
 32	seo	seo	DET	Det	PronType=Dem	30	det	_	_
 33	ar	ar	ADP	Simp	_	34	case	_	_
-34	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes
+34	Phádraig	Pádraig	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes
 35	Ó	ó	PART	Pat	PartType=Pat	34	flat:name	_	NamedEntity=Yes
-36	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	34	flat:name	_	NamedEntity=Yes
+36	hIceadha	Iceadha	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	34	flat:name	_	NamedEntity=Yes
 37	i	i	ADP	Simp	_	38	case	_	_
 38	dtoll	toll	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	28	obl	_	_
 39	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	40	nmod:poss	_	_
-40	chéile	céile	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	38	nmod	_	SpaceAfter=No
+40	chéile	céile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	38	nmod	_	SpaceAfter=No
 41	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 382
@@ -9774,12 +9774,12 @@
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 5	anseo	anseo	ADV	Loc	_	3	xcomp:pred	_	_
 6	sa	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	gcistin	cistin	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
+7	gcistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 9	'	'	PUNCT	Punct	_	3	punct	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
 11	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-12	Monica	Monica	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	nsubj	_	SpaceAfter=No
+12	Monica	Monica	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	11	nsubj	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	11	punct	_	_
 
 # sent_id = 384
@@ -9793,15 +9793,15 @@
 7	le	le	ADP	Simp	_	8	case	_	_
 8	chéile	céile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	gcomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
+10	gcomhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
 12	Celtic	Celtic	X	Foreign	Foreign=Yes	10	appos	_	NamedEntity=Yes
 13	Candles	Candles	X	Foreign	Foreign=Yes	12	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	16	punct	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
-16	mBaile	Baile	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
-17	Átha	Átha	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
-18	Cliath	Cliath	PROPN	Noun	_	17	nmod	_	NamedEntity=Yes
+16	mBaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+17	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Cliath	Cliath	PROPN	Noun	Definite=Def	17	nmod	_	NamedEntity=Yes
 19	agus	agus	CCONJ	Coord	_	20	cc	_	_
 20	dhein	dein	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
 21	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nsubj	_	_
@@ -9831,18 +9831,18 @@
 8	Cor	cor	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	Ochtar	ochtar	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	8	flat:foreign	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
-11	Gay	Gay	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
-12	Gordons	Gordons	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	flat:foreign	_	SpaceAfter=No
+11	Gay	Gay	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
+12	Gordons	Gordons	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	flat:foreign	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	Highland	Highland	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
-15	Fling	Fling	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	flat:foreign	_	SpaceAfter=No
+14	Highland	Highland	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
+15	Fling	Fling	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	flat:foreign	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
-17	Sword	Sword	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
-18	Dance	Dance	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	flat:foreign	_	SpaceAfter=No
+17	Sword	Sword	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
+18	Dance	Dance	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	flat:foreign	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
-20	Dashing	Dashing	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
-21	White	White	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	flat:foreign	_	_
-22	Sargents	Sargents	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	flat:foreign	_	_
+20	Dashing	Dashing	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
+21	White	White	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	flat:foreign	_	_
+22	Sargents	Sargents	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	flat:foreign	_	_
 23	agus	agus	CCONJ	Coord	_	24	cc	_	_
 24	mórán	mórán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	conj	_	_
 25	eile	eile	DET	Det	PronType=Dem	24	det	_	_
@@ -9850,7 +9850,7 @@
 27	dhamhsaí	damhsa	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	24	nmod	_	_
 28	bríomhara	bríomhar	ADJ	Adj	Case=NomAcc|NounType=NotSlender|Number=Plur	27	amod	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-30	hAlban	Albain	PROPN	Noun	Case=Gen|Form=HPref|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
+30	hAlban	Albain	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
 31	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 386
@@ -9861,7 +9861,7 @@
 4	eile	eile	DET	Det	PronType=Dem	3	det	_	_
 5	siar	siar	ADV	Dir	_	3	advmod	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
-7	Johnny	Johnny	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
+7	Johnny	Johnny	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 8	Rua	Rua	ADJ	Adj	Gender=Masc|Number=Sing	7	amod	_	NamedEntity=Yes|SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -9908,7 +9908,7 @@
 # text = 'Faoin am seo - lár an lae más buan mo chuimhne - bhí teas ollmhór ann agus thug mé faoi deara go raibh an chré sa bhlaosc tosaithe ag leá.
 1	'	'	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
 2	Faoin	faoi	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	am	am	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
+3	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	-	-	PUNCT	Punct	_	6	punct	_	_
 6	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
@@ -9917,7 +9917,7 @@
 9	más	má	SCONJ	Subord	VerbForm=Cop	10	mark	_	_
 10	buan	buan	ADJ	Adj	Degree=Pos	3	advcl	_	_
 11	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	12	nmod:poss	_	_
-12	chuimhne	cuimhne	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	nsubj	_	_
+12	chuimhne	cuimhne	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nsubj	_	_
 13	-	-	PUNCT	Punct	_	3	punct	_	_
 14	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 15	teas	teas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -9944,18 +9944,18 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	101	101	NUM	Num	_	1	nsubj	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
-4	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
-5	Eo	Eo	PROPN	Noun	Number=Sing	4	nmod	_	NamedEntity=Yes
+4	Maigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+5	Eo	Eo	PROPN	Noun	Definite=Def|Number=Sing	4	nmod	_	NamedEntity=Yes
 6	féin	féin	PRON	Ref	Reflex=Yes	4	nmod	_	_
 7	-	-	PUNCT	Punct	_	8	punct	_	_
-8	Gaeltacht	Gaeltacht	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nmod	_	_
+8	Gaeltacht	Gaeltacht	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
 9	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	8	acl:relcl	_	_
 10	chomh	chomh	ADV	Its	_	11	advmod	_	_
 11	scaipthe	scaipthe	ADJ	Adj	Degree=Pos	9	xcomp:pred	_	_
 12	le	le	ADP	Simp	_	13	case	_	_
-13	Gaeltachtaí	Gaeltacht	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	9	obl	_	NamedEntity=Yes
+13	Gaeltachtaí	Gaeltacht	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	9	obl	_	NamedEntity=Yes
 14	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	NamedEntity=Yes
-15	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
+15	Mumhan	Mumhan	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
 16	freisin	freisin	ADV	Gn	_	9	advmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -9965,9 +9965,9 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	t-ollamh	ollamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 4	Mac	mac	PART	Pat	PartType=Pat	3	flat	_	NamedEntity=Yes
-5	Craith	Craith	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+5	Craith	Craith	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
+7	dóigh	dóigh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 8	ar	ar	PART	Vb	PartType=Vb|PronType=Rel|Tense=Past	9	obl	_	_
 9	fhorbair	forbair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	7	acl:relcl	_	_
 10	coincheapa	coincheap	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	9	nsubj	_	_
@@ -9981,12 +9981,12 @@
 18	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
 19	Gael	Gael	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	18	nmod	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
-21	seanGhall	seanGhall	PROPN	Noun	Case=Gen|Gender=Masc|Number=Plur	19	conj	_	_
+21	seanGhall	seanGhall	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	19	conj	_	_
 22	ó	ó	ADP	Simp	_	23	case	_	_
 23	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
 25	séú	sé	NUM	Num	NumType=Ord	26	amod	_	_
-26	haois	aois	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	_
+26	haois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	23	nmod	_	_
 27	déag	déag	NOUN	Subst	Case=NomAcc|Number=Sing	25	nmod	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10002,14 +10002,14 @@
 8	...	...	PUNCT	Punct	_	9	punct	_	_
 9	Cuirtear	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	1	parataxis	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	ghnéasúlacht	gnéasúlacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
+11	ghnéasúlacht	gnéasúlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obj	_	_
 12	chéanna	céanna	ADJ	Adj	Degree=Pos|Form=Len	11	amod	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	agus	agus	CCONJ	Coord	_	18	cc	_	_
 15	go	go	PART	Ad	PartType=Ad	16	mark:prt	_	_
 16	deimhin	deimhin	ADJ	Adj	Degree=Pos	18	advmod	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	chiontaíl	ciontaíl	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	conj	_	_
+18	chiontaíl	ciontaíl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	conj	_	_
 19	a	a	PART	Vb	PartType=Vb|PronType=Rel	20	nsubj	_	_
 20	théas	téigh	VERB	VTI	Form=Len|Mood=Ind|PronType=Rel|Tense=Pres	18	acl:relcl	_	_
 21	leis	le	ADP	Simp	_	23	case	_	_
@@ -10029,7 +10029,7 @@
 35	macnas	macnas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 36	agus	agus	CCONJ	Coord	_	38	cc	_	_
 37	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
-38	súnás	súnás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	conj	_	_
+38	súnás	súnás	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	35	conj	_	_
 39	(	(	PUNCT	Punct	_	42	punct	_	SpaceAfter=No
 40	agus	agus	CCONJ	Coord	_	42	cc	_	_
 41	ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	42	cop	_	_
@@ -10051,7 +10051,7 @@
 1	Ar	ar	ADP	Simp	_	4	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 3	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	4	amod	_	_
-4	dul	dul	NOUN	Noun	VerbForm=Inf	7	obl	_	_
+4	dul	dul	NOUN	Noun	Definite=Def|VerbForm=Inf	7	obl	_	_
 5	síos	síos	ADV	Dir	_	4	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	4	punct	_	_
 7	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -10096,7 +10096,7 @@
 
 # sent_id = 398
 # text = Splándíd: Nach iontach sin.
-1	Splándíd	Splándíd	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+1	Splándíd	Splándíd	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	4	punct	_	_
 3	Nach	is	AUX	Cop	Mood=Int|Polarity=Neg|Tense=Pres|VerbForm=Cop	4	cop	_	_
 4	iontach	iontach	ADJ	Adj	Degree=Pos	1	parataxis	_	_
@@ -10126,7 +10126,7 @@
 7	agus	agus	CCONJ	Coord	_	8	mark	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 9	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	10	case	_	_
-10	shá	sá	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
+10	shá	sá	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	8	xcomp	_	_
 11	féin	féin	PRON	Ref	Reflex=Yes	10	nmod	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	bpiont	piont	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	10	nmod	_	_
@@ -10157,10 +10157,10 @@
 15	bogadh	bog	VERB	VTI	Mood=Imp|Number=Sing|Person=3	11	conj	_	_
 16	isteach	isteach	ADV	Dir	_	15	advmod	_	_
 17	san	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	oifig	oifig	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obl	_	_
+18	oifig	oifig	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obl	_	_
 19	thosaigh	tosach	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	18	compound	_	_
 20	le	le	ADP	Simp	_	21	case	_	_
-21	Susan	Susan	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	15	obl	_	_
+21	Susan	Susan	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obl	_	_
 22	ar	ar	ADP	Cmpd	PrepForm=Cmpd	24	case	_	_
 23	feadh	feadh	ADP	Cmpd	_	22	fixed	_	_
 24	leathuaire	leathuair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	obl	_	_
@@ -10174,9 +10174,9 @@
 1	Conas	conas	ADV	Q	PronType=Int	3	advmod	_	_
 2	a	a	PART	Vb	PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	chosnaíonn	cosain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	0	root	_	_
-4	Beckett	Beckett	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	SpaceAfter=No
+4	Beckett	Beckett	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Joyce	Joyce	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	conj	_	_
+6	Joyce	Joyce	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	conj	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	gearáin	gearán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	3	obl	_	_
@@ -10190,7 +10190,7 @@
 3	ar	ar	ADV	Dir	_	2	advmod	_	_
 4	ais	ais	ADV	Dir	_	3	fixed	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
-6	Dhamien	Dhamien	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
+6	Dhamien	Dhamien	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 7	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	9	cop	_	SpaceAfter=No
 8	in	sin	PRON	Dem	PronType=Dem	9	nmod	_	_
 9	roimhe	roimh	ADP	Prep	Gender=Masc|Number=Sing|Person=3	0	root	_	_
@@ -10228,7 +10228,7 @@
 7	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 8	oibrithe	oibrí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	7	nsubj	_	_
 9	ón	ó	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	taobhlach	taobhlach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
+10	taobhlach	taobhlach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
 12	gcabhair	cabhair	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	7	obl	_	_
 13	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	12	obl:prep	_	SpaceAfter=No
@@ -10254,12 +10254,12 @@
 11	roinn	roinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
 12	bheag	beag	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	11	amod	_	_
 13	den	de	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	Roinn	roinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
+14	Roinn	roinn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
 15	Ealaíon	ealaín	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Weak|Number=Plur	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	Cultúir	cultúr	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+19	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 20	agus	agus	CCONJ	Coord	_	21	cc	_	NamedEntity=Yes
 21	Oileán	oileán	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	15	conj	_	NamedEntity=Yes|SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
@@ -10271,7 +10271,7 @@
 3	Anois	anois	ADV	Gn	_	10	advmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	3	punct	_	_
 5	a	a	PART	Voc	PartType=Voc	6	case:voc	_	_
-6	Pháidín	Páidín	PROPN	Noun	Case=Voc|Form=Len|Gender=Masc	10	vocative	_	SpaceAfter=No
+6	Pháidín	Páidín	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	10	vocative	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
 8	'	'	PUNCT	Punct	_	6	punct	_	_
 9	a	a	PART	Vb	PartType=Vb|PronType=Rel	10	mark:prt	_	_
@@ -10284,7 +10284,7 @@
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	iarraidh	iarraidh	NOUN	Noun	VerbForm=Vnoun	14	xcomp	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
-19	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	obj	_	_
+19	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
 20	seo	seo	DET	Det	PronType=Dem	19	det	_	_
 21	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
 22	litir	litir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
@@ -10302,7 +10302,7 @@
 34	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	31	csubj:cleft	_	_
 35	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	34	xcomp:pred	_	_
 36	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	37	case	_	_
-37	bharr	barr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	34	obl	_	SpaceAfter=No
+37	bharr	barr	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	34	obl	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	10	punct	_	_
 
 # sent_id = 410
@@ -10348,7 +10348,7 @@
 3	tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 4	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	6	nmod:poss	_	_
 5	thrí	trí	NUM	Num	Form=Len|NumType=Card	6	nummod	_	_
-6	oiread	oiread	NOUN	Subst	Number=Sing	3	nsubj	_	_
+6	oiread	oiread	NOUN	Subst	Definite=Def|Number=Sing	3	nsubj	_	_
 7	agatsa	ag	ADP	Prep	Number=Sing|Person=2|PronType=Emp	3	obl:prep	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
 9	maitheamh	maitheamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	_
@@ -10357,18 +10357,18 @@
 
 # sent_id = 413
 # text = Peigí ag déanamh patróil níos déine sa chistin, ise ina crunca gúngach níos mó uair ná ba ghnách léi, gach aon rite reaite tríd an teach de ríog agus clamhsán i sean-ard a cinn i dtaobh rud éigin aici.
-1	Peigí	Peigí	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
+1	Peigí	Peigí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 2	ag	ag	ADP	Simp	_	3	case	_	_
 3	déanamh	déanamh	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 4	patróil	patról	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	obj	_	_
 5	níos	níos	PART	Cmp	PartType=Comp	6	mark:prt	_	_
 6	déine	dian	ADJ	Adj	Degree=Cmp,Sup	4	amod	_	_
 7	sa	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	chistin	cistin	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+8	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	ise	ise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	1	parataxis	_	_
 11	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	12	case	_	_
-12	crunca	crunca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	xcomp:pred	_	_
+12	crunca	crunca	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	xcomp:pred	_	_
 13	gúngach	gúngach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	12	amod	_	_
 14	níos	níos	PART	Cmp	PartType=Comp	15	mark:prt	_	_
 15	mó	mór	ADJ	Adj	Degree=Cmp,Sup	16	amod	_	_
@@ -10392,7 +10392,7 @@
 33	i	i	ADP	Simp	_	34	case	_	_
 34	sean-ard	sean-ard	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	nmod	_	_
 35	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
-36	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	34	nmod	_	_
+36	cinn	ceann	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
 37	i	i	ADP	Simp	_	38	case	_	_
 38	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	32	nmod	_	_
 39	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	38	nmod	_	_
@@ -10406,9 +10406,9 @@
 2	éis	éis	ADP	Cmpd	_	1	fixed	_	_
 3	píosa	píosa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obl	_	_
 4	den	de	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
+5	lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	_
 6	bhuail	buail	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-7	Micil	Micil	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
+7	Micil	Micil	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	siar	siar	ADV	Dir	_	6	amod	_	_
 9	abhaile	abhaile	ADV	Dir	_	6	advmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	6	punct	_	_
@@ -10418,25 +10418,25 @@
 1	Níl	bí	VERB	PresInd	Mood=Ind|Polarity=Neg|Tense=Pres	0	root	_	_
 2	fágtha	fágtha	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 3	den	de	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
-4	seandream	seandream	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
+4	seandream	seandream	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 5	ach	ach	SCONJ	Subord	_	1	mark:prt	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	Ceannaire	ceannaire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
-9	Mary	Mary	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	appos	_	NamedEntity=Yes
-10	Harney	Harney	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+9	Mary	Mary	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	appos	_	NamedEntity=Yes
+10	Harney	Harney	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
-13	Liz	Liz	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	conj	_	NamedEntity=Yes
+13	Liz	Liz	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	conj	_	NamedEntity=Yes
 14	O'	o'	PART	Pat	PartType=Pat	13	flat:name	_	NamedEntity=Yes
-15	Donnell	Donnell	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+15	Donnell	Donnell	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 416
 # text = Dá bhfeicfeá Teaim Rua is é ag séideadh na luatha Is na sáspain ag éirí ins na spéartha; An mule ar an mbruach ag croitheadh a chuid cluasa Ag faire ag dul chuig an bhféasta.
 1	Dá	dá	SCONJ	Subord	_	2	mark	_	_
 2	bhfeicfeá	feic	VERB	VTI	Form=Ecl|Mood=Cnd|Number=Sing|Person=2	21	advcl	_	_
-3	Teaim	Teaim	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
+3	Teaim	Teaim	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 4	Rua	Rua	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	is	agus	CCONJ	Coord	_	6	mark	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	advcl	_	_
@@ -10457,11 +10457,11 @@
 21	mule	mule	X	Foreign	Foreign=Yes	0	root	_	_
 22	ar	ar	ADP	Simp	_	24	case	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	mbruach	bruach	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	nmod	_	_
+24	mbruach	bruach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	21	nmod	_	_
 25	ag	ag	ADP	Simp	_	26	case	_	_
 26	croitheadh	croitheadh	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 27	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	nmod:poss	_	_
-28	chuid	cuid	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	26	obj	_	_
+28	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obj	_	_
 29	cluasa	cluas	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	28	nmod	_	_
 30	Ag	ag	ADP	Simp	_	31	case	_	_
 31	faire	faire	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
@@ -10469,7 +10469,7 @@
 33	dul	dul	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
 34	chuig	chuig	ADP	Simp	_	36	case	_	_
 35	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
-36	bhféasta	féasta	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
+36	bhféasta	féasta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	33	nmod	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	21	punct	_	_
 
 # sent_id = 417
@@ -10517,7 +10517,7 @@
 # text = Táthar á rá gurb í is ciontach le galar nua ar a dtugtar 'bréagthochtán' - tinneas a chuireann isteach ar pháistí go háirithe.
 1	Táthar	bí	VERB	PresInd	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	3	case	_	_
-3	rá	rá	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
+3	rá	rá	NOUN	Noun	Definite=Def|VerbForm=Inf	1	xcomp	_	_
 4	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	5	cop	_	_
 5	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	3	ccomp	_	_
 6	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	7	cop	_	_
@@ -10553,7 +10553,7 @@
 7	geal	geal	ADJ	Adj	Degree=Pos	5	advmod	_	_
 8	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	obl:prep	_	_
 9	i	i	ADP	Simp	_	10	case	_	_
-10	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	_
+10	nGaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	_
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
 12	scrúdú	scrúdú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 13	meánteistiméireachta	meánteistiméireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
@@ -10565,7 +10565,7 @@
 19	céad	céad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
 20	des	de	ADP	Simp	Dialect=Munster	22	case	_	_
 21	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	22	det	_	_
-22	focail	focal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	19	nsubj	_	_
+22	focail	focal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	19	nsubj	_	_
 23	crua	crua	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Plur	22	amod	_	_
 24	sa	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
 25	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	_
@@ -10579,7 +10579,7 @@
 33	,	,	PUNCT	Punct	_	35	punct	_	_
 34	le	le	ADP	Simp	_	35	case	_	_
 35	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	obl	_	_
-36	Dé	Dia	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
+36	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 421
@@ -10608,20 +10608,20 @@
 # sent_id = 422
 # text = 'Amaquatl,' arsa Xatlacan agus, ag baint a láimhe ó ghualainn Phóil, shiúil sé chuige.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Amaquatl	Amaquatl	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
+2	Amaquatl	Amaquatl	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 4	'	'	PUNCT	Punct	_	2	punct	_	_
 5	arsa	arsa	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
-6	Xatlacan	Xatlacan	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
+6	Xatlacan	Xatlacan	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	agus	agus	SCONJ	Subord	_	10	mark	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	7	punct	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	baint	baint	NOUN	Noun	VerbForm=Vnoun	5	xcomp	_	_
 11	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	nmod:poss	_	_
-12	láimhe	lámh	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	obj	_	_
+12	láimhe	lámh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	obj	_	_
 13	ó	ó	ADP	Simp	_	14	case	_	_
 14	ghualainn	gualainn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
-15	Phóil	Pól	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	14	nmod	_	SpaceAfter=No
+15	Phóil	Pól	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	14	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	shiúil	siúil	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	advcl	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
@@ -10632,9 +10632,9 @@
 # text = Síleann na húdaráis i gCambridge go mbeidh an lámh in uachtar acu feasta ar mhic léinn a thugann aistí réamhullmhaithe leo go dtí na scrúduithe.
 1	Síleann	síl	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
 2	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	húdaráis	údarás	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	1	nsubj	_	_
+3	húdaráis	údarás	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	1	nsubj	_	_
 4	i	i	ADP	Simp	_	5	case	_	_
-5	gCambridge	Cambridge	PROPN	Noun	Case=Gen|Form=Ecl|Gender=Masc|Number=Plur	3	nmod	_	_
+5	gCambridge	Cambridge	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	3	nmod	_	_
 6	go	go	PART	Vb	PartType=Cmpl	7	mark:prt	_	_
 7	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	1	ccomp	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
@@ -10669,7 +10669,7 @@
 # text = As a phóca flaithiúil féin a tháinig an t-airgead a choinnigh ag imeacht iad.
 1	As	as	ADP	Simp	_	3	case	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
-3	phóca	póca	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+3	phóca	póca	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 4	flaithiúil	flaithiúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	féin	féin	PRON	Ref	Reflex=Yes	3	nmod	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	mark:prt	_	_
@@ -10702,7 +10702,7 @@
 15	féachaint	féachaint	NOUN	Noun	VerbForm=Vnoun	11	xcomp	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	mbean	bean	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
+18	mbean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	a	a	PART	Vb	PartType=Vb|PronType=Rel	21	obl	_	_
 21	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	18	acl:relcl	_	_
@@ -10774,7 +10774,7 @@
 36	suas	suas	ADV	Dir	_	34	advmod	_	_
 37	ar	ar	ADP	Simp	_	39	case	_	_
 38	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	39	det	_	_
-39	gcrann	crann	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	34	obl	_	SpaceAfter=No
+39	gcrann	crann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	34	obl	_	SpaceAfter=No
 40	,	,	PUNCT	Punct	_	31	punct	_	_
 41	'	'	PUNCT	Punct	_	42	punct	_	SpaceAfter=No
 42	adeir	abair	VERB	PresInd	Mood=Ind|Tense=Pres	7	parataxis	_	_
@@ -10808,7 +10808,7 @@
 # text = 'M'anam gur dócha go raibh an ceart ag an maor,' a deir Micil, 'ach ceart nó mícheart é, ní gheobhaidh an fear sin aon phunt uaimse níos mó.
 1	'	'	PUNCT	Punct	_	5	punct	_	SpaceAfter=No
 2	M'	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	3	nmod:poss	_	SpaceAfter=No
-3	anam	anam	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
+3	anam	anam	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 4	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	5	cop	_	_
 5	dócha	dócha	ADJ	Adj	Degree=Pos	16	ccomp	_	_
 6	go	go	PART	Vb	PartType=Cmpl	7	mark:prt	_	_
@@ -10822,7 +10822,7 @@
 14	'	'	PUNCT	Punct	_	5	punct	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
 16	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-17	Micil	Micil	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
+17	Micil	Micil	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	20	punct	_	_
 19	'	'	PUNCT	Punct	_	20	punct	_	SpaceAfter=No
 20	ach	ach	SCONJ	Subord	_	21	mark	_	_
@@ -10881,7 +10881,7 @@
 34	;	;	PUNCT	Punct	_	37	punct	_	_
 35	-	-	PUNCT	Punct	_	37	punct	_	_
 36	gach	gach	DET	Det	Definite=Def	37	det	_	_
-37	saghas	saghas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	obj	_	_
+37	saghas	saghas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	45	obj	_	_
 38	sócmhainní	sócmhainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	37	nmod	_	_
 39	airgid	airgead	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	38	nmod	_	_
 40	eachtraigh	eachtrach	ADJ	Adj	Case=Gen|Gender=Masc|Number=Sing	39	amod	_	_
@@ -10909,7 +10909,7 @@
 62	urrúis	urrús	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	54	obj	_	_
 63	agus	agus	CCONJ	Coord	_	65	cc	_	_
 64	gach	gach	DET	Det	Definite=Def	65	det	_	_
-65	sócmhainn	sócmhainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	62	conj	_	_
+65	sócmhainn	sócmhainn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	62	conj	_	_
 66	eile	eile	DET	Det	PronType=Dem	65	det	_	_
 67	in	i	ADP	Simp	_	68	case	_	_
 68	airgeadra	airgeadra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	62	nmod	_	_
@@ -10934,7 +10934,7 @@
 87	dá	dá	PART	Rel	PronType=Rel	88	obj	_	_
 88	dtagraítear	tagair	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	86	acl:relcl	_	_
 89	san	i	ADP	Art	Number=Sing|PronType=Art	90	case	_	_
-90	Airteagal	airteagal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	88	obl	_	_
+90	Airteagal	airteagal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	88	obl	_	_
 91	seo	seo	DET	Det	PronType=Dem	90	det	_	_
 92	a	a	PART	Inf	PartType=Inf	93	mark	_	_
 93	shealbhú	sealbhú	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	_
@@ -10944,7 +10944,7 @@
 97	;	;	PUNCT	Punct	_	104	punct	_	_
 98	-	-	PUNCT	Punct	_	104	punct	_	_
 99	gach	gach	DET	Det	Definite=Def	100	det	_	_
-100	saghas	saghas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	104	obj	_	_
+100	saghas	saghas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	104	obj	_	_
 101	idirbheart	idirbheart	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	100	nmod	_	_
 102	baincéireachta	baincéireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	101	nmod	_	_
 103	a	a	PART	Inf	PartType=Inf	104	mark	_	_
@@ -10975,22 +10975,22 @@
 1	Tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 2	Bealach	bealach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 3	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
-4	Choin	Choin	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
-5	Ghlais	Glais	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes|SpaceAfter=No
+4	Choin	Choin	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
+5	Ghlais	glas	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	4	amod	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	8	punct	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	caolas	caolas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 9	idir	idir	ADP	Simp	_	10	case	_	_
-10	Lunga	Lunga	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
+10	Lunga	Lunga	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
-12	Sgarba	Sgarba	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	_
+12	Sgarba	Sgarba	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	dul	dul	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 15	thart	thart	ADV	Dir	_	14	advmod	_	_
 16	le	le	ADP	Simp	_	17	case	_	_
-17	Eilean	Eilean	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
+17	Eilean	Eilean	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
 18	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	NamedEntity=Yes
-19	Bhealaich	Bhealaich	PROPN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+19	Bhealaich	Bhealaich	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 20	chomh	chomh	ADV	Its	_	21	advmod	_	_
 21	contúirteach	contúirteach	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 22	le	le	ADP	Simp	_	23	case	_	_
@@ -10998,18 +10998,18 @@
 24	Bhreacháin	bhreachán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	23	acl:relcl	_	_
 26	idir	idir	ADP	Simp	_	27	case	_	_
-27	Sgarba	Sgarba	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	xcomp:pred	_	_
+27	Sgarba	Sgarba	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	xcomp:pred	_	_
 28	agus	agus	CCONJ	Coord	_	29	cc	_	_
-29	Eilean	Eilean	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	conj	_	NamedEntity=Yes
-30	Diùra	Diùra	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
+29	Eilean	Eilean	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	27	conj	_	NamedEntity=Yes
+30	Diùra	Diùra	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
 32	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	23	appos	_	_
 33	a	a	PART	Vb	PartType=Vb|PronType=Rel	34	obl	_	_
 34	raibh	bí	VERB	VI	Mood=Ind|Tense=Past	32	acl:relcl	_	_
 35	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
-36	sgríobhnóir	sgríobhnóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	nsubj	_	_
-37	George	George	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	36	appos	_	NamedEntity=Yes
-38	Orwell	Orwell	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
+36	sgríobhnóir	sgríobhnóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	34	nsubj	_	_
+37	George	George	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	36	appos	_	NamedEntity=Yes
+38	Orwell	Orwell	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
 39	fá	faoi	ADP	Simp	Dialect=Ulster|Gender=Masc|Number=Sing|Person=3	34	xcomp:pred	_	_
 40	aon	aon	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	42	obj	_	_
 41	do	do	PART	Inf	PartType=Inf	42	mark	_	_
@@ -11020,7 +11020,7 @@
 # sent_id = 431
 # text = 'BEITSÍN: Mura bhfuil ocras ort anois, beidh ar ball, mar ar an tsaol seo tagann chuile shórt ocraisí ar na daoine.
 1	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
-2	BEITSÍN	Beitsín	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
+2	BEITSÍN	Beitsín	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 3	:	:	PUNCT	Punct	_	2	punct	_	_
 4	Mura	mura	SCONJ	Subord	_	5	mark	_	_
 5	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	10	advcl	_	_
@@ -11074,18 +11074,18 @@
 13	dáimh	dáimh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	conj	_	_
 14	ag	ag	ADP	Simp	_	16	case	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	Éirinn	Éire	PROPN	Noun	Case=Dat|Gender=Fem|Number=Sing	10	obl	_	_
+16	Éirinn	Éire	PROPN	Noun	Case=Dat|Definite=Def|Gender=Fem|Number=Sing	10	obl	_	_
 17	sin	sin	DET	Det	PronType=Dem	16	det	_	_
 18	le	le	ADP	Simp	_	19	case	_	_
-19	hÉire	Éire	PROPN	Noun	Case=NomAcc|Form=HPref|Gender=Fem|Number=Sing	10	obl	_	_
-20	Bhriain	Brian	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
+19	hÉire	Éire	PROPN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	10	obl	_	_
+20	Bhriain	Brian	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
 21	is	agus	CCONJ	Coord	_	22	cc	_	_
-22	Chormaic	Cormac	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	20	conj	_	SpaceAfter=No
+22	Chormaic	Cormac	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	20	conj	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
-24	Éire	Éire	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	appos	_	_
-25	Choinn	Conn	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc	24	nmod	_	NamedEntity=Yes
+24	Éire	Éire	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	19	appos	_	_
+25	Choinn	Conn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	24	nmod	_	NamedEntity=Yes
 26	Uí	uí	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
-27	Néill	Néill	PROPN	Noun	Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+27	Néill	Néill	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	?	?	PUNCT	?	_	6	punct	_	_
 
 # sent_id = 434
@@ -11102,21 +11102,21 @@
 # text = Suirbhéireacht Ordanáis Éireann, Rehab Group, Irish Shell, Sportsfile, Tesco Ireland agus The Yard.
 1	Suirbhéireacht	suirbhéireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	NamedEntity=Yes
 2	Ordanáis	ordanás	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-3	Éireann	Éire	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
+3	Éireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
-5	Rehab	Rehab	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
-6	Group	Group	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+5	Rehab	Rehab	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+6	Group	Group	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
-8	Irish	Irish	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
-9	Shell	Shell	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+8	Irish	Irish	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
+9	Shell	Shell	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
-11	Sportsfile	Sportsfile	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	SpaceAfter=No
+11	Sportsfile	Sportsfile	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
-13	Tesco	Tesco	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
-14	Ireland	Ireland	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	flat:foreign	_	NamedEntity=Yes
+13	Tesco	Tesco	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	NamedEntity=Yes
+14	Ireland	Ireland	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	flat:foreign	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	17	cc	_	_
 16	The	the	DET	Foreign	Foreign=Yes	6	conj	_	NamedEntity=Yes
-17	Yard	Yard	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+17	Yard	Yard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 436
@@ -11154,7 +11154,7 @@
 5	t-aon	aon	DET	Det	_	6	det	_	_
 6	scéal	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nsubj	_	_
 7	sa	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	_
+8	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	inar	i	PART	Rel	PronType=Rel	10	obl	_	_
 10	éirigh	éirigh	VERB	PastInd	Mood=Ind|Tense=Past	6	acl:relcl	_	_
 11	le	le	ADP	Simp	_	12	case	_	_
@@ -11170,13 +11170,13 @@
 5	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	8	cop	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nmod	_	_
 7	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	8	nmod:poss	_	_
-8	thuairimse	tuairim	NOUN	Noun	Case=NomAcc|Form=Emp,Len|Gender=Fem|Number=Sing	3	ccomp	_	_
+8	thuairimse	tuairim	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Emp,Len|Gender=Fem|Number=Sing	3	ccomp	_	_
 9	leis	le	ADP	Simp	_	10	case	_	_
 10	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nmod	_	_
 11	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	12	cop	_	_
 12	bréaga	bréag	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	8	csubj:cop	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	det	_	_
-14	leath	leath	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	nmod	_	_
+14	leath	leath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	_
 15	dá	dá	PART	Rel	PronType=Rel	16	nsubj	_	_
 16	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	12	acl:relcl	_	_
 17	foghlamtha	foghlamtha	ADJ	Adj	VerbForm=Part	16	xcomp:pred	_	_
@@ -11187,7 +11187,7 @@
 # text = Is mise Briain.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 2	mise	mé	PRON	Pers	Number=Sing|Person=1|PronType=Emp	0	root	_	_
-3	Briain	Briain	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
+3	Briain	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 441
@@ -11195,7 +11195,7 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Múineadh	múin	VERB	VTI	Mood=Ind|Person=0|Tense=Past	22	parataxis	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	oiread	oiread	NOUN	Subst	Number=Sing	2	nsubj	_	_
+4	oiread	oiread	NOUN	Subst	Definite=Def|Number=Sing	2	nsubj	_	_
 5	sin	sin	DET	Det	PronType=Dem	4	det	_	_
 6	rudaí	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	obj	_	_
 7	dúinn	do	ADP	Prep	Number=Plur|Person=1	2	obl:prep	_	_
@@ -11214,7 +11214,7 @@
 20	'	'	PUNCT	Punct	_	2	punct	_	_
 21	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	mark:prt	_	_
 22	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-23	Moira	Moira	PROPN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	22	nsubj	_	SpaceAfter=No
+23	Moira	Moira	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	22	nsubj	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	22	punct	_	_
 
 # sent_id = 442
@@ -11224,7 +11224,7 @@
 3	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
 4	lúide	beag	ADJ	Adj	Degree=Cmp,Sup	0	root	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	taitneamh	taitneamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nsubj	_	_
+6	taitneamh	taitneamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nsubj	_	_
 7	a	a	PART	Vb	PartType=Vb|PronType=Rel	8	obj	_	_
 8	bhaineann	bain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	6	acl:relcl	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
@@ -11232,7 +11232,7 @@
 11	as	as	ADP	Simp	_	12	case	_	_
 12	scéalta	scéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	8	obl	_	_
 13	seo	seo	DET	Det	PronType=Dem	12	det	_	_
-14	Mháire	Máire	PROPN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
+14	Mháire	Máire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	_
 15	rian	rian	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nsubj	_	_
 16	seo	seo	DET	Det	PronType=Dem	15	det	_	_
 17	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
@@ -11263,7 +11263,7 @@
 2	chuadar	téigh	VERB	PastInd	Form=Len|Mood=Ind|Number=Plur|Person=3|Tense=Past	0	root	_	_
 3	leis	le	ADP	Simp	_	5	case	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	bpolaitíocht	polaitíocht	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
+5	bpolaitíocht	polaitíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
 7	céard	céard	PRON	Q	PronType=Int	2	ccomp	_	_
 8	nár	is	AUX	Cop	Polarity=Neg|PronType=Rel|Tense=Past|VerbForm=Cop	9	cop	_	_
@@ -11287,14 +11287,14 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	praghas	praghas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	case	_	_
-5	laghdú	laghdú	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
+5	laghdú	laghdú	NOUN	Noun	Definite=Def|VerbForm=Inf	1	xcomp	_	_
 6	de	de	ADP	Simp	_	7	case	_	_
-7	Euro	Euro	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
+7	Euro	euro	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 8	1,400	1,400	NUM	Num	_	7	nummod	_	_
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Nissan	Nissan	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
-12	Tino	Tino	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
+11	Nissan	Nissan	X	Foreign	Foreign=Yes	5	obl	_	NamedEntity=Yes
+12	Tino	Tino	X	Foreign	Foreign=Yes	11	flat:foreign	_	NamedEntity=Yes
 13	don	do	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
 14	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	11	nmod	_	_
 15	seo	seo	DET	Det	PronType=Dem	14	det	_	_
@@ -11305,7 +11305,7 @@
 20	díol	díol	NOUN	Noun	VerbForm=Inf	18	xcomp:pred	_	_
 21	anois	anois	ADV	Gn	_	20	advmod	_	_
 22	ar	ar	ADP	Simp	_	23	case	_	_
-23	Euro	Euro	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	obl	_	_
+23	Euro	Euro	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 24	22,470	22,470	NUM	Num	_	23	nummod	_	_
 25	(	(	PUNCT	Punct	_	26	punct	_	SpaceAfter=No
 26	IRP17,659	IRP17,659	NUM	Num	_	24	nmod	_	SpaceAfter=No
@@ -11320,7 +11320,7 @@
 4	bhialann	bialann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	nmod	_	_
 5	2.00-6.00	2.00-6.00	NUM	Num	_	4	nmod	_	_
 6	in	i	ADP	Simp	_	7	case	_	_
-7	BRICRIÚ	BRICRIÚ	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
+7	BRICRIÚ	Bricriú	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	SpaceAfter=No
 8	:	:	PUNCT	Punct	_	9	punct	_	_
 9	Beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	1	parataxis	_	_
 10	mé	mé	PRON	Pers	Number=Sing|Person=1	9	nsubj	_	_
@@ -11363,12 +11363,12 @@
 
 # sent_id = 449
 # text = Tuairisc ar limistéir thuaithe cháilitheacha Shligigh.
-1	Tuairisc	Tuairisc	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
+1	Tuairisc	tuairisc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	ar	ar	ADP	Simp	_	3	case	_	_
 3	limistéir	limistéar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	nmod	_	_
 4	thuaithe	tuath	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 5	cháilitheacha	cáilitheach	ADJ	Adj	Case=NomAcc|Form=Len|NounType=Slender|Number=Plur	4	amod	_	_
-6	Shligigh	Sligeach	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	SpaceAfter=No
+6	Shligigh	Sligeach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 450
@@ -11378,7 +11378,7 @@
 3	thug	tabhair	VERB	VD	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 4	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	3	nsubj	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
-6	Mháire	Máire	PROPN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
+6	Mháire	Máire	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
 7	?	?	PUNCT	?	_	3	punct	_	_
 
 # sent_id = 451
@@ -11389,7 +11389,7 @@
 4	scriosfaidh	scrios	VERB	VTI	Mood=Ind|Tense=Fut	1	conj	_	_
 5	tú	tú	PRON	Pers	Number=Sing|Person=2	4	nsubj	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	aiste	aiste	NOUN	Subst	Gender=Fem|Number=Sing	1	obj	_	_
+7	aiste	aiste	NOUN	Subst	Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
 9	botúin	botún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obl	_	_
 10	mar	mar	ADP	Simp	_	11	case	_	_
@@ -11401,8 +11401,8 @@
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
 2	oiread	oiread	NOUN	Subst	Number=Sing	6	advcl	_	_
 3	le	le	ADP	Simp	_	4	case	_	_
-4	Jurassic	Jurassic	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
-5	Park	Park	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
+4	Jurassic	Jurassic	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
+5	Park	Park	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 7	bunchlocha	bunchloch	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
@@ -11419,7 +11419,7 @@
 4	réadúil	réadúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	do	do	ADP	Simp	_	6	case	_	_
 6	ghníomhaíochtaí	gníomhaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	3	nmod	_	_
-7	Phípí	Phípí	PROPN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	_
+7	Phípí	Pípí	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
 9	phríomhchathair	príomhchathair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 10	ó	ó	ADP	Simp	_	11	case	_	_
@@ -11430,13 +11430,13 @@
 15	nach	nach	PART	Vb	PartType=Vb|Polarity=Neg|PronType=Rel	16	obj	_	_
 16	bhfacthas	feic	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Past	12	acl:relcl	_	_
 17	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
-18	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	obj	_	_
+18	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	obj	_	_
 19	go	go	ADP	Cmpd	PrepForm=Cmpd	21	case	_	_
 20	dtí	dtí	ADP	Cmpd	Form=Ecl	19	fixed	_	_
 21	seo	seo	PRON	Dem	PronType=Dem	16	obl	_	_
 22	in	i	ADP	Simp	_	23	case	_	_
 23	úrscéal	úrscéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obl	_	_
-24	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
+24	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 454
@@ -11445,15 +11445,15 @@
 2	fosta	fosta	ADV	Gn	_	1	advmod	_	_
 3	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	obj	_	_
 4	san	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	eachtra	eachtra	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl	_	_
+5	eachtra	eachtra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 6	ina	i	PART	Rel	PronType=Rel	7	obl	_	_
 7	mbuaileann	buail	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Pres	5	acl:relcl	_	_
 8	Babaí	babaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	Dálach	dálach	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	7	obj	_	_
+10	Dálach	Dálach	PROPN	Subst	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 11	trasna	trasna	PART	Inf	PartType=Inf	13	case	_	_
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	pluice	pluc	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	obl	_	_
+13	pluice	pluc	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
 14	(	(	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
 15	46-54	46-54	NUM	Num	_	13	nmod	_	SpaceAfter=No
 16	)	)	PUNCT	Punct	_	15	punct	_	SpaceAfter=No


### PR DESCRIPTION
This fixes issue #43. The script is complicated but basically implements the various rules in the Christian Brothers' grammar for definiteness. Cases where the script had problems were all caused by incorrect dependencies which I fixed manually; this will be a nice trick for finding subtle attachment errors in NPs. More on that when I resolve #52!