### PR TITLE
Add Case features across the treebank

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -5092,7 +5092,7 @@
 23	dhúisigh	dúisigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	20	ccomp	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
 25	t-uisce	uisce	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	_
-26	láithreach	láithreach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	advmod	_	_
+26	láithreach	láithreach	ADV	_	_	23	advmod	_	_
 27	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	23	obj	_	_
 28	agus	agus	CCONJ	Coord	_	30	cc	_	_
 29	go	go	PART	Vb	PartType=Cmpl	30	mark:prt	_	_
@@ -10206,7 +10206,7 @@
 2	rith	rith	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 3	Pinocchio	Pinocchio	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	chuige	chuig	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
-5	láithreach	láithreach	ADV	Dir	Degree=Pos	2	advmod	_	_
+5	láithreach	láithreach	ADV	_	Degree=Pos	2	advmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	mark	_	_
 7	siúd	siúd	PRON	Dem	PronType=Dem	9	nsubj	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -1,7 +1,7 @@
 # sent_id = 455
 # text = Na Dúshláin don Leanbh Cad é mar atá an cur chuige cumarsáideach seo sa Ghaelscoil i dtaca leis an leanbh ó thaobh na Gaeilge de?
 1	Na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	2	det	_	_
-2	Dúshláin	dúshlán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
+2	Dúshláin	dúshlán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
 3	don	do	ADP	Art	Number=Sing|PronType=Art	4	case	_	_
 4	Leanbh	leanbh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	Cad	cad	PRON	Q	PronType=Int	2	parataxis	_	_
@@ -14,9 +14,9 @@
 12	cumarsáideach	cumarsáideach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	10	amod	_	_
 13	seo	seo	DET	Det	PronType=Dem	10	det	_	_
 14	sa	i	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	Ghaelscoil	Gaelscoil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	8	obl	_	_
+15	Ghaelscoil	Gaelscoil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	8	obl	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	dtaca	taca	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
+17	dtaca	taca	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	8	obl	_	_
 18	leis	le	ADP	Simp	_	20	case	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	leanbh	leanbh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	_
@@ -108,7 +108,7 @@
 # sent_id = 460
 # text = Ach beo bocht a bheadh ar an té nach mbeadh aige ach preátaí tura.
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
-2	beo	beo	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+2	beo	beo	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	bocht	bocht	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	mark:prt	_	_
 5	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	2	csubj:cleft	_	_
@@ -130,7 +130,7 @@
 3	Bryan	Bryan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	McFadden	McFadden	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 5	ón	ó	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	bPopghrúpa	popghrúpa	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	nmod	_	_
+6	bPopghrúpa	popghrúpa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	nmod	_	_
 7	'	'	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
 8	Westlife	Westlife	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
 9	'	'	PUNCT	Punct	_	8	punct	_	_
@@ -138,13 +138,13 @@
 11	Kerry	Kerry	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
 12	Katona	Katona	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	cailín	cailín	NOUN	Noun	Gender=Masc|Number=Sing	11	appos	_	_
+14	cailín	cailín	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	appos	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
 16	bhíodh	bí	VERB	VI	Aspect=Imp|Form=Len|Tense=Past	14	acl:relcl	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
-18	amhranaí	amhránaí	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
+18	amhranaí	amhránaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	16	obl	_	_
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	ghrúpa	grúpa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
+20	ghrúpa	grúpa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
 22	Atomic	Atomic	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat	_	_
 23	Kitten	Kitten	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	flat:foreign	_	SpaceAfter=No
@@ -177,7 +177,7 @@
 4	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	1	advcl	_	_
 5	cóirithe	cóirithe	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	_
 6	fé	faoi	ADP	Simp	_	7	case	_	_
-7	bhrat	brat	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
+7	bhrat	brat	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 8	buí	buí	ADJ	Adj	Gender=Masc|Number=Sing	7	amod	_	_
 9	síoda	síoda	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
@@ -225,7 +225,7 @@
 5	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 6	as	as	ADP	Simp	_	8	case	_	_
 7	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
-8	huimhreacha	uimhir	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Plur	5	obl	_	_
+8	huimhreacha	uimhir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Plur	5	obl	_	_
 9	4-15	4-15	NUM	Num	_	8	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -258,7 +258,7 @@
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 5	an-tóir	an-tóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	nsubj	_	_
 6	go	go	ADP	Simp	_	4	advmod	_	_
-7	deo	deo	NOUN	Subst	Number=Sing	6	fixed	_	_
+7	deo	deo	NOUN	Subst	Case=NomAcc|Number=Sing	6	fixed	_	_
 8	acu	ag	ADP	Prep	Number=Plur|Person=3	4	obl:prep	_	_
 9	orthu	ar	ADP	Prep	Number=Plur|Person=3	4	obl:prep	_	_
 10	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
@@ -268,7 +268,7 @@
 14	ach	ach	SCONJ	Subord	_	17	mark	_	_
 15	níorbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	17	cop	_	_
 16	aon	aon	DET	Det	PronType=Ind	17	det	_	_
-17	iontas	iontas	NOUN	Noun	Gender=Masc|Number=Sing	4	advcl	_	_
+17	iontas	iontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	advcl	_	_
 18	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
 19	sin	sin	PRON	Dem	PronType=Dem	18	det	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
@@ -276,7 +276,7 @@
 22	an-tóir	an-tóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	nsubj	_	_
 23	ag	ag	ADP	Simp	_	25	case	_	_
 24	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	25	det	_	_
-25	Francaigh	Francach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	21	obl	_	_
+25	Francaigh	Francach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	21	obl	_	_
 26	ar	ar	ADP	Simp	_	28	case	_	_
 27	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	28	det	_	_
 28	shórt	sórt	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
@@ -286,10 +286,10 @@
 32	lathaí	lathach	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	31	compound	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_
 34	ar	ar	ADP	Simp	_	35	case	_	_
-35	phortáin	portán	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	31	conj	_	_
+35	phortáin	portán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	31	conj	_	_
 36	agus	agus	CCONJ	Coord	_	38	cc	_	_
 37	ar	ar	ADP	Simp	_	38	case	_	_
-38	ghailléisc	gailliasc	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	31	conj	_	_
+38	ghailléisc	gailliasc	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	31	conj	_	_
 39	bhréana	bréan	ADJ	Adj	Form=Len|NounType=Slender|Number=Plur	38	amod	_	SpaceAfter=No
 40	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -314,7 +314,7 @@
 # text = Cur amú óige na cruinne a bhí sa dá chogadh dhomhanda a d'fhág a lorg fuilteach ar na mílte a chuaigh chun troda i bpáirceanna an áir san Eoraip agus níos mó faide ón bhaile.
 1	Cur	cur	NOUN	Noun	Definite=Def|VerbForm=Inf	0	root	_	_
 2	amú	amú	ADV	Gn	_	1	advmod	_	_
-3	óige	óige	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
+3	óige	óige	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	cruinne	cruinne	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	mark:prt	_	_
@@ -327,17 +327,17 @@
 13	d'	do	PART	Vb	PartType=Vb	14	mark:prt	_	SpaceAfter=No
 14	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	acl:relcl	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	lorg	lorg	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
+16	lorg	lorg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
 17	fuilteach	fuilteach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	16	amod	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-20	mílte	míle	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	14	obl	_	_
+20	mílte	míle	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	14	obl	_	_
 21	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	nsubj	_	_
 22	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
 23	chun	chun	ADP	Simp	_	24	case	_	_
 24	troda	troid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	22	obl	_	_
 25	i	i	ADP	Simp	_	26	case	_	_
-26	bpáirceanna	páirc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	24	nmod	_	_
+26	bpáirceanna	páirc	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	24	nmod	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	áir	ár	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
@@ -347,13 +347,13 @@
 33	mó	mór	ADJ	Adj	Degree=Cmp,Sup	34	amod	_	_
 34	faide	fada	ADJ	Adj	Degree=Cmp,Sup	36	amod	_	_
 35	ón	ó	ADP	Art	Number=Sing|PronType=Art	36	case	_	_
-36	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	conj	_	SpaceAfter=No
+36	bhaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	conj	_	SpaceAfter=No
 37	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 471
 # text = 'Díospoireacht a dhéanamh eatarthu fhéin: 'Tá sí timpeall an chúinne ag caochadh súl ar 'Fheara Fáil' a phéinteáil Jack.
 1	'	'	PUNCT	Punct	_	4	punct	_	SpaceAfter=No
-2	Díospoireacht	díospóireacht	NOUN	Noun	Gender=Fem|Number=Sing|Typo=Yes	4	obj	_	_
+2	Díospoireacht	díospóireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing|Typo=Yes	4	obj	_	_
 3	a	a	PART	Inf	PartType=Inf	4	mark	_	_
 4	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	9	parataxis	_	_
 5	eatarthu	idir	ADP	Prep	Number=Plur|Person=3	4	obl:prep	_	_
@@ -392,7 +392,7 @@
 10	rinne	déan	VERB	PastInd	Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
-13	buaiceacha	buaic	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	10	obj	_	SpaceAfter=No
+13	buaiceacha	buaic	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	10	obj	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 473
@@ -400,12 +400,12 @@
 1	Dé	Dé	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl:tmod	_	NamedEntity=Yes
 2	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	i	i	ADP	Simp	_	4	case	_	_
-4	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
+4	gceantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 5	poist	post	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
 6	Dhoirí	Doirí	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	nmod	_	NamedEntity=Yes
 7	Beaga	beag	ADJ	Adj	NounType=NotSlender|Number=Plur	6	amod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
-9	dTír	tír	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
+9	dTír	tír	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
 10	Chonaill	Conall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
@@ -422,9 +422,9 @@
 
 # sent_id = 474
 # text = Duaisdhráma ó Oireachtas 1955 is ea Moloney.
-1	Duaisdhráma	duaisdráma	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
+1	Duaisdhráma	duaisdráma	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
 2	ó	ó	ADP	Simp	_	3	case	_	_
-3	Oireachtas	oireachtas	NOUN	Noun	Gender=Masc|Number=Sing	1	nmod	_	_
+3	Oireachtas	oireachtas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nmod	_	_
 4	1955	1955	NUM	Num	_	3	nmod	_	_
 5	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	7	cop	_	_
 6	ea	ea	PRON	Pers	Number=Sing|Person=3	7	nmod	_	_
@@ -440,46 +440,46 @@
 5	difríochtaí	difríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	2	nsubj	_	_
 6	idir	idir	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	sábh	sábh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
+8	sábh	sábh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 9	tionúir	tionúr	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
 10	agus	agus	CCONJ	Coord	_	12	cc	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	déadsábh	déadsábh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
+12	déadsábh	déadsábh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
 13	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 476
 # text = Chonaic mé fir is mná, daoine bréatha óga ag fáil bháis sa long sin, agus caitheadh na coirp isteach sa bhfarraige, beannacht Dé lena n-anamnacha, na créatúirí bochta.
 1	Chonaic	feic	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	mé	mé	PRON	Pers	Number=Sing|Person=1	1	nsubj	_	_
-3	fir	fear	NOUN	Noun	Gender=Masc|Number=Plur	1	obj	_	_
+3	fir	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obj	_	_
 4	is	agus	CCONJ	Coord	_	5	cc	_	_
-5	mná	bean	NOUN	Noun	Gender=Fem|Number=Plur	3	conj	_	SpaceAfter=No
+5	mná	bean	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	3	conj	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	3	nmod	_	_
+7	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	nmod	_	_
 8	bréatha	breá	ADJ	Adj	NounType=NotSlender|Number=Plur|Typo=Yes	7	amod	_	_
 9	óga	óg	ADJ	Adj	NounType=NotSlender|Number=Plur	7	amod	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
 11	fáil	fáil	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 12	bháis	bás	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	11	obj	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	long	long	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	11	obl	_	_
+14	long	long	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	11	obl	_	_
 15	sin	sin	DET	Det	PronType=Dem	14	det	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	agus	agus	CCONJ	Coord	_	18	cc	_	_
 18	caitheadh	caith	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-20	coirp	corp	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
+20	coirp	corp	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
 21	isteach	isteach	ADV	Dir	_	20	advmod	_	_
 22	sa	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	bhfarraige	farraige	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
+23	bhfarraige	farraige	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	18	obl	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	beannacht	beannacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	18	parataxis	_	_
 26	Dé	Dia	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	_
 27	lena	le	ADP	Poss	Number=Plur|Person=3|Poss=Yes	28	case	_	_
-28	n-anamnacha	anam	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
+28	n-anamnacha	anam	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	31	det	_	_
-31	créatúirí	créatúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	28	nmod	_	_
+31	créatúirí	créatúr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	28	nmod	_	_
 32	bochta	bocht	ADJ	Adj	NounType=NotSlender|Number=Plur	31	amod	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -538,7 +538,7 @@
 # sent_id = 479
 # text = 'Ceoltóirí na háite, Fearghas Ó hÍr, Brian Ó Mórdha, Éamann Mór, Mary Ryan as Baile Átha Cliath, Deirdre Nic Con Uisce, b'fhéidir, agus an réalta is nua agus is gile i spéir an Tuaiscirt, chan ea, ach spéir na hÉireann, mar atá, Gráinne Holland.
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Ceoltóirí	ceoltóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
+2	Ceoltóirí	ceoltóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
 3	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -566,11 +566,11 @@
 27	Uisce	Uisce	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	30	punct	_	_
 29	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	30	cop	_	SpaceAfter=No
-30	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	2	parataxis	_	SpaceAfter=No
+30	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	2	parataxis	_	SpaceAfter=No
 31	,	,	PUNCT	Punct	_	32	punct	_	_
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	réalta	réalta	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	6	conj	_	_
+34	réalta	réalta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	conj	_	_
 35	is	is	PART	Sup	PartType=Sup	36	mark:prt	_	_
 36	nua	nua	ADJ	Adj	Degree=Cmp,Sup	34	amod	_	_
 37	agus	agus	CCONJ	Coord	_	39	cc	_	_
@@ -606,7 +606,7 @@
 6	molta	molta	ADJ	Adj	Degree=Pos	3	xcomp:pred	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
 8	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
-9	stádas	stádas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
+9	stádas	stádas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
 11	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	16	punct	_	_
@@ -631,7 +631,7 @@
 8	spéisiúil	spéisiúil	ADJ	Adj	Degree=Pos	4	xcomp:pred	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	leath	leath	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
+11	leath	leath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 12	thiar	thiar	ADV	Gn	_	11	advmod	_	_
 13	de	de	ADP	Simp	_	14	case	_	_
 14	Chonamara	Conamara	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
@@ -653,7 +653,7 @@
 5	go	go	ADP	Simp	_	6	case	_	_
 6	Meiriceá	Meiriceá	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 7	ag	ag	ADP	Simp	_	8	case	_	_
-8	Foras	foras	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+8	Foras	foras	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
 10	Mara	muir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
 11	agus	agus	CCONJ	Coord	_	12	mark	_	_
@@ -661,20 +661,20 @@
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	staidéar	staidéar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	xcomp	_	_
 15	i	i	ADP	Cmpd	PrepForm=Cmpd	18	case	_	_
-16	gcuideachta	cuideachta	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	14	nmod	_	_
+16	gcuideachta	cuideachta	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	14	nmod	_	_
 17	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	18	det	_	_
-18	saineolaithe	saineolaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	16	nmod	_	_
+18	saineolaithe	saineolaí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	16	nmod	_	_
 19	a	a	PART	Vb	PartType=Vb|PronType=Rel	20	nsubj	_	_
 20	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	18	acl:relcl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	taighde	taighde	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	obj	_	_
+22	taighde	taighde	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	obj	_	_
 23	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	22	amod	_	_
 24	ar	ar	ADP	Simp	_	26	case	_	_
 25	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	26	det	_	_
-26	bradáin	bradán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	obl	_	SpaceAfter=No
+26	bradáin	bradán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	20	obl	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
 28	sna	i	ADP	Art	Number=Plur|PronType=Art	29	case	_	_
-29	hochtóidí	ochtó	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	20	obl:tmod	_	SpaceAfter=No
+29	hochtóidí	ochtó	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	20	obl:tmod	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 483
@@ -693,16 +693,16 @@
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nmod	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	líne	líne	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
+4	líne	líne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	0	root	_	_
 5	ghlas	glas	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	teorainn	teorainn	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
+8	cheantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	6	nmod	_	_
 9	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	4	csubj:cleft	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	feiceáil	feiceáil	NOUN	Noun	VerbForm=Inf	9	xcomp	_	_
 12	san	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	aerfótagraf	aerfótagraf	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
+13	aerfótagraf	aerfótagraf	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	ghabhann	gabh	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	13	acl:relcl	_	_
 16	leis	le	ADP	Simp	_	17	case	_	_
@@ -736,7 +736,7 @@
 13	sin	sin	PRON	Dem	PronType=Dem	11	obj	_	_
 14	i	i	ADP	Simp	_	16	case	_	_
 15	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	16	nmod:poss	_	_
-16	chroí	croí	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
+16	chroí	croí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 487
@@ -752,7 +752,7 @@
 
 # sent_id = 488
 # text = Amharc géar ag Dara Ó Cinnéide ó Chiarraí Thiar ar Roland Neher de chuid Chrócaigh Chill Airne i gcluiche leathcheannais an Chontae.
-1	Amharc	amharc	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Amharc	amharc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	géar	géar	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	Dara	Dara	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
@@ -770,7 +770,7 @@
 16	Chill	Cill	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	Airne	Airne	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gcluiche	cluiche	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	nmod	_	_
+19	gcluiche	cluiche	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	nmod	_	_
 20	leathcheannais	leathcheannas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	Chontae	contae	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
@@ -788,7 +788,7 @@
 1	Dúrt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 2	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 3	pé	pé	PRON	Idf	PronType=Ind	1	obj	_	_
-4	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	3	nmod	_	_
+4	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
 5	do	do	PART	Vb	PartType=Vb	6	nsubj	_	_
 6	raghadh	téigh	VERB	VTI	Mood=Cnd	3	acl:relcl	_	_
 7	á	do	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	case	_	_
@@ -818,7 +818,7 @@
 31	inniu	inniu	ADV	Temp	_	26	advmod	_	_
 32	ar	ar	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	gcuma	cuma	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	28	obl	_	_
+34	gcuma	cuma	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	28	obl	_	_
 35	chéanna	céanna	ADJ	Adj	Form=Len|Number=Sing	34	amod	_	SpaceAfter=No
 36	,	,	PUNCT	Punct	_	37	punct	_	_
 37	agus	agus	CCONJ	Coord	_	39	cc	_	_
@@ -847,21 +847,21 @@
 8	chistin	cistin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	tuilshoilse	tuilsolas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur|Typo=Yes	8	nmod	_	_
+11	tuilshoilse	tuilsolas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur|Typo=Yes	8	nmod	_	_
 12	-	-	PUNCT	Punct	_	13	punct	_	_
 13	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	áit	áit	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	13	nsubj	_	_
 16	an-bheag	an-bheag	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	13	xcomp:pred	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
-18	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	16	obl	_	_
+18	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obl	_	_
 19	agus	agus	CCONJ	Coord	_	21	cc	_	_
 20	dhá	dó	NUM	Num	Form=Len|NumType=Card	21	nummod	_	_
 21	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	6	conj	_	_
 22	eile	eile	DET	Det	PronType=Dem	15	det	_	_
 23	ag	ag	ADP	Simp	_	25	case	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
-25	chúl	cúl	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
+25	chúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 26	;	;	PUNCT	Punct	_	27	punct	_	_
 27	ise	ise	PRON	Pers	Gender=Fem|Number=Sing|Person=3|PronType=Emp	13	parataxis	_	_
 28	frámaithe	frámaithe	ADJ	Adj	VerbForm=Part	27	xcomp:pred	_	_
@@ -877,7 +877,7 @@
 # text = PATÓ: Fíordhrochspite.
 1	PATÓ	PATÓ	NOUN	Abr	Abbr=Yes	0	root	_	SpaceAfter=No
 2	:	:	PUNCT	Punct	_	3	punct	_	_
-3	Fíordhrochspite	fíordhrochspite	NOUN	Noun	Gender=Fem|Number=Sing	1	parataxis	_	SpaceAfter=No
+3	Fíordhrochspite	fíordhrochspite	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	parataxis	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 493
@@ -892,10 +892,10 @@
 # sent_id = 494
 # text = Ar gcúl, taispeántar slua ag iarraidh brú isteach.
 1	Ar	ar	ADP	Simp	_	2	case	_	_
-2	gcúl	cúl	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
+2	gcúl	cúl	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	2	punct	_	_
 4	taispeántar	taispeáin	VERB	VT	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
-5	slua	slua	NOUN	Noun	Gender=Masc|Number=Sing	4	obj	_	_
+5	slua	slua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
 7	iarraidh	iarraidh	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
 8	brú	brú	NOUN	Noun	VerbForm=Inf	7	xcomp	_	_
@@ -912,24 +912,24 @@
 6	ar	ar	ADP	Simp	_	7	case	_	_
 7	bun	bun	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	xcomp:pred	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
-9	Anglacánaigh	Anglacánach	NOUN	Noun	Gender=Masc|Number=Plur	4	obl	_	_
+9	Anglacánaigh	Anglacánach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	4	obl	_	_
 10	as	as	ADP	Simp	_	12	case	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
 12	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 13	den	de	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	domhan	domhan	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
+14	domhan	domhan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 15	:	:	PUNCT	Punct	_	16	punct	_	_
 16	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	4	parataxis	_	_
 17	breis	breis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	nsubj	_	_
 18	agus	agus	CCONJ	Coord	_	20	cc	_	_
 19	ceithre	ceathair	NUM	Num	NumType=Card	20	nummod	_	_
 20	scór	scór	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	conj	_	_
-21	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
+21	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	idir	idir	ADP	Simp	_	24	case	_	_
 24	chléir	cléir	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	16	obl	_	_
 25	agus	agus	CCONJ	Coord	_	26	cc	_	_
-26	tuath	tuath	NOUN	Noun	Gender=Fem|Number=Sing	24	conj	_	SpaceAfter=No
+26	tuath	tuath	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	conj	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	28	punct	_	_
 28	páirteach	páirteach	ADJ	Adj	Degree=Pos	16	xcomp:pred	_	_
 29	sa	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
@@ -1011,21 +1011,21 @@
 25	íoc	íoc	VERB	VTI	Mood=Ind|Tense=Past	19	ccomp	_	_
 26	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	25	nsubj	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
-28	liúntas	liúntas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	obj	_	_
+28	liúntas	liúntas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	obj	_	_
 29	míosúil	míosúil	ADJ	Adj	Gender=Masc|Number=Sing	28	amod	_	_
 30	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	case	_	_
 31	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	25	obl	_	_
 32	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	31	compound	_	_
 33	tríd	trí	ADP	Simp	_	35	case	_	_
 34	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	35	det	_	_
-35	mbanc	banc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
+35	mbanc	banc	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
 36	in	i	ADP	Simp	_	37	case	_	_
 37	áit	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	35	nmod	_	_
-38	seic	seic	NOUN	Noun	Gender=Masc|Number=Sing	40	obj	_	_
+38	seic	seic	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	40	obj	_	_
 39	a	a	PART	Inf	PartType=Inf	40	mark	_	_
 40	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	25	xcomp	_	_
 41	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	42	det	_	_
-42	mhí	mí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	40	obl:tmod	_	_
+42	mhí	mí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	40	obl:tmod	_	_
 43	i	i	ADP	Cmpd	PrepForm=Cmpd	46	case	_	_
 44	ndiaidh	ndiaidh	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	43	fixed	_	_
 45	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	46	nmod:poss	_	_
@@ -1055,7 +1055,7 @@
 8	'	'	PUNCT	Punct	_	7	punct	_	_
 9	mar	mar	ADP	Simp	_	11	case	_	_
 10	chéad	céad	NUM	Num	Form=Len|NumType=Ord	11	amod	_	_
-11	fhocal	focal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+11	fhocal	focal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 12	ag	ag	ADP	Simp	_	13	case	_	_
 13	mórán	mórán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 14	páistí	páiste	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	13	nmod	_	SpaceAfter=No
@@ -1078,11 +1078,11 @@
 13	Go	go	PART	Vb	Mood=Sub|PartType=Vb	14	mark:prt	_	_
 14	mbeimis	bí	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Plur|Person=1	7	parataxis	_	_
 15	id	i_do	ADP	Det	Number=Sing|Person=2|Poss=Yes	16	case	_	_
-16	shamhailt	samhailt	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
+16	shamhailt	samhailt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 17	gach	gach	DET	Det	Definite=Def	18	det	_	_
 18	uair	uair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	obl:tmod	_	_
 19	den	de	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
-20	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
+20	Lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	7	punct	_	_
 
 # sent_id = 502
@@ -1094,12 +1094,12 @@
 5	bráithreachas	bráithreachas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	obj	_	_
 6	briste	briste	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	idir	idir	ADP	Simp	_	8	case	_	_
-8	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	5	nmod	_	SpaceAfter=No
+8	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	5	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	13	punct	_	_
 10	agus	agus	CCONJ	Coord	_	13	cc	_	_
 11	idir	idir	ADP	Simp	_	13	case	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	conj	_	_
+13	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	conj	_	_
 14	agus	agus	CCONJ	Coord	_	20	cc	_	_
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
 16	imshaol	imshaol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	conj	_	_
@@ -1120,12 +1120,12 @@
 7	ámh	ámh	ADV	Gn	_	9	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	7	punct	_	_
 9	foilsíodh	foilsigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	0	root	_	_
-10	alt	alt	NOUN	Noun	Gender=Masc|Number=Sing	9	obj	_	_
+10	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obj	_	_
 11	taighde	taighde	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
 13	bhFrainc	Frainc	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	9	obl	_	_
 14	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	teideal	teideal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+15	teideal	teideal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	'	'	PUNCT	Punct	_	18	punct	_	SpaceAfter=No
 18	Monsieur	Monsieur	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	15	appos	_	NamedEntity=Yes
@@ -1138,7 +1138,7 @@
 1	Ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	2	advmod	_	_
 2	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
 3	aon	aon	DET	Det	PronType=Ind	4	det	_	_
-4	ghá	gá	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	ghá	gá	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	le	le	ADP	Simp	_	6	case	_	_
 6	cuireadh	cuireadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	_	_
@@ -1148,13 +1148,13 @@
 1	Déantar	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	ar	ar	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	gcaoi	caoi	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
+4	gcaoi	caoi	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	obl	_	_
 5	sin	sin	DET	Det	PronType=Dem	4	det	_	_
 6	den	de	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	fhéar	féar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
+7	fhéar	féar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	obl	_	_
 8	suaithinseach	suaithinseach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	paiste	paiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
+10	paiste	paiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 11	slán	slán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 12	i	i	ADP	Cmpd	PrepForm=Cmpd	15	case	_	_
 13	lár	lár	ADP	Cmpd	PrepForm=Cmpd	12	fixed	_	_
@@ -1168,7 +1168,7 @@
 21	slán	slán	ADJ	Adj	Degree=Pos	20	amod	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 23	'	'	PUNCT	Punct	_	24	punct	_	SpaceAfter=No
-24	abhlainn	abhlann	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
+24	abhlainn	abhlann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
 25	bheannaithe	beannaithe	ADJ	Adj	Degree=Pos|Form=Len	24	amod	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	nsubj	_	_
 27	thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	20	acl:relcl	_	_
@@ -1189,7 +1189,7 @@
 42	dtiocfar	tar	VERB	VI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	40	acl:relcl	_	_
 43	ar	ar	ADP	Simp	_	45	case	_	_
 44	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	45	det	_	_
-45	mbeatha	beatha	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	42	obl	_	_
+45	mbeatha	beatha	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	42	obl	_	_
 46	spioradálta	spioradálta	ADJ	Adj	Gender=Fem|Number=Sing	45	amod	_	_
 47	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	45	acl:relcl	_	_
 48	ionann	ionann	ADJ	Adj	Degree=Pos	47	xcomp:pred	_	_
@@ -1199,7 +1199,7 @@
 52	plúchta	plúchta	ADJ	Adj	VerbForm=Part	48	conj	_	_
 53	ag	ag	ADP	Simp	_	55	case	_	_
 54	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	55	det	_	_
-55	fiailí	fiaile	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	47	obl	_	SpaceAfter=No
+55	fiailí	fiaile	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	47	obl	_	SpaceAfter=No
 56	,	,	PUNCT	Punct	_	60	punct	_	_
 57	ar	is	AUX	Cop	Tense=Pres|VerbForm=Cop	60	cop	_	_
 58	mar	mar	ADP	Simp	_	60	case	_	_
@@ -1208,10 +1208,10 @@
 61	iad	iad	PRON	Pers	Number=Plur|Person=3	60	nsubj	_	_
 62	agus	agus	CCONJ	Coord	_	64	cc	_	_
 63	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	64	det	_	_
-64	ghné	gné	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	48	conj	_	_
+64	ghné	gné	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	48	conj	_	_
 65	aimrid	aimrid	ADJ	Adj	Gender=Fem|Number=Sing	64	amod	_	_
 66	de	de	ADP	Simp	_	67	case	_	_
-67	nádúr	nádúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	64	nmod	_	_
+67	nádúr	nádúr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	64	nmod	_	_
 68	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	69	det	_	_
 69	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	67	nmod	_	SpaceAfter=No
 70	.	.	PUNCT	.	_	1	punct	_	_
@@ -1239,13 +1239,13 @@
 19	,	,	PUNCT	Punct	_	22	punct	_	_
 20	ná	ná	CCONJ	Coord	_	22	mark	_	_
 21	le	le	ADP	Simp	_	22	case	_	_
-22	comaoineach	comaoineach	NOUN	Noun	Gender=Fem|Number=Sing	14	conj	_	_
+22	comaoineach	comaoineach	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	conj	_	_
 23	naofa	naofa	ADJ	Adj	Gender=Fem|Number=Sing	22	amod	_	SpaceAfter=No
 24	;	;	PUNCT	Punct	_	25	punct	_	_
 25	agus	agus	CCONJ	Coord	_	26	cc	_	_
 26	tugann	tabhair	VERB	VTI	Mood=Ind|Tense=Pres	10	conj	_	_
 27	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	26	nsubj	_	_
-28	peaca	peaca	NOUN	Noun	Gender=Masc|Number=Sing	26	obj	_	_
+28	peaca	peaca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	26	obj	_	_
 29	ar	ar	ADP	Simp	_	31	case	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	dán	dán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
@@ -1258,7 +1258,7 @@
 38	don	do	ADP	Art	Number=Sing|PronType=Art	39	case	_	_
 39	eaglais	eaglais	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	36	obl	_	_
 40	Mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	41	nmod:poss	_	_
-41	chnuasach	cnuasach	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	obj	_	_
+41	chnuasach	cnuasach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	36	obj	_	_
 42	nuapheacaí	nuapheaca	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	41	nmod	_	SpaceAfter=No
 43	,	,	PUNCT	Punct	_	44	punct	_	_
 44	Do	do	PART	Vb	PartType=Vb	45	mark:prt	_	_
@@ -1313,7 +1313,7 @@
 19	chun	chun	ADP	Simp	_	20	case	_	_
 20	teacht	teacht	NOUN	Noun	VerbForm=Inf	17	xcomp	_	_
 21	ar	ar	ADP	Simp	_	22	case	_	_
-22	réiteach	réiteach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
+22	réiteach	réiteach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 23	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
 24	faidhbe	fadhb	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	_
 25	seo	seo	DET	Det	PronType=Dem	24	det	_	SpaceAfter=No
@@ -1356,16 +1356,16 @@
 # text = Féadfar an ráiteas sin a fhorlíonadh le measúnú sonrach ar gach mór-réimse de ghníomhaíocht an Chomhphobail.
 1	Féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	ráiteas	ráiteas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
+3	ráiteas	ráiteas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	sin	sin	DET	Det	PronType=Dem	3	det	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
 6	fhorlíonadh	forlíonadh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
-8	measúnú	measúnú	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+8	measúnú	measúnú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 9	sonrach	sonrach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
 10	ar	ar	ADP	Simp	_	12	case	_	_
 11	gach	gach	DET	Det	Definite=Def	12	det	_	_
-12	mór-réimse	mór-réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
+12	mór-réimse	mór-réimse	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 13	de	de	ADP	Simp	_	14	case	_	_
 14	ghníomhaíocht	gníomhaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	nmod	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -1379,7 +1379,7 @@
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
 4	saighdeadh	saighdeadh	NOUN	Noun	VerbForm=Inf	2	conj	_	_
 5	agus	agus	CCONJ	Coord	_	6	cc	_	_
-6	argóintí	argóint	NOUN	Noun	Gender=Fem|Number=Plur	2	conj	_	_
+6	argóintí	argóint	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	2	conj	_	_
 7	acu	ag	ADP	Prep	Number=Plur|Person=3	1	obl:prep	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	12	punct	_	_
 9	ach	ach	SCONJ	Subord	_	12	mark	_	_
@@ -1390,7 +1390,7 @@
 14	crú	crú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nsubj	_	_
 15	ar	ar	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	tairne	tairne	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
+17	tairne	tairne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 18	d'	do	PART	Vb	PartType=Vb	19	mark:prt	_	SpaceAfter=No
 19	fhéadfaí	féad	VERB	VTI	Form=Len|Mood=Cnd|Person=0	12	parataxis	_	_
 20	brath	brath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obj	_	_
@@ -1405,7 +1405,7 @@
 4	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	1	fixed	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	nsubj	_	_
-7	Aire	aire	NOUN	Noun	Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
+7	Aire	aire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
 8	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	againn	ag	ADP	Prep	Number=Plur|Person=1	5	obl:prep	_	_
 10	anseo	anseo	ADV	Loc	_	5	advmod	_	_
@@ -1413,9 +1413,9 @@
 12	nGaillimh	Gaillimh	PROPN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	nsubj	_	_
 14	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	6	acl:relcl	_	_
-15	peann	peann	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
+15	peann	peann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obj	_	_
 16	le	le	ADP	Simp	_	17	case	_	_
-17	pár	pár	NOUN	Noun	Gender=Masc|Number=Sing	14	obl	_	_
+17	pár	pár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obl	_	_
 18	-	-	PUNCT	Punct	_	19	punct	_	_
 19	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	parataxis	_	NamedEntity=Yes
 20	Geoghegan-Quinn	Geoghegan-Quinn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
@@ -1479,7 +1479,7 @@
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	23	obl:tmod	_	_
 32	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	33	case	_	_
-33	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	31	nmod	_	_
+33	dhiaidh	diaidh	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Len|Number=Sing	31	nmod	_	_
 34	sin	sin	PRON	Dem	PronType=Dem	33	det	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1494,9 +1494,9 @@
 7	siamsa	siamsa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	bríomhar	bríomhar	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	7	amod	_	_
 9	ó	ó	ADP	Simp	_	10	case	_	_
-10	cheoltóirí	ceoltóir	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Plur	6	obl	_	_
+10	cheoltóirí	ceoltóir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	6	obl	_	_
 11	óga	óg	ADJ	Adj	NounType=Slender|Number=Plur	10	amod	_	_
-12	Scoil	scoil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
+12	Scoil	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
 13	Francis	Francis	PROPN	Noun	Definite=Def	12	nmod	_	NamedEntity=Yes
 14	McPeake	McPeake	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	16	cc	_	_
@@ -1510,7 +1510,7 @@
 23	mbunscoil	bunscoil	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	16	obl	_	NamedEntity=Yes
 24	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	23	flat	_	NamedEntity=Yes
 25	Reachtain	Reachtain	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	flat:name	_	NamedEntity=Yes
-26	amhrán	amhrán	NOUN	Noun	Gender=Masc|Number=Sing	16	obj	_	_
+26	amhrán	amhrán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obj	_	_
 27	breá	breá	ADJ	Adj	Gender=Masc|Number=Sing	26	amod	_	_
 28	faoi	faoi	ADP	Simp	_	29	case	_	_
 29	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	16	obl	_	_
@@ -1527,7 +1527,7 @@
 3	a	a	PART	Voc	PartType=Voc	4	case:voc	_	_
 4	mhac	mac	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	vocative	_	_
 5	go	go	ADP	Simp	_	9	advmod	_	_
-6	deo	deo	NOUN	Subst	Number=Sing	5	fixed	_	SpaceAfter=No
+6	deo	deo	NOUN	Subst	Case=NomAcc|Number=Sing	5	fixed	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	5	punct	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	mark:prt	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
@@ -1555,13 +1555,13 @@
 31	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	conj	_	_
 32	caite	caite	ADJ	Adj	VerbForm=Part	28	xcomp:pred	_	_
 33	gan	gan	ADP	Simp	_	34	case	_	_
-34	ord	ord	NOUN	Noun	Gender=Masc|Number=Sing	28	nmod	_	_
+34	ord	ord	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	28	nmod	_	_
 35	ná	ná	CCONJ	Coord	_	36	cc	_	_
 36	eagar	eagar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	conj	_	_
 37	sa	i	ADP	Art	Number=Sing|PronType=Art	38	case	_	_
 38	phuiteach	puiteach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 39	,	,	PUNCT	Punct	_	40	punct	_	_
-40	francaigh	francach	NOUN	Noun	Gender=Masc|Number=Plur	9	parataxis	_	_
+40	francaigh	francach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	9	parataxis	_	_
 41	ag	ag	ADP	Simp	_	42	case	_	_
 42	smúrthacht	smúrthacht	NOUN	Noun	VerbForm=Vnoun	40	xcomp	_	_
 43	chugam	chuig	ADP	Prep	Number=Sing|Person=1	42	obl:prep	_	_
@@ -1600,11 +1600,11 @@
 12	dhúnmharaithe	dúnmharú	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	9	conj	_	_
 13	agus	agus	CCONJ	Coord	_	15	cc	_	_
 14	de	de	ADP	Simp	_	15	case	_	_
-15	mhadraí	madra	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	9	conj	_	_
+15	mhadraí	madra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	9	conj	_	_
 16	crochta	crochta	ADJ	Adj	VerbForm=Part	15	amod	_	_
 17	agus	agus	SCONJ	Subord	_	19	mark	_	_
 18	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	19	det	_	_
-19	dhuine	duine	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	4	advcl	_	_
+19	dhuine	duine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	4	advcl	_	_
 20	ag	ag	ADP	Simp	_	21	case	_	_
 21	gáirí	gáirí	NOUN	Noun	VerbForm=Vnoun	19	xcomp	_	_
 22	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
@@ -1617,7 +1617,7 @@
 29	a	a	PART	Inf	PartType=Inf	30	mark	_	_
 30	scaoileadh	scaoileadh	NOUN	Noun	VerbForm=Inf	26	xcomp	_	_
 31	le	le	ADP	Simp	_	32	case	_	_
-32	seanghráinghunnaí	seanghráinghunna	NOUN	Noun	Gender=Masc|Number=Plur	30	nmod	_	_
+32	seanghráinghunnaí	seanghráinghunna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	30	nmod	_	_
 33	meirgeacha	meirgeach	ADJ	Adj	NounType=NotSlender|Number=Plur	32	amod	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -1641,7 +1641,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	íomhá	íomhá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	gcuimhne	cuimhne	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	_
+6	gcuimhne	cuimhne	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	2	obl	_	_
 7	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	2	obl:prep	_	_
 8	buachaill	buachaill	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
 9	beag	beag	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
@@ -1650,7 +1650,7 @@
 12	stánadh	stánadh	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	ghealach	gealach	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	obl	_	_
+15	ghealach	gealach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	12	obl	_	_
 16	úr	úr	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	15	amod	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	2	punct	_	_
 18	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
@@ -1660,12 +1660,12 @@
 22	bhfaca	feic	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	18	ccomp	_	_
 23	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	22	nsubj	_	_
 24	ach	ach	SCONJ	Subord	_	22	mark:prt	_	_
-25	leathanach	leathanach	NOUN	Noun	Gender=Masc|Number=Sing	22	obj	_	_
+25	leathanach	leathanach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	obj	_	_
 26	smálaithe	smálaithe	ADJ	Adj	VerbForm=Part	25	amod	_	_
 27	gan	gan	ADP	Simp	_	28	case	_	_
-28	bhrí	brí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	25	nmod	_	_
+28	bhrí	brí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	25	nmod	_	_
 29	gan	gan	ADP	Simp	_	30	case	_	_
-30	chiall	ciall	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
+30	chiall	ciall	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	25	nmod	_	SpaceAfter=No
 31	.	.	PUNCT	.	_	18	punct	_	_
 
 # sent_id = 521
@@ -1684,20 +1684,20 @@
 12	leo	le	ADP	Prep	Number=Plur|Person=3	11	obl:prep	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
-15	tráthnóna	tráthnóna	NOUN	Noun	Gender=Masc|Number=Sing	17	obl:tmod	_	SpaceAfter=No
+15	tráthnóna	tráthnóna	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obl:tmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	15	punct	_	_
 17	shuíodh	suigh	VERB	VTI	Aspect=Imp|Form=Len|Tense=Past	1	conj	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
 19	amuigh	amuigh	ADV	Dir	_	17	advmod	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
-21	gcearnóg	cearnóg	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	_
+21	gcearnóg	cearnóg	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
+23	bhaile	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
 25	canadh	canadh	NOUN	Noun	VerbForm=Vnoun	17	xcomp	_	_
 26	ceoil	ceol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	obj	_	_
 27	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	28	case	_	_
-28	gcuideachta	cuideachta	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
+28	gcuideachta	cuideachta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	17	obl	_	SpaceAfter=No
 29	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 522
@@ -1708,7 +1708,7 @@
 4	ag	ag	ADP	Simp	_	5	case	_	_
 5	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 6	dar	dar	ADP	Simp	_	7	case	_	_
-7	theideal	teideal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+7	theideal	teideal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 8	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
 9	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	NamedEntity=Yes
 10	Fáinne	fáinne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	appos	_	NamedEntity=Yes|SpaceAfter=No
@@ -1718,7 +1718,7 @@
 14	Irish	Irish	X	_	Foreign=Yes	1	obl	_	_
 15	Independent	Independent	X	_	Foreign=Yes	14	flat:foreign	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
-17	blianta	bliain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	1	obl:tmod	_	_
+17	blianta	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	obl:tmod	_	_
 18	1927	1927	NUM	Num	_	17	nmod	_	_
 19	agus	agus	CCONJ	Coord	_	20	cc	_	_
 20	1928	1928	NUM	Num	_	18	conj	_	SpaceAfter=No
@@ -1748,7 +1748,7 @@
 10	bán	bán	ADJ	Adj	Degree=Pos	8	conj	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	13	punct	_	_
 12	Le	le	ADP	Simp	_	13	case	_	_
-13	grá	grá	NOUN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+13	grá	grá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	_
 14	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	13	obl:prep	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	13	punct	_	_
 16	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -1758,7 +1758,7 @@
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Tugann	tabhair	VERB	PresInd	Mood=Ind|Tense=Pres	16	parataxis	_	_
 22	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	21	nsubj	_	_
-23	uachtar	uachtar	NOUN	Noun	Gender=Masc|Number=Sing	21	obj	_	_
+23	uachtar	uachtar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	obj	_	_
 24	go	go	PART	Ad	PartType=Ad	25	mark:prt	_	_
 25	flaithiúil	flaithiúil	ADJ	Adj	Degree=Pos	21	advmod	_	SpaceAfter=No
 26	,	,	PUNCT	Punct	_	28	punct	_	_
@@ -1766,7 +1766,7 @@
 28	n-ithe	ith	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	21	obl	_	_
 29	le	le	ADP	Simp	_	31	case	_	_
 30	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	31	nmod:poss	_	_
-31	thoirtín	toirtín	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	obl	_	_
+31	thoirtín	toirtín	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	28	obl	_	_
 32	úll	úll	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	31	nmod	_	SpaceAfter=No
 33	.	.	PUNCT	.	_	16	punct	_	_
 
@@ -1779,7 +1779,7 @@
 # text = D'ainneoin fíoch na filíochta idir an bheirt thug fear Ceann Tíre isteach an strainséir agus thug béile aráin rósta dó agus im tíre air a thug a bhean anall ón Chill san Cheann Deas.
 1	D'	de	ADP	Simp	_	2	case	_	SpaceAfter=No
 2	ainneoin	ainneoin	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	9	obl	_	_
-3	fíoch	fíoch	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
+3	fíoch	fíoch	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	filíochta	filíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	_
 6	idir	idir	ADP	Simp	_	8	case	_	_
@@ -1787,14 +1787,14 @@
 8	bheirt	beirt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 9	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 10	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
-11	Ceann	ceann	NOUN	Noun	Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
+11	Ceann	ceann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	Tíre	tír	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	isteach	isteach	ADV	Dir	_	9	advmod	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	strainséir	strainséir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
 17	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	9	conj	_	_
-18	béile	béile	NOUN	Noun	Gender=Masc|Number=Sing	17	obj	_	_
+18	béile	béile	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obj	_	_
 19	aráin	arán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	_
 20	rósta	rósta	ADJ	Adj	VerbForm=Part	19	amod	_	_
 21	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	17	obl:prep	_	_
@@ -1826,7 +1826,7 @@
 8	ar	ar	ADP	Simp	_	11	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 10	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	11	amod	_	_
-11	leathanach	leathanach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+11	leathanach	leathanach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 12	:	:	PUNCT	Punct	_	14	punct	_	_
 13	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	14	cop	_	_
 14	óg	óg	ADJ	Adj	Degree=Pos	1	parataxis	_	_
@@ -1840,7 +1840,7 @@
 22	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	obj	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	25	punct	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
-25	ród	ród	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	appos	_	_
+25	ród	ród	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	appos	_	_
 26	sin	sin	DET	Det	PronType=Dem	25	det	_	_
 27	a	a	PART	Vb	PartType=Vb|PronType=Rel	28	nsubj	_	_
 28	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	25	acl:relcl	_	_
@@ -1855,7 +1855,7 @@
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
 3	Fhoireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	nsubj	_	NamedEntity=Yes
 4	um	um	ADP	Simp	_	5	case	_	NamedEntity=Yes
-5	Fhorbairt	forbairt	NOUN	Noun	Form=Len|VerbForm=Inf	3	nmod	_	NamedEntity=Yes
+5	Fhorbairt	forbairt	NOUN	Noun	Case=NomAcc|Form=Len|VerbForm=Inf	3	nmod	_	NamedEntity=Yes
 6	Pleanála	pleanáil	NOUN	Noun	Case=Gen|VerbForm=Inf	5	nmod	_	NamedEntity=Yes
 7	Scoile	scoil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes
 8	aiseolas	aiseolas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obj	_	_
@@ -1875,12 +1875,12 @@
 # text = Ba é Oileán an Deargánaigh an chéad fhaiche phoiblí a bhí i mBéal Feirste agus b'fhada ina ionad caitheamh aimsire ag a chuid saoránach é.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	Oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	Oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	NamedEntity=Yes
 5	Deargánaigh	Deargánach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 7	chéad	céad	NUM	Num	Form=Len|NumType=Ord	8	amod	_	_
-8	fhaiche	faiche	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
+8	fhaiche	faiche	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nmod	_	_
 9	phoiblí	poiblí	ADJ	Adj	Degree=Pos|Form=Len	8	amod	_	_
 10	a	a	PART	Vb	PartType=Vb|PronType=Rel	11	mark:prt	_	_
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
@@ -1910,7 +1910,7 @@
 5	clocha	cloch	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	obl	_	_
 6	is	agus	CCONJ	Coord	_	8	cc	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
-8	stumpaí	stumpa	NOUN	Noun	Gender=Masc|Number=Plur	5	conj	_	_
+8	stumpaí	stumpa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	5	conj	_	_
 9	adhmaid	adhmad	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -1932,7 +1932,7 @@
 4	cuid	cuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obj	_	_
 5	de	de	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
-7	plaistigh	plaisteach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	4	nmod	_	_
+7	plaistigh	plaisteach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	4	nmod	_	_
 8	faoi	faoi	ADP	Simp	_	9	case	_	_
 9	sholas	solas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
 10	díreach	díreach	ADJ	Adj	Gender=Masc|Number=Sing	9	amod	_	_
@@ -1958,7 +1958,7 @@
 3	Pluincéadach	Pluincéadach	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	tar	tar	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 5	éis	éis	ADP	Cmpd	PrepForm=Cmpd	4	fixed	_	_
-6	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	8	obj	_	_
+6	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	8	obj	_	_
 7	a	a	PART	Inf	PartType=Inf	8	mark	_	_
 8	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 9	amach	amach	ADV	Dir	_	8	advmod	_	_
@@ -1975,15 +1975,15 @@
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 22	de	de	ADP	Simp	_	23	case	_	_
-23	dhánaíocht	dánaíocht	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	21	xcomp:pred	_	_
+23	dhánaíocht	dánaíocht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	21	xcomp:pred	_	_
 24	san	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	fhear	fear	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
+25	fhear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
 26	chéanna	céanna	ADJ	Adj	Degree=Pos|Form=Len	25	amod	_	_
 27	sin	sin	DET	Det	PronType=Dem	25	det	_	_
 28	a	a	PART	Inf	PartType=Inf	29	mark	_	_
 29	rá	rá	NOUN	Noun	VerbForm=Inf	21	xcomp	_	_
 30	gurbh	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	31	cop	_	_
-31	easpag	easpag	NOUN	Noun	Gender=Masc|Number=Sing	29	ccomp	_	_
+31	easpag	easpag	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	ccomp	_	_
 32	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	31	nsubj	_	_
 33	ar	ar	ADP	Simp	_	35	case	_	_
 34	aon	aon	DET	Det	PronType=Ind	35	det	_	_
@@ -1994,7 +1994,7 @@
 39	-	-	PUNCT	Punct	_	42	punct	_	_
 40	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	42	cop	_	_
 41	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	42	nmod	_	_
-42	Easpag	easpag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	31	parataxis	_	_
+42	Easpag	easpag	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	parataxis	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	fhíona	fíon	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	42	nmod	_	_
 45	is	agus	CCONJ	Coord	_	47	cc	_	_
@@ -2011,10 +2011,10 @@
 3	scoil	scoil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nsubj	_	_
 4	éisc	iasc	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	faoi	faoi	ADP	Simp	_	6	case	_	_
-6	lán	lán	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+6	lán	lán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 7	siúil	siúl	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	uisce	uisce	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
+9	uisce	uisce	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 10	agus	agus	SCONJ	Subord	_	12	mark	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
 12	t-iascaire	iascaire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	advcl	_	_
@@ -2034,23 +2034,23 @@
 
 # sent_id = 535
 # text = Cothú sa Duine Tá cúig chéim i gceist le cothú sa duine: Daoibhse atá ar bheagán Shakespeare, nó daoibhse a d'fhág cúrsaí staidéir níos mó ná cúpla lá ó shin, seo é, go gonta, scéal traigéideach marfach Phrionsa na Danmhairge.
-1	Cothú	cothú	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Cothú	cothú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	sa	i	ADP	Art	Number=Sing|PronType=Art	3	case	_	_
-3	Duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
+3	Duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	_
 4	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 5	cúig	cúig	NUM	Num	NumType=Card	6	nummod	_	_
 6	chéim	céim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	nsubj	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
 8	gceist	ceist	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	4	xcomp:pred	_	_
 9	le	le	ADP	Simp	_	10	case	_	_
-10	cothú	cothú	NOUN	Noun	Gender=Masc|Number=Sing	4	xcomp	_	_
+10	cothú	cothú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	xcomp	_	_
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
+12	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
 13	:	:	PUNCT	Punct	_	14	punct	_	_
 14	Daoibhse	do	ADP	Prep	Number=Plur|Person=2|PronType=Emp	1	parataxis	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	14	acl:relcl	_	_
 16	ar	ar	ADP	Simp	_	17	case	_	_
-17	bheagán	beagán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
+17	bheagán	beagán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
 18	Shakespeare	Shakespeare	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
@@ -2058,12 +2058,12 @@
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	nsubj	_	_
 23	d'	do	PART	Vb	PartType=Vb	24	obl	_	SpaceAfter=No
 24	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	21	acl:relcl	_	_
-25	cúrsaí	cúrsa	NOUN	Noun	Gender=Masc|Number=Plur	24	obj	_	_
+25	cúrsaí	cúrsa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	24	obj	_	_
 26	staidéir	staidéar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
 27	níos	níos	PART	Cmp	PartType=Comp	28	mark:prt	_	_
 28	mó	mó	ADJ	Adj	Degree=Pos	25	amod	_	_
 29	ná	ná	CCONJ	Coord	_	30	mark	_	_
-30	cúpla	cúpla	NOUN	Noun	Gender=Masc|Number=Sing	25	obl:tmod	_	_
+30	cúpla	cúpla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	obl:tmod	_	_
 31	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	30	nmod	_	_
 32	ó	ó	ADP	Simp	_	33	case	_	_
 33	shin	sin	PRON	Dem	Form=Len|PronType=Dem	30	nmod	_	SpaceAfter=No
@@ -2077,7 +2077,7 @@
 41	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	36	nsubj	_	_
 42	traigéideach	traigéideach	ADJ	Adj	Case=NomAcc|Number=Sing	41	amod	_	_
 43	marfach	marfach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	41	amod	_	_
-44	Phrionsa	prionsa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	41	nmod	_	_
+44	Phrionsa	prionsa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	41	nmod	_	_
 45	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	46	det	_	_
 46	Danmhairge	Danmhairg	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	44	nmod	_	SpaceAfter=No
 47	.	.	PUNCT	.	_	1	punct	_	_
@@ -2099,13 +2099,13 @@
 2	taom	taom	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	croí	croí	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	compound	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	tiománaí	tiománaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
+5	tiománaí	tiománaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	cailleadh	caill	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	7	obj	_	_
 9	d'	de	ADP	Simp	_	10	case	_	SpaceAfter=No
-10	easpa	easpa	NOUN	Noun	Gender=Fem|Number=Sing	7	obl	_	_
-11	aire	aire	NOUN	Noun	Gender=Fem|Number=Sing	10	nmod	_	_
+10	easpa	easpa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	obl	_	_
+11	aire	aire	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	_
 12	leighis	leigheas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2120,7 +2120,7 @@
 7	sin	sin	DET	Det	PronType=Dem	5	det	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+10	mhéid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 11	nach	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
 12	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	ccomp	_	_
 13	amháin	amháin	ADJ	Adj	Degree=Pos	2	amod	_	_
@@ -2148,7 +2148,7 @@
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	obair	obair	NOUN	Noun	VerbForm=Vnoun	1	xcomp	_	_
 5	in	i	ADP	Simp	_	6	case	_	_
-6	áiteacha	áit	NOUN	Noun	Gender=Fem|Number=Plur	1	obl	_	_
+6	áiteacha	áit	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	obl	_	_
 7	eile	eile	DET	Det	PronType=Dem	6	det	_	_
 8	roimh	roimh	ADP	Simp	_	9	case	_	_
 9	sin	sin	PRON	Dem	PronType=Dem	6	nmod	_	_
@@ -2200,13 +2200,13 @@
 9	labhair	labhair	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
 10	muid	muid	PRON	Pers	Number=Plur|Person=1	9	nsubj	_	_
 11	faoi	faoi	ADP	Simp	_	12	case	_	_
-12	chúrsaí	cúrsa	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	9	obl	_	_
+12	chúrsaí	cúrsa	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	9	obl	_	_
 13	bia	bia	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	_
 14	don	do	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
 15	té	té	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	nsubj	_	_
 17	chaithfeadh	caith	VERB	Cond	Form=Len|Mood=Cnd	15	acl:relcl	_	_
-18	mairstin	mairstin	NOUN	Noun	Gender=Fem|Number=Sing	17	obj	_	_
+18	mairstin	mairstin	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obj	_	_
 19	in	i	ADP	Simp	_	20	case	_	_
 20	ifrinn	ifreann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	17	obl	_	_
 21	shaolta	saolta	ADJ	Adj	Form=Len|Gender=Masc|Number=Sing	20	amod	_	_
@@ -2231,18 +2231,18 @@
 7	CAM	cam	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	6	amod	_	_
 8	dochar	dochar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	_
 9	don	do	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	fheachtas	feachtas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+10	fheachtas	feachtas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
-12	bhfabhar	fabhar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
+12	bhfabhar	fabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	5	obl	_	_
 13	Nice	Nice	PROPN	Noun	Definite=Def|Number=Sing	12	nmod	_	SpaceAfter=No
 14	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 543
 # text = B'fhéidir gur galar tógálach é is go bhfuil an páirtí sa stát seo gafa leis.
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	SpaceAfter=No
-2	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	0	root	_	_
+2	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	0	root	_	_
 3	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
-4	galar	galar	NOUN	Noun	Gender=Masc|Number=Sing	2	csubj:cop	_	_
+4	galar	galar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	csubj:cop	_	_
 5	tógálach	tógálach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	4	amod	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
 7	is	agus	CCONJ	Coord	_	9	cc	_	_
@@ -2251,7 +2251,7 @@
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	páirtí	páirtí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	stát	stát	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
+13	stát	stát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 14	seo	seo	DET	Det	PronType=Dem	13	det	_	_
 15	gafa	gafa	ADJ	Adj	VerbForm=Part	9	xcomp:pred	_	_
 16	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
@@ -2267,7 +2267,7 @@
 6	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	NamedEntity=Yes
 7	Sceire	sceir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	go	go	ADP	Simp	_	3	advmod	_	_
-9	deo	deo	NOUN	Subst	Number=Sing	8	fixed	_	SpaceAfter=No
+9	deo	deo	NOUN	Subst	Case=NomAcc|Number=Sing	8	fixed	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 545
@@ -2278,11 +2278,11 @@
 4	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	1	obl:prep	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+7	oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 8	:	:	PUNCT	Punct	_	11	punct	_	_
 9	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
 10	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	11	cop	_	_
-11	Aifreann	Aifreann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	NamedEntity=Yes
+11	Aifreann	Aifreann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	NamedEntity=Yes
 12	Domhnaigh	Domhnach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	níor	níor	PART	Vb	PartType=Vb|Tense=Past	14	advmod	_	_
 14	éist	éist	VERB	VTI	Mood=Ind|Tense=Past	11	ccomp	_	_
@@ -2293,9 +2293,9 @@
 # sent_id = 546
 # text = B'fhéidir gur aingeal í anois atá ag tabhairt aire dhuit ach tá 'fhios ag Mac Dé go bhfaca mise í.
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	SpaceAfter=No
-2	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	0	root	_	_
+2	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	0	root	_	_
 3	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	4	cop	_	_
-4	aingeal	aingeal	NOUN	Noun	Gender=Masc|Number=Sing	2	csubj:cop	_	_
+4	aingeal	aingeal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	csubj:cop	_	_
 5	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nsubj	_	_
 6	anois	anois	ADV	Gn	_	4	advmod	_	_
 7	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	4	acl:relcl	_	_
@@ -2370,7 +2370,7 @@
 21	FF	FF	PROPN	Abr	Abbr=Yes	19	obl	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 23	tríú	trí	NUM	Num	NumType=Ord	24	amod	_	_
-24	suíochán	suíochán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
+24	suíochán	suíochán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
 25	a	a	PART	Inf	PartType=Inf	26	mark	_	_
 26	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
 27	amach	amach	ADV	Dir	_	26	advmod	_	_
@@ -2378,7 +2378,7 @@
 29	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	26	nmod	_	NamedEntity=Yes
 30	Thiar	thiar	ADV	Dir	_	29	amod	_	NamedEntity=Yes
 31	(	(	PUNCT	Punct	_	32	punct	_	SpaceAfter=No
-32	slán	slán	NOUN	Noun	Gender=Masc|Number=Sing	14	parataxis	_	_
+32	slán	slán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	parataxis	_	_
 33	leat	le	ADP	Prep	Number=Sing|Person=2	32	obl:prep	_	SpaceAfter=No
 34	,	,	PUNCT	Punct	_	36	punct	_	_
 35	a	a	PART	Voc	PartType=Voc	36	case:voc	_	_
@@ -2390,7 +2390,7 @@
 # text = Rángamar an Pasáiste go batrálta tréithlag is thángas-sa go Port Láirge ar cosa-in-airde im aonar.
 1	Rángamar	ráinigh	VERB	PastInd	Mood=Ind|Number=Plur|Person=1|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	Pasáiste	pasáiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
+3	Pasáiste	pasáiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 4	go	go	PART	Ad	PartType=Ad	5	mark:prt	_	_
 5	batrálta	batrálta	ADJ	Adj	VerbForm=Part	1	advmod	_	_
 6	tréithlag	tréithlag	ADJ	Adj	Degree=Pos	1	amod	_	_
@@ -2400,7 +2400,7 @@
 10	Port	Port	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	NamedEntity=Yes
 11	Láirge	Láirge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	ar	ar	ADP	Simp	_	13	case	_	_
-13	cosa-in-airde	cosa-in-airde	NOUN	Noun	Gender=Fem|Number=Sing	8	obl	_	_
+13	cosa-in-airde	cosa-in-airde	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	obl	_	_
 14	im	i_mo	ADP	_	Number=Sing|Person=1|Poss=Yes	15	case	_	_
 15	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
@@ -2422,9 +2422,9 @@
 # sent_id = 551
 # text = Ní féidir gach gearán a shocrú go háitiúil ach ba cheart go mbeadh foráil sa chóras gearán inmheánach faoina bhféadfaí gearán a chur faoi bhráid an Ombudsman nuair is gá agus is cuí.
 1	Ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	féidir	féidir	NOUN	Subst	Number=Sing	0	root	_	_
+2	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	0	root	_	_
 3	gach	gach	DET	Det	Definite=Def	4	det	_	_
-4	gearán	gearán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
+4	gearán	gearán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obj	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
 6	shocrú	socrú	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 7	go	go	PART	Ad	PartType=Ad	8	mark:prt	_	_
@@ -2436,21 +2436,21 @@
 13	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	11	csubj:cop	_	_
 14	foráil	foráil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nsubj	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	chóras	córas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
-17	gearán	gearán	NOUN	Noun	Gender=Masc|Number=Sing	16	nmod	_	_
+16	chóras	córas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+17	gearán	gearán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	16	nmod	_	_
 18	inmheánach	inmheánach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	17	amod	_	_
 19	faoina	faoi	PART	Rel	PronType=Rel	20	obl	_	_
 20	bhféadfaí	féad	VERB	VTI	Form=Ecl|Mood=Cnd|Person=0	16	acl:relcl	_	_
-21	gearán	gearán	NOUN	Noun	Gender=Masc|Number=Sing	23	obj	_	_
+21	gearán	gearán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	obj	_	_
 22	a	a	PART	Inf	PartType=Inf	23	mark	_	_
 23	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	20	xcomp	_	_
 24	faoi	faoi	ADP	Cmpd	PrepForm=Cmpd	27	case	_	_
 25	bhráid	bhráid	ADP	Cmpd	PrepForm=Cmpd	24	fixed	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	Ombudsman	Ombudsman	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
+27	Ombudsman	Ombudsman	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
 28	nuair	nuair	SCONJ	Subord	_	30	mark	_	_
 29	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	30	cop	_	_
-30	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	13	advcl	_	_
+30	gá	gá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	advcl	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	_
 32	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	33	cop	_	_
 33	cuí	cuí	ADJ	Adj	Degree=Pos	30	conj	_	SpaceAfter=No
@@ -2472,7 +2472,7 @@
 12	thalamh	talamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	obl	_	_
 13	slán	slán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	12	amod	_	_
 14	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	15	cop	_	SpaceAfter=No
-15	amhala	amhala	NOUN	Subst	Number=Sing	0	root	_	_
+15	amhala	amhala	NOUN	Subst	Case=NomAcc|Number=Sing	0	root	_	_
 16	ba	is	PART	Sup	PartType=Sup	17	mark:prt	_	_
 17	mheasa	olc	ADJ	Adj	Degree=Cmp,Sup|Form=Len	15	csubj:cop	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
@@ -2494,7 +2494,7 @@
 5	amháin	amháin	ADJ	Adj	Degree=Pos	3	amod	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	siopa	siopa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
+8	siopa	siopa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 9	sin	sin	DET	Det	PronType=Dem	8	det	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2510,7 +2510,7 @@
 8	gur	gur	PART	Vb	PartType=Vb|Tense=Past	9	mark:prt	_	_
 9	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	ccomp	_	_
 10	agus	agus	CCONJ	Coord	_	15	cc	_	_
-11	soicindí	soicind	NOUN	Noun	Gender=Masc|Number=Plur	15	obl:tmod	_	_
+11	soicindí	soicind	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	15	obl:tmod	_	_
 12	níos	níos	PART	Cmp	PartType=Comp	13	mark:prt	_	_
 13	déanaí	déanach	ADJ	Adj	Degree=Cmp,Sup	11	amod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	11	punct	_	_
@@ -2525,18 +2525,18 @@
 23	agus	agus	CCONJ	Coord	_	24	mark	_	_
 24	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	15	advcl	_	_
 25	ar	ar	ADP	Simp	_	26	case	_	_
-26	tí	tí	NOUN	Noun	Gender=Fem|Number=Sing	24	xcomp	_	_
+26	tí	tí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	24	xcomp	_	_
 27	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	nmod:poss	_	_
 28	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	33	obj	_	_
 29	is	agus	CCONJ	Coord	_	33	cc	_	_
 30	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	31	nmod:poss	_	_
-31	leannán	leannán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	conj	_	_
+31	leannán	leannán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	conj	_	_
 32	a	a	PART	Inf	PartType=Inf	33	mark	_	_
 33	shá	sá	NOUN	Noun	Form=Len|VerbForm=Inf	24	xcomp	_	_
 34	chun	chun	ADP	Simp	_	35	case	_	_
 35	báis	bás	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	33	obl	_	_
 36	le	le	ADP	Simp	_	37	case	_	_
-37	siosúr	siosúr	NOUN	Noun	Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
+37	siosúr	siosúr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 555
@@ -2558,14 +2558,14 @@
 15	nglaoitear	glaoigh	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	11	ccomp	_	_
 16	Boilg	boilg	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obj	_	NamedEntity=Yes
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	NamedEntity=Yes
-18	Chruaidh	cruaidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Chruaidh	cruaidh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	_	_
 
 # sent_id = 556
 # text = 'Sampla?
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Sampla	sampla	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+2	Sampla	sampla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 557
@@ -2578,7 +2578,7 @@
 6	a	a	PART	Inf	PartType=Inf	7	nsubj	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	acl:relcl	_	_
 8	ar	ar	ADP	Simp	_	9	case	_	_
-9	bhinse	binse	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
+9	bhinse	binse	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
 10	Charoline	Caroline	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
 11	is	agus	CCONJ	Coord	_	12	cc	_	_
 12	scuab	scuab	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
@@ -2588,7 +2588,7 @@
 16	amach	amach	ADV	Dir	_	12	advmod	_	_
 17	chun	chun	ADP	Simp	_	19	case	_	_
 18	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
-19	saoirse	saoirse	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	obl	_	SpaceAfter=No
+19	saoirse	saoirse	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	12	obl	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 558
@@ -2596,7 +2596,7 @@
 1	Ach	ach	SCONJ	Subord	_	8	mark	_	SpaceAfter=No
 2	,	,	PUNCT	Punct	_	1	punct	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	8	obl	_	_
+4	dhiaidh	diaidh	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Len|Number=Sing	8	obl	_	_
 5	sin	sin	DET	Det	PronType=Dem	4	det	_	_
 6	féin	féin	PRON	Ref	Reflex=Yes	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	4	punct	_	_
@@ -2607,7 +2607,7 @@
 12	baint	baint	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	iomarca	iomarca	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	obl	_	_
+15	iomarca	iomarca	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	obl	_	_
 16	meáchain	meáchan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	19	punct	_	_
 18	go	go	PART	Ad	PartType=Ad	19	mark:prt	_	_
@@ -2619,12 +2619,12 @@
 24	sláinte	sláinte	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	22	nmod	_	_
 25	ag	ag	ADP	Simp	_	27	case	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
+27	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 559
 # text = Mac léinn díograiseach ba ea Colm Cille agus bhí dúil ar leith aige san fhilíocht.
-1	Mac	mac	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	léinn	léann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	compound	_	_
 3	díograiseach	díograiseach	ADJ	Adj	Case=NomAcc|NounType=Weak|Number=Sing	1	amod	_	_
 4	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	6	cop	_	_
@@ -2644,11 +2644,11 @@
 # sent_id = 560
 # text = Crochann casóg ar chuaille, tamall, mé i mbun spáide, Ach fuaraíonn an t-allas faoin léine.
 1	Crochann	croch	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-2	casóg	casóg	NOUN	Noun	Gender=Fem|Number=Sing	1	obj	_	_
+2	casóg	casóg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	chuaille	cuaille	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+4	chuaille	cuaille	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	tamall	tamall	NOUN	Noun	Gender=Masc|Number=Sing	1	obl:tmod	_	SpaceAfter=No
+6	tamall	tamall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl:tmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	mé	mé	PRON	Pers	Number=Sing|Person=1	1	advcl	_	_
 9	i	i	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
@@ -2660,7 +2660,7 @@
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	t-allas	allas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	_
 17	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	léine	léine	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
+18	léine	léine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 561
@@ -2669,11 +2669,11 @@
 2	mhaith	maith	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	1	amod	_	_
 3	de	de	ADP	Simp	_	5	case	_	SpaceAfter=No
 4	'n	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
-5	teangaidh	teanga	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
+5	teangaidh	teanga	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	obl	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 8	in	i	ADP	Simp	_	9	case	_	_
-9	áithrid	áithrid	NOUN	Noun	Gender=Fem|Number=Sing	7	xcomp:pred	_	_
+9	áithrid	áithrid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	xcomp:pred	_	_
 10	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	7	obl:prep	_	_
 11	ag	ag	ADP	Simp	_	13	case	_	_
 12	a'	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
@@ -2685,7 +2685,7 @@
 18	dtug	tabhair	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	16	csubj:cleft	_	_
 19	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	18	nsubj	_	_
 20	d'	de	ADP	Simp	_	21	case	_	SpaceAfter=No
-21	áirleacan	airleacan	NOUN	Noun	Gender=Masc|Number=Sing	18	obl	_	_
+21	áirleacan	airleacan	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	obl	_	_
 22	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	18	obl:prep	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
 24	noiméad	nóiméad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	28	obj	_	_
@@ -2696,23 +2696,23 @@
 29	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	28	obl:prep	_	_
 30	as	as	ADP	Simp	_	32	case	_	_
 31	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
-32	siopa	siopa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
+32	siopa	siopa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	36	punct	_	_
 34	nó	nó	CCONJ	Coord	_	36	cc	_	_
 35	go	go	PART	Vb	PartType=Cmpl	36	mark:prt	_	_
 36	gcuirfeadh	cuir	VERB	VTI	Form=Ecl|Mood=Cnd	1	conj	_	_
 37	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	36	nsubj	_	_
 38	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	39	det	_	_
-39	póilíos	póilín	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	36	obj	_	_
+39	póilíos	póilín	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	36	obj	_	_
 40	in	i	ADP	Simp	_	42	case	_	_
 41	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	42	nmod:poss	_	_
-42	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	36	obl	_	SpaceAfter=No
+42	dhiaidh	diaidh	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Len|Number=Sing	36	obl	_	SpaceAfter=No
 43	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 562
 # text = Na tithe cois abhann Iad uile faoi shuan Fásann siad sa cheo, Is airde iad, is báine.
 1	Na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	2	det	_	_
-2	tithe	teach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
+2	tithe	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	0	root	_	_
 3	cois	cois	ADP	Simp	_	4	case	_	_
 4	abhann	abhainn	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
 5	Iad	iad	PRON	Pers	Number=Plur|Person=3	2	nsubj	_	_
@@ -2722,7 +2722,7 @@
 9	Fásann	fás	VERB	VTI	Mood=Ind|Tense=Pres	2	parataxis	_	_
 10	siad	siad	PRON	Pers	Number=Plur|Person=3	9	nsubj	_	_
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	cheo	ceo	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+12	cheo	ceo	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	Is	is	PART	Sup	PartType=Sup	15	mark:prt	_	_
 15	airde	ard	ADJ	Adj	Degree=Cmp,Sup	10	amod	_	_
@@ -2745,7 +2745,7 @@
 9	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	obl:prep	_	_
 10	te	te	ADJ	Adj	Degree=Pos	9	amod	_	_
 11	ón	ó	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	oigheann	oigheann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
+12	oigheann	oigheann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	15	cop	_	_
 15	fearr	maith	ADJ	Adj	Degree=Cmp,Sup	1	parataxis	_	_
@@ -2756,19 +2756,19 @@
 20	feadh	feadh	ADP	Cmpd	PrepForm=Cmpd	19	fixed	_	_
 21	seachtaine	seachtain	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	18	obl	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	stán	stán	NOUN	Noun	Gender=Masc|Number=Sing	18	nmod	_	_
+23	stán	stán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
 24	aerobach	aerobach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	amod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 564
 # text = Fear ciúin ab ea Donncha - fear nach raibh suim aige i rud ar bith taobh amuigh dá líon tí.
-1	Fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	ciúin	ciúin	ADJ	Adj	Gender=Masc|Number=Sing	1	amod	_	_
 3	ab	is	AUX	Cop	Form=VF|PronType=Rel|Tense=Past|VerbForm=Cop	5	cop	_	_
 4	ea	ea	PRON	Pers	Number=Sing|Person=3	5	nmod	_	_
 5	Donncha	Donncha	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 6	-	-	PUNCT	Punct	_	7	punct	_	_
-7	fear	fear	NOUN	Noun	Gender=Masc|Number=Sing	5	appos	_	_
+7	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	appos	_	_
 8	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	9	mark:prt	_	_
 9	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	parataxis	_	_
 10	suim	suim	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	nsubj	_	_
@@ -2796,11 +2796,11 @@
 8	choimeád	coimeád	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	2	xcomp	_	_
 9	siar	siar	ADV	Dir	_	8	advmod	_	_
 10	toisc	toisc	SCONJ	Subord	_	11	mark	_	_
-11	easpa	easpa	NOUN	Noun	Gender=Fem|Number=Sing	2	obl	_	_
+11	easpa	easpa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obl	_	_
 12	caipitil	caipiteal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	agus	agus	CCONJ	Coord	_	19	cc	_	_
-15	airgead	airgead	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	obj	_	_
+15	airgead	airgead	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	obj	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
 17	phobail	pobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 18	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	19	case	_	_
@@ -2811,9 +2811,9 @@
 23	chailliúnt	cailliúint	NOUN	Noun	Definite=Def|Form=Len|Typo=Yes|VerbForm=Inf	19	conj	_	SpaceAfter=No
 24	)	)	PUNCT	Punct	_	23	punct	_	_
 25	ar	ar	ADP	Simp	_	26	case	_	_
-26	scairmhargaí	scairmhargadh	NOUN	Noun	Gender=Masc|Number=Plur	19	obl	_	_
+26	scairmhargaí	scairmhargadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	19	obl	_	_
 27	thar	thar	ADP	Simp	_	19	nmod	_	_
-28	lear	lear	NOUN	Noun	Gender=Masc|Number=Sing	27	fixed	_	_
+28	lear	lear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	fixed	_	_
 29	ag	ag	ADP	Simp	_	31	case	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	_
@@ -2833,7 +2833,7 @@
 3	Cheathrú	ceathrú	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	NamedEntity=Yes
 4	Uain	uan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	sa	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chaoi	caoi	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+6	chaoi	caoi	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	go	go	PART	Vb	PartType=Cmpl	8	mark:prt	_	_
 8	mbíonn	bí	VERB	PresImp	Aspect=Hab|Form=Ecl|Mood=Ind|Tense=Pres	1	ccomp	_	_
 9	teacht	teacht	NOUN	Noun	VerbForm=Inf	8	nsubj	_	_
@@ -2850,7 +2850,7 @@
 2	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	amháin	amháin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	den	de	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	tseimineár	seimineár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
+5	tseimineár	seimineár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 6	seo	seo	DET	Det	PronType=Dem	2	det	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
 8	fhorbairt	forbairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
@@ -2875,7 +2875,7 @@
 27	ar	ar	ADP	Simp	_	28	case	_	_
 28	bhunús	bunús	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
 29	agus	agus	CCONJ	Coord	_	30	cc	_	_
-30	todhchaí	todhchaí	NOUN	Noun	Gender=Fem|Number=Sing	28	conj	_	_
+30	todhchaí	todhchaí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	28	conj	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
 32	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_
@@ -2896,7 +2896,7 @@
 48	fite	fite	ADJ	Adj	VerbForm=Part	45	xcomp:pred	_	_
 49	fuaite	fuaite	ADJ	Adj	VerbForm=Part	48	fixed	_	_
 50	le	le	ADP	Simp	_	51	case	_	_
-51	traidisiún	traidisiún	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	48	obl	_	_
+51	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	obl	_	_
 52	scéalaíochta	scéalaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	51	nmod	_	_
 53	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	54	det	_	_
 54	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	51	nmod	_	_
@@ -2907,7 +2907,7 @@
 59	Ó	ó	PART	Pat	PartType=Pat	57	flat:name	_	NamedEntity=Yes
 60	Criomhthainn	Criomhthainn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat:name	_	NamedEntity=Yes
 61	ó	ó	ADP	Simp	_	62	case	_	_
-62	Choláiste	coláiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
+62	Choláiste	coláiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
 63	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	64	det	_	NamedEntity=Yes
 64	hOllscoile	ollscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	62	nmod	_	NamedEntity=Yes|SpaceAfter=No
 65	,	,	PUNCT	Punct	_	66	punct	_	_
@@ -2922,14 +2922,14 @@
 74	a	a	PART	Vb	PartType=Vb|PronType=Rel	76	mark:prt	_	_
 75	d'	do	PART	Vb	PartType=Vb	76	mark:prt	_	SpaceAfter=No
 76	fhéadfaí	féad	VERB	VTI	Form=Len|Mood=Cnd|Person=0	71	ccomp	_	_
-77	córais	córas	NOUN	Noun	Gender=Masc|Number=Plur	87	obj	_	_
+77	córais	córas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	87	obj	_	_
 78	nua	nua	ADJ	Adj	Degree=Pos	77	amod	_	_
 79	teileachumarsáide	teileachumarsáid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	77	nmod	_	SpaceAfter=No
 80	,	,	PUNCT	Punct	_	82	punct	_	_
 81	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	82	det	_	_
 82	Internet	Internet	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	77	appos	_	_
 83	mar	mar	ADP	Simp	_	84	case	_	_
-84	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	82	nmod	_	SpaceAfter=No
+84	shampla	sampla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	82	nmod	_	SpaceAfter=No
 85	,	,	PUNCT	Punct	_	77	punct	_	_
 86	a	a	PART	Inf	PartType=Inf	87	mark	_	_
 87	úsáid	úsáid	NOUN	Noun	VerbForm=Inf	76	xcomp	_	_
@@ -2947,13 +2947,13 @@
 # text = Ghearr rialaitheoirí píonós de $100m ar Merrill Lynch mí ó shin toisc gur mhol taighdeoir d'infheisteoirí scaireanna comhlacht, Winstar, a cheannach cé gur sheol an té a d'eisigh an moladh ríomhphost chuig comhghleacaí ag rá gur cacamas iomlán an comhlacht.
 1	Ghearr	Gearr	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	rialaitheoirí	rialaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	nsubj	_	_
-3	píonós	píonós	NOUN	Noun	Gender=Masc|Number=Sing	2	obj	_	_
+3	píonós	píonós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
 5	$100m	$100m	NUM	Num	_	3	nmod	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
 7	Merrill	Merrill	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 8	Lynch	Lynch	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
-9	mí	mí	NOUN	Noun	Gender=Fem|Number=Sing	1	obl:tmod	_	_
+9	mí	mí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obl:tmod	_	_
 10	ó	ó	ADP	Simp	_	11	case	_	_
 11	shin	sin	PRON	Dem	Form=Len|PronType=Dem	9	nmod	_	_
 12	toisc	toisc	SCONJ	Subord	_	14	mark	_	_
@@ -2961,9 +2961,9 @@
 14	mhol	mol	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 15	taighdeoir	taighdeoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
 16	d'	do	ADP	Simp	_	17	case	_	SpaceAfter=No
-17	infheisteoirí	infheisteoir	NOUN	Noun	Gender=Masc|Number=Plur	14	obl	_	_
-18	scaireanna	scair	NOUN	Noun	Gender=Fem|Number=Plur	17	nmod	_	_
-19	comhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	obj	_	SpaceAfter=No
+17	infheisteoirí	infheisteoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	14	obl	_	_
+18	scaireanna	scair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	24	obj	_	_
+19	comhlacht	comhlacht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Winstar	Winstar	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	appos	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	19	punct	_	_
@@ -2979,9 +2979,9 @@
 32	eisigh	eisigh	VERB	VT	Mood=Ind|Tense=Past	29	acl:relcl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
 34	moladh	moladh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	32	obj	_	_
-35	ríomhphost	ríomhphost	NOUN	Noun	Gender=Masc|Number=Sing	27	obj	_	_
+35	ríomhphost	ríomhphost	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	obj	_	_
 36	chuig	chuig	ADP	Simp	_	37	case	_	_
-37	comhghleacaí	comhghleacaí	NOUN	Noun	Gender=Masc|Number=Sing	27	obl	_	_
+37	comhghleacaí	comhghleacaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	obl	_	_
 38	ag	ag	ADP	Simp	_	39	case	_	_
 39	rá	rá	NOUN	Noun	VerbForm=Vnoun	29	xcomp	_	_
 40	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	41	cop	_	_
@@ -3006,7 +3006,7 @@
 
 # sent_id = 570
 # text = File tuaithe atá ann.
-1	File	file	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	File	file	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	tuaithe	tuath	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
 3	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	1	csubj:cleft	_	_
 4	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	3	xcomp:pred	_	SpaceAfter=No
@@ -3021,7 +3021,7 @@
 5	ráta	ráta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	_
 6	réitithe	réitithe	ADJ	Adj	VerbForm=Part	3	xcomp:pred	_	_
 7	i	i	ADP	Simp	_	8	case	_	_
-8	bhfad	fad	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	_
+8	bhfad	fad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	_
 9	níos	níos	PART	Cmp	PartType=Comp	10	mark:prt	_	_
 10	ísle	íseal	ADJ	Adj	Degree=Cmp,Sup	3	advmod	_	_
 11	ná	ná	CCONJ	Coord	_	12	mark	_	_
@@ -3038,34 +3038,34 @@
 1	Duradh	abair	VERB	VTI	Mood=Ind|Person=0|Tense=Past|Typo=Yes	0	root	_	_
 2	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 3	seo	seo	PRON	Dem	PronType=Dem	1	ccomp	_	_
-4	ceann	ceann	NOUN	Noun	Gender=Masc|Number=Sing	3	nmod	_	_
+4	ceann	ceann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
 5	dena	de_na	ADP	Art	Number=Plur|PronType=Art	6	case	_	_
-6	fadhbanna	fadhb	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	_
+6	fadhbanna	fadhb	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	_
 7	is	is	PART	Sup	PartType=Sup	8	mark:prt	_	_
 8	mó	mór	ADJ	Adj	Degree=Cmp,Sup	6	amod	_	_
 9	atá	bí	VERB	VI	Mood=Ind|PronType=Rel|Tense=Pres	6	acl:relcl	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
+11	cheantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 573
 # text = Fás na nGaelscoileanna.
-1	Fás	fás	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
+1	Fás	fás	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 2	na	na	DET	Art	PronType=Art	3	det	_	_
 3	nGaelscoileanna	Gaelscoil	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 574
 # text = Duine bocht a chaill leathlámh agus leathcos i dtimpiste i Londain is ea príomhcharachtar an úrscéil Deoraíocht.
-1	Duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	bocht	bocht	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	nsubj	_	_
 4	chaill	caill	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	acl:relcl	_	_
 5	leathlámh	leathlámh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obj	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
-7	leathcos	leathchos	NOUN	Noun	Gender=Fem|Number=Sing|Typo=Yes	5	conj	_	_
+7	leathcos	leathchos	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing|Typo=Yes	5	conj	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	dtimpiste	timpiste	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	4	obl	_	_
+9	dtimpiste	timpiste	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	4	obl	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
 11	Londain	Londain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	4	obl	_	_
 12	is	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	14	cop	_	_
@@ -3090,10 +3090,10 @@
 10	reachtaíocht	reachtaíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nmod	_	_
 11	nó	nó	CCONJ	Coord	_	13	cc	_	_
 12	faoi	faoi	ADP	Simp	_	13	case	_	_
-13	cheadúnas	ceadúnas	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	10	conj	_	_
+13	cheadúnas	ceadúnas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	conj	_	_
 14	clúdaithe	clúdaithe	ADJ	Adj	VerbForm=Part	13	xcomp:pred	_	_
 15	faoi	faoi	ADP	Simp	_	16	case	_	_
-16	fho-mhír	fomhír	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	13	nmod	_	_
+16	fho-mhír	fomhír	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	13	nmod	_	_
 17	(c)	(c)	NUM	Item	_	16	nmod	_	_
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	(d)	(d)	NUM	Item	_	17	conj	_	_
@@ -3108,7 +3108,7 @@
 4	a	a	PART	Inf	PartType=Inf	5	mark	_	_
 5	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
-7	phointe	pointe	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+7	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	nsubj	_	_
 9	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	7	acl:relcl	_	_
 10	tuarascáil	tuarascáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	_
@@ -3128,10 +3128,10 @@
 24	)	)	PUNCT	Punct	_	23	punct	_	_
 25	ar	ar	ADP	Simp	_	27	case	_	_
 26	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	27	det	_	_
-27	daoine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	_
+27	daoine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	_
 28	a	a	PART	Vb	PartType=Vb|PronType=Rel	29	nsubj	_	_
 29	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	27	acl:relcl	_	_
-30	bonn	bonn	NOUN	Noun	Gender=Masc|Number=Sing	29	obj	_	_
+30	bonn	bonn	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	obj	_	_
 31	faoi	faoi	ADP	Simp	_	32	case	_	_
 32	theangeolaíocht	teangeolaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	29	obl	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
@@ -3142,7 +3142,7 @@
 # sent_id = 577
 # text = Ag barr an chnoic, ar scáth crainn chnó chapall, casann an bheirt ar deis.
 1	Ag	ag	ADP	Simp	_	2	case	_	_
-2	barr	barr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
+2	barr	barr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	chnoic	cnoc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -3171,7 +3171,7 @@
 8	díreach	díreach	ADJ	Adj	Degree=Pos	6	advmod	_	_
 9	isteach	isteach	ADV	Dir	_	6	advmod	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	gciorcad	ciorcad	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
+11	gciorcad	ciorcad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	i.e.	i.e.	ADV	Abr	Abbr=Yes	14	advmod	_	_
 14	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	16	obj	_	_
@@ -3179,7 +3179,7 @@
 16	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	2	parataxis	_	_
 17	sraithcheangailte	sraithcheangailte	ADJ	Adj	VerbForm=Part	16	xcomp:pred	_	_
 18	(	(	PUNCT	Punct	_	19	punct	_	SpaceAfter=No
-19	Fíor	fíor	NOUN	Noun	Gender=Fem|Number=Sing	17	appos	_	_
+19	Fíor	fíor	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	appos	_	_
 20	4)	4)	NUM	Item	_	19	nmod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -3211,18 +3211,18 @@
 2	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 3	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	as	as	ADP	Simp	_	5	case	_	_
-5	Foinse	foinse	NOUN	Noun	Gender=Fem|Number=Sing	2	obl	_	_
+5	Foinse	foinse	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	obl	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	dreapadóir	dreapadóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	_
 9	Paul	Paul	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	appos	_	NamedEntity=Yes
 10	Pritchard	Pritchard	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
 11	ar	ar	ADP	Simp	_	12	case	_	_
-12	pháipéar	páipéar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+12	pháipéar	páipéar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	Teastais	teastas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 15	Shóisearaigh	sóisearach	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	14	amod	_	NamedEntity=Yes
-16	gnáthleibhéal	gnáthleibhéal	NOUN	Noun	Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
+16	gnáthleibhéal	gnáthleibhéal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 581
@@ -3240,7 +3240,7 @@
 11	ag	ag	ADP	Simp	_	12	case	_	_
 12	seo	seo	PRON	Dem	PronType=Dem	0	root	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	geallta	geall	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	_
+14	geallta	geall	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	12	nmod	_	_
 15	ante-post	ante-post	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	14	nmod	_	_
 16	-	-	PUNCT	Punct	_	17	punct	_	_
 17	Mr.	Mr.	NOUN	Abr	Abbr=Yes	12	parataxis	_	NamedEntity=Yes
@@ -3249,7 +3249,7 @@
 20	5	5	NUM	Num	_	21	nummod	_	_
 21	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
-23	bua	bua	NOUN	Noun	Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
+23	bua	bua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
 25	ag	ag	ADP	Simp	_	26	case	_	_
 26	7/1	7/1	NUM	Num	_	23	nmod	_	SpaceAfter=No
@@ -3262,7 +3262,7 @@
 33	3	3	NUM	Num	_	34	nummod	_	_
 34	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	29	nmod	_	SpaceAfter=No
 35	,	,	PUNCT	Punct	_	36	punct	_	_
-36	bua	bua	NOUN	Noun	Gender=Masc|Number=Sing	34	nmod	_	_
+36	bua	bua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	34	nmod	_	_
 37	ag	ag	ADP	Simp	_	38	case	_	_
 38	10/1	10/1	NUM	Num	_	36	nmod	_	SpaceAfter=No
 39	)	)	PUNCT	Punct	_	34	punct	_	SpaceAfter=No
@@ -3274,7 +3274,7 @@
 45	2	2	NUM	Num	_	46	nummod	_	_
 46	phointe	pointe	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	42	nmod	_	SpaceAfter=No
 47	,	,	PUNCT	Punct	_	48	punct	_	_
-48	bua	bua	NOUN	Noun	Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
+48	bua	bua	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	51	punct	_	_
 50	ag	ag	ADP	Simp	_	51	case	_	_
 51	14/1	14/1	NUM	Num	_	48	nmod	_	SpaceAfter=No
@@ -3290,7 +3290,7 @@
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	iarghrúpa	iarghrúpa	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	_
 7	In	i	ADP	Simp	_	8	case	_	NamedEntity=Yes
-8	Tua	tua	NOUN	Noun	Gender=Fem|Number=Sing	6	flat	_	NamedEntity=Yes
+8	Tua	tua	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	flat	_	NamedEntity=Yes
 9	Nua	nua	ADJ	Adj	Degree=Pos	8	amod	_	NamedEntity=Yes
 10	le	le	ADP	Simp	_	11	case	_	_
 11	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
@@ -3310,10 +3310,10 @@
 25	ar	ar	ADP	Simp	_	26	case	_	_
 26	fáil	fáil	NOUN	Noun	VerbForm=Inf	22	xcomp	_	_
 27	sna	i	ADP	Art	Number=Plur|PronType=Art	28	case	_	_
-28	siopaí	siopa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	26	obl	_	_
+28	siopaí	siopa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	26	obl	_	_
 29	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 30	chéad	céad	NUM	Num	Form=Len|NumType=Ord	31	amod	_	_
-31	mhí	mí	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl:tmod	_	_
+31	mhí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl:tmod	_	_
 32	eile	eile	DET	Det	PronType=Dem	31	det	_	SpaceAfter=No
 33	...	...	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	1	punct	_	_
@@ -3361,15 +3361,15 @@
 10	t-amhras	amhras	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 11	agus	agus	CCONJ	Coord	_	13	cc	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	féincheistiú	féincheistiú	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	conj	_	_
+13	féincheistiú	féincheistiú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	conj	_	_
 14	a	a	PART	Vb	PartType=Vb|PronType=Rel	15	nsubj	_	_
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	10	acl:relcl	_	_
 16	chomh	chomh	ADV	Its	_	17	advmod	_	_
 17	forleathan	forleathan	ADJ	Adj	Degree=Pos	15	xcomp:pred	_	_
 18	sin	sin	PRON	Dem	PronType=Dem	17	det	_	_
 19	i	i	ADP	Simp	_	21	case	_	_
-20	measc	measc	NOUN	Noun	Gender=Masc|Number=Sing	19	fixed	_	_
-21	phobal	pobal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
+20	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	fixed	_	_
+21	phobal	pobal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	15	obl	_	_
 22	SAM	SAM	PROPN	Abr	Abbr=Yes	21	nmod	_	_
 23	ag	ag	ADP	Simp	_	25	case	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
@@ -3389,7 +3389,7 @@
 9	Fhichiú	fichiú	NUM	_	Form=Len|NumType=Ord	10	amod	_	_
 10	hAois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	1	obl:tmod	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
-12	bhrí	brí	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+12	bhrí	brí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 13	gur	gur	PART	Vb	PartType=Vb|Tense=Past	14	mark:prt	_	_
 14	glacadh	glac	VERB	VT	Mood=Ind|Person=0|Tense=Past	1	ccomp	_	_
 15	lena	le	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	16	case	_	_
@@ -3404,21 +3404,21 @@
 
 # sent_id = 587
 # text = Meatachán scanraithe agus a lámha cáidheach le roidealach an bhóthair.
-1	Meatachán	meatachán	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Meatachán	meatachán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	scanraithe	scanraithe	ADJ	Adj	VerbForm=Part	1	amod	_	_
 3	agus	agus	CCONJ	Coord	_	5	cc	_	_
 4	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	nmod:poss	_	_
 5	lámha	lámh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	conj	_	_
 6	cáidheach	cáidheach	ADJ	Adj	Degree=Pos	5	amod	_	_
 7	le	le	ADP	Simp	_	8	case	_	_
-8	roidealach	roidealach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
+8	roidealach	roidealach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	bhóthair	bóthar	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 588
 # text = BRÍSTÍNÍ BRÉIDÍN Nimh sa luibh?
-1	BRÍSTÍNÍ	brístín	NOUN	Noun	Gender=Masc|Number=Plur	0	root	_	_
+1	BRÍSTÍNÍ	brístín	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
 2	BRÉIDÍN	bréidín	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
 3	Nimh	nimh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	parataxis	_	_
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
@@ -3450,7 +3450,7 @@
 2	méadú	méadú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	56%	56	NUM	Num	_	2	nmod	_	_
 4	i	i	ADP	Simp	_	5	case	_	_
-5	lion	líon	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	1	obl	_	_
+5	lion	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	1	obl	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	dturasóirí	turasóir	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	5	nmod	_	_
 8	go	go	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
@@ -3458,7 +3458,7 @@
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	Tuaisceart	tuaisceart	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	_
 12	i	i	ADP	Simp	_	11	nmod	_	_
-13	gcoitinne	coitinne	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	12	fixed	_	_
+13	gcoitinne	coitinne	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	12	fixed	_	_
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	100%	100	NUM	Num	_	2	conj	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
@@ -3518,7 +3518,7 @@
 13	sheasamh	seasamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 14	ar	ar	ADP	Simp	_	15	case	_	_
 15	scraith	scraith	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obl	_	_
-16	ghlogair	glogar	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
+16	ghlogair	glogar	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 17	agus	agus	CCONJ	Coord	_	19	cc	_	_
 18	nach	nach	PART	Vb	PartType=Cmpl	19	mark:prt	_	_
 19	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	10	conj	_	_
@@ -3527,15 +3527,15 @@
 22	agat	ag	ADP	Prep	Number=Sing|Person=2	19	obl:prep	_	_
 23	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	19	obj	_	_
 24	agus	agus	SCONJ	Subord	_	25	mark	_	_
-25	plup	plup	NOUN	Noun	Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
+25	plup	plup	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	SpaceAfter=No
 26	!	!	PUNCT	!	_	1	punct	_	_
 
 # sent_id = 594
 # text = Dráma an-dána ar fad a bhí ann don am úd - phléigh sí ann ceisteanna an-chonspóideacha mar mháithreacha neamhphósta agus ginmhilleadh.
-1	Dráma	dráma	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Dráma	dráma	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	an-dána	an-dána	ADJ	Adj	Degree=Pos	1	amod	_	_
 3	ar	ar	ADP	Simp	_	1	nmod	_	_
-4	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	3	fixed	_	_
+4	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	fixed	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	mark:prt	_	_
 6	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	csubj:cleft	_	_
 7	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	6	xcomp:pred	_	_
@@ -3546,10 +3546,10 @@
 12	phléigh	pléigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	parataxis	_	_
 13	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	12	nsubj	_	_
 14	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	obl:prep	_	_
-15	ceisteanna	ceist	NOUN	Noun	Gender=Fem|Number=Plur	12	obj	_	_
+15	ceisteanna	ceist	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	12	obj	_	_
 16	an-chonspóideacha	an-chonspóideach	ADJ	Adj	NounType=NotSlender|Number=Plur	15	amod	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
-18	mháithreacha	máthair	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	12	obl	_	_
+18	mháithreacha	máthair	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	12	obl	_	_
 19	neamhphósta	neamhphósta	ADJ	Adj	Degree=Pos	18	amod	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
 21	ginmhilleadh	ginmhilleadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	conj	_	SpaceAfter=No
@@ -3573,15 +3573,15 @@
 14	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	9	conj	_	_
 15	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	14	nsubj	_	_
 16	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	17	nmod:poss	_	_
-17	cóta	cóta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
+17	cóta	cóta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obj	_	_
 18	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
+19	béal	béal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
 20	nó	nó	CCONJ	Coord	_	21	cc	_	_
-21	íochtar	íochtar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	conj	_	_
+21	íochtar	íochtar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	conj	_	_
 22	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
-23	cóta	cóta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
+23	cóta	cóta	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	_
 24	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	25	case	_	_
-25	béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	_
+25	béal	béal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	obl	_	_
 26	agus	agus	CCONJ	Coord	_	27	cc	_	_
 27	rith	rith	VERB	VTI	Mood=Ind|Tense=Past	14	conj	_	_
 28	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	27	nsubj	_	_
@@ -3603,16 +3603,16 @@
 6	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	ccomp	_	_
 7	tú	tú	PRON	Pers	Number=Sing|Person=2	6	nsubj	_	_
 8	chun	chun	ADP	Simp	_	12	case	_	_
-9	ionad	ionad	NOUN	Noun	Gender=Masc|Number=Sing	12	obj	_	_
+9	ionad	ionad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
 10	siamsaíochta	siamsaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
 11	a	a	PART	Inf	PartType=Inf	12	mark	_	_
 12	thógáil	tógáil	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	cheantar	ceantar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+14	cheantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 15	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	14	acl:relcl	_	_
 16	léirithe	léirithe	ADJ	Adj	VerbForm=Part	15	xcomp:pred	_	_
 17	sa	i	ADP	Art	Number=Sing|PronType=Art	18	case	_	_
-18	ghrianghraf	grianghraf	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
+18	ghrianghraf	grianghraf	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 597
@@ -3621,7 +3621,7 @@
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	an-chóngarach	an-chóngarach	ADJ	Adj	Degree=Pos	1	advmod	_	_
 4	don	do	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+5	bhaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 8	mé	mé	PRON	Pers	Number=Sing|Person=1	7	nsubj	_	_
@@ -3644,7 +3644,7 @@
 8	sin	sin	DET	Det	PronType=Dem	7	det	_	_
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	chéidh	céidh	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
+11	chéidh	céidh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	nDeisceart	deisceart	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
@@ -3663,7 +3663,7 @@
 2	Íosa	Íosa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	iarracht	iarracht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	shólás	sólás	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	3	nmod	_	_
+5	shólás	sólás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 8	dóibh	do	ADP	Prep	Number=Plur|Person=3	7	obl:prep	_	SpaceAfter=No
@@ -3676,10 +3676,10 @@
 15	saol	saol	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 16	sibh	sibh	PRON	Pers	Number=Plur|Person=2	11	obj	_	_
 17	gan	gan	ADP	Simp	_	18	case	_	_
-18	sparán	sparán	NOUN	Noun	Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
+18	sparán	sparán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
 20	ná	ná	CCONJ	Coord	_	21	cc	_	_
-21	mála	mála	NOUN	Noun	Gender=Masc|Number=Sing	18	conj	_	SpaceAfter=No
+21	mála	mála	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	conj	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
 23	ná	ná	CCONJ	Coord	_	24	cc	_	_
 24	bróga	bróg	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	18	conj	_	_
@@ -3702,14 +3702,14 @@
 5	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
 6	de	de	ADP	Cmpd	PrepForm=Cmpd	8	case	_	_
 7	réir	réir	ADP	Cmpd	PrepForm=Cmpd	6	fixed	_	_
-8	Acht	acht	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
+8	Acht	acht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	NamedEntity=Yes
 9	Parlaiminte	parlaimint	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes
 10	i	i	ADP	Simp	_	11	case	_	_
 11	1854	1854	NUM	Num	_	1	obl:tmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	osclaíodh	oscail	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 14	don	do	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	phobal	pobal	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+15	phobal	pobal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 16	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	obj	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
 18	1864	1864	NUM	Num	_	13	obl:tmod	_	SpaceAfter=No
@@ -3719,12 +3719,12 @@
 # text = Seasaim le balla trasna uathu dá bhféachaint nóiméad.
 1	Seasaim	seas	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
 2	le	le	ADP	Simp	_	3	case	_	_
-3	balla	balla	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+3	balla	balla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 4	trasna	trasna	ADV	_	_	1	advmod	_	_
 5	uathu	ó	ADP	Prep	Number=Plur|Person=3	1	obl:prep	_	_
 6	dá	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes	7	case	_	_
 7	bhféachaint	féachaint	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	1	obl	_	_
-8	nóiméad	nóiméad	NOUN	Noun	Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
+8	nóiméad	nóiméad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl:tmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 602
@@ -3756,7 +3756,7 @@
 14	fulaingt	fulaingt	NOUN	Noun	VerbForm=Vnoun	12	xcomp	_	_
 15	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	case	_	_
 16	chodladh	codladh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
-17	fém	fém	NOUN	Noun	Gender=Fem|Number=Sing	16	nmod	_	_
+17	fém	fém	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	nmod	_	_
 18	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	obl:prep	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
 20	agus	agus	CCONJ	Coord	_	21	cc	_	_
@@ -3777,7 +3777,7 @@
 35	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	nmod:poss	_	_
 36	uillinneacha	uillinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Strong|Number=Plur	34	nmod	_	_
 37	sa	i	ADP	Art	Number=Sing|PronType=Art	38	case	_	_
-38	chloch	cloch	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	32	obl	_	SpaceAfter=No
+38	chloch	cloch	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	32	obl	_	SpaceAfter=No
 39	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 604
@@ -3795,7 +3795,7 @@
 4	rá	rá	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 5	go	go	PART	Vb	PartType=Cmpl	7	mark:prt	_	_
 6	mb'	is	AUX	Cop	Form=Ecl,VF|Tense=Past|VerbForm=Cop	7	cop	_	SpaceAfter=No
-7	fhiú	fiú	NOUN	Subst	Form=Len|Number=Sing	2	ccomp	_	_
+7	fhiú	fiú	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	2	ccomp	_	_
 8	aird	aird	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obj	_	_
 9	a	a	PART	Inf	PartType=Inf	10	mark	_	_
 10	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	7	csubj:cop	_	_
@@ -3804,7 +3804,7 @@
 13	scéal	scéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	_
 14	faoi	faoi	ADP	Simp	_	16	case	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	jabanna	jab	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
+16	jabanna	jab	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
 18	gCorcaigh	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	16	nmod	_	SpaceAfter=No
 19	;	;	PUNCT	Punct	_	21	punct	_	_
@@ -3876,9 +3876,9 @@
 16	tír	tír	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	19	punct	_	_
 18	ó	ó	ADP	Simp	_	19	case	_	_
-19	thuaith	tuath	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	14	conj	_	_
+19	thuaith	tuath	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	conj	_	_
 20	go	go	ADP	Simp	_	21	case	_	_
-21	tuaith	tuath	NOUN	Noun	Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
+21	tuaith	tuath	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	ó	ó	ADP	Simp	_	24	case	_	_
 24	thriúcha	triúcha	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	14	conj	_	_
@@ -3886,9 +3886,9 @@
 26	triúcha	triúcha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	29	punct	_	_
 28	ó	ó	ADP	Simp	_	29	case	_	_
-29	bhaile	baile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
+29	bhaile	baile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
 30	go	go	ADP	Simp	_	31	case	_	_
-31	baile	baile	NOUN	Noun	Gender=Masc|Number=Sing	29	nmod	_	SpaceAfter=No
+31	baile	baile	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	34	punct	_	_
 33	ó	ó	ADP	Simp	_	34	case	_	_
 34	thigh	teach	NOUN	Noun	Case=Dat|Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
@@ -3896,22 +3896,22 @@
 36	tigh	teach	NOUN	Noun	Case=Dat|Gender=Masc|Number=Sing	34	nmod	_	SpaceAfter=No
 37	,	,	PUNCT	Punct	_	39	punct	_	_
 38	ó	ó	ADP	Simp	_	39	case	_	_
-39	bhothán	bothán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
+39	bhothán	bothán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
 40	go	go	ADP	Simp	_	41	case	_	_
-41	bothán	bothán	NOUN	Noun	Gender=Masc|Number=Sing	39	nmod	_	SpaceAfter=No
+41	bothán	bothán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	39	nmod	_	SpaceAfter=No
 42	,	,	PUNCT	Punct	_	39	punct	_	_
 43	agus	agus	CCONJ	Coord	_	45	cc	_	_
 44	ó	ó	ADP	Simp	_	45	case	_	_
-45	phosta	post	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
+45	phosta	post	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	conj	_	_
 46	go	go	ADP	Simp	_	47	case	_	_
-47	piléar	piléar	NOUN	Noun	Gender=Masc|Number=Sing	45	nmod	_	SpaceAfter=No
+47	piléar	piléar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	nmod	_	SpaceAfter=No
 48	,	,	PUNCT	Punct	_	50	punct	_	_
 49	i	i	ADP	Simp	_	50	case	_	_
 50	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	52	nmod	_	_
 51	a	a	PART	Vb	PartType=Vb|PronType=Rel	52	nsubj	_	_
 52	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	11	xcomp	_	_
 53	'na	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	54	case	_	_
-54	mháistir	máistir	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	52	xcomp:pred	_	_
+54	mháistir	máistir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	52	xcomp:pred	_	_
 55	scoile	scoil	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	54	nmod	_	SpaceAfter=No
 56	,	,	PUNCT	Punct	_	57	punct	_	_
 57	ag	ag	ADP	Simp	_	58	case	_	_
@@ -3928,9 +3928,9 @@
 68	,	,	PUNCT	Punct	_	71	punct	_	_
 69	in	in	ADP	Cmpd	PrepForm=Cmpd	71	case	_	_
 70	aghaidh	aghaidh	ADP	Cmpd	PrepForm=Cmpd	69	fixed	_	_
-71	ceartdhlí	ceartdlí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	52	nmod	_	_
+71	ceartdhlí	ceartdlí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	52	nmod	_	_
 72	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	73	det	_	_
-73	bhfáidhe	fáidh	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	71	nmod	_	_
+73	bhfáidhe	fáidh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	71	nmod	_	_
 74	agus	agus	CCONJ	Coord	_	76	cc	_	_
 75	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	76	det	_	_
 76	bhfíorollún	fíorollamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	73	conj	_	SpaceAfter=No
@@ -3938,10 +3938,10 @@
 78	agus	agus	CCONJ	Coord	_	79	cc	_	_
 79	contrárdha	contrárdha	ADJ	Adj	Degree=Pos	71	conj	_	_
 80	do	do	ADP	Simp	_	81	case	_	_
-81	rialacha	riail	NOUN	Noun	Gender=Fem|Number=Plur	79	obl	_	_
+81	rialacha	riail	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	79	obl	_	_
 82	léinn	léann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	81	nmod	_	_
 83	agus	agus	CCONJ	Coord	_	86	cc	_	_
-84	lán	lán	NOUN	Noun	Gender=Masc|Number=Sing	71	conj	_	_
+84	lán	lán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	71	conj	_	_
 85	fhoghlamtha	foghlamtha	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	84	amod	_	_
 86	chúirte	cúirt	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	81	nmod	_	_
 87	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	89	det	_	_
@@ -3964,7 +3964,7 @@
 9	ocsaigin	ocsaigin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obj	_	_
 10	do	do	ADP	Simp	_	12	case	_	_
 11	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	12	det	_	_
-12	fíocháin	fíochán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	SpaceAfter=No
+12	fíocháin	fíochán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	obl	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 609
@@ -3972,7 +3972,7 @@
 1	Buailimid	buail	VERB	PresInd	Mood=Ind|Number=Plur|Person=1|Tense=Pres	0	root	_	_
 2	leis	le	ADP	Simp	_	4	case	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	bhfeiniméan	feiniméan	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+4	bhfeiniméan	feiniméan	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 5	céanna	céanna	ADJ	Adj	Gender=Masc|Number=Sing	4	amod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	8	punct	_	_
 7	'	'	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
@@ -3991,13 +3991,13 @@
 20	á	do	ADP	Poss	Person=3|PronType=Prs	21	case	_	_
 21	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	19	xcomp	_	_
 22	san	i	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	earrach	earrach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
+23	earrach	earrach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	21	obl	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	26	punct	_	_
 25	i	i	ADP	Simp	_	26	case	_	_
-26	gcuntas	cuntas	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+26	gcuntas	cuntas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 27	suntasach	suntasach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	26	amod	_	_
 28	ó	ó	ADP	Simp	_	29	case	_	_
-29	Chontae	contae	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
+29	Chontae	contae	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
 30	Loch	Loch	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes
 31	Garman	Garman	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	NamedEntity=Yes|SpaceAfter=No
 32	:	:	PUNCT	Punct	_	1	punct	_	SpaceAfter=No
@@ -4006,11 +4006,11 @@
 # sent_id = 610
 # text = nó deimhnithe imréitigh cánach arna eisiúint ag na Coimisinéirí Ioncaim... a chur ar fáil.
 1	nó	nó	CCONJ	Coord	_	2	cc	_	_
-2	deimhnithe	deimhniú	NOUN	Noun	Gender=Masc|Number=Plur	13	obj	_	_
+2	deimhnithe	deimhniú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	13	obj	_	_
 3	imréitigh	imréiteach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
 4	cánach	cáin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
 5	arna	ar	ADP	Poss	Number=Plur|Person=3|Poss=Yes	6	case	_	_
-6	eisiúint	eisiúint	NOUN	Noun	Definite=Def|VerbForm=Inf	2	nmod	_	_
+6	eisiúint	eisiúint	NOUN	Noun	Case=NomAcc|Definite=Def|VerbForm=Inf	2	nmod	_	_
 7	ag	ag	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	Coimisinéirí	coimisinéir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	obl	_	NamedEntity=Yes
@@ -4029,7 +4029,7 @@
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
 4	tharraing	tarraing	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 5	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
-6	bosca	bosca	NOUN	Noun	Gender=Masc|Number=Sing	4	obj	_	_
+6	bosca	bosca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	obj	_	_
 7	chuige	chuig	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4053,7 +4053,7 @@
 2	amháin	amháin	ADJ	Adj	Degree=Pos	1	amod	_	_
 3	a	a	PART	Vb	PartType=Vb|PronType=Rel	4	mark:prt	_	_
 4	thabharfas	tabhair	VERB	VTI	Form=Len|Mood=Ind|PronType=Rel|Tense=Fut	1	csubj:cleft	_	_
-5	aire	aire	NOUN	Noun	Gender=Fem|Number=Sing	4	obj	_	_
+5	aire	aire	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obj	_	_
 6	dó	do	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -4099,7 +4099,7 @@
 11	Ogedei	Ogedei	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	10	nsubj	_	_
 12	bás	bás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obj	_	_
 13	(	(	PUNCT	Punct	_	14	punct	_	SpaceAfter=No
-14	mac	mac	NOUN	Noun	Gender=Masc|Number=Sing	11	appos	_	_
+14	mac	mac	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	appos	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
 16	Geingeas	Geingeas	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Cán	Cán	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
@@ -4149,12 +4149,12 @@
 5	éifeacht	éifeacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	xcomp:pred	_	_
 6	uathoibríoch	uathoibríoch	ADJ	Adj	Gender=Fem|Number=Sing	5	amod	_	_
 7	le	le	ADP	Simp	_	10	case	_	_
-8	hachomharc	achomharc	NOUN	Noun	Form=HPref|Gender=Masc|Number=Sing	10	obj	_	_
+8	hachomharc	achomharc	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	10	obj	_	_
 9	a	a	PART	Inf	PartType=Inf	10	mark	_	_
 10	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	3	xcomp	_	_
 11	i	i	ADP	Cmpd	PrepForm=Cmpd	13	case	_	_
 12	gcoinne	gcoinne	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	11	fixed	_	_
-13	fógra	fógra	NOUN	Noun	Gender=Masc|Number=Sing	10	nmod	_	_
+13	fógra	fógra	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	obl	_	_
 14	toirmisc	toirmeasc	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	_
 15	de	de	ADP	Cmpd	PrepForm=Cmpd	17	case	_	_
 16	réir	réir	ADP	Cmpd	PrepForm=Cmpd	15	fixed	_	_
@@ -4170,7 +4170,7 @@
 26	féadfaidh	féad	VERB	VTI	Mood=Ind|Tense=Fut	3	advcl	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 28	t-achomharcóir	achomharcóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nsubj	_	_
-29	iarratas	iarratas	NOUN	Noun	Gender=Masc|Number=Sing	31	obj	_	_
+29	iarratas	iarratas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	obj	_	_
 30	a	a	PART	Inf	PartType=Inf	31	mark	_	_
 31	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	26	xcomp	_	_
 32	chuig	chuig	ADP	Simp	_	34	case	_	_
@@ -4179,7 +4179,7 @@
 35	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	36	case	_	_
 36	chur	cur	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	31	nmod	_	_
 37	faoi	faoi	ADP	Simp	_	38	case	_	_
-38	deara	deara	NOUN	Subst	Number=Sing	31	nmod	_	_
+38	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	31	nmod	_	_
 39	oibriú	oibriú	NOUN	Noun	Definite=Def|VerbForm=Inf	43	obj	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
 41	fhógra	fógra	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	39	nmod	_	_
@@ -4293,13 +4293,13 @@
 # text = Ach i bhfógra a foilsíodh ag dream darb ainm, 'Education First', sna páipéir Bhéarla, an tseachtain seo caite, cuirtear i leith an Aire Oideachais, Máirtín Mac Aonghusa, nach leor an rogha a bheith ag tuismitheoirí cé acu scoil a rachaidh a bpáistí uirthi.
 1	Ach	ach	SCONJ	Subord	_	25	mark	_	_
 2	i	i	ADP	Simp	_	3	case	_	_
-3	bhfógra	fógra	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
+3	bhfógra	fógra	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	25	obl	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	obj	_	_
 5	foilsíodh	foilsigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	3	acl:relcl	_	_
 6	ag	ag	ADP	Simp	_	7	case	_	_
 7	dream	dream	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 8	darb	dar	SCONJ	Subord	Form=VF|VerbForm=Cop	9	mark	_	_
-9	ainm	ainm	NOUN	Noun	Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
+9	ainm	ainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	'	'	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 12	Education	Education	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	7	appos	_	_
@@ -4307,7 +4307,7 @@
 14	'	'	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	12	punct	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
-17	páipéir	páipéar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
+17	páipéir	páipéar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
 18	Bhéarla	Béarla	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
@@ -4319,7 +4319,7 @@
 26	i	i	ADP	Simp	_	27	case	_	_
 27	leith	leith	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	25	obl	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
-29	Aire	aire	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
+29	Aire	aire	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
 30	Oideachais	oideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	29	nmod	_	NamedEntity=Yes|SpaceAfter=No
 31	,	,	PUNCT	Punct	_	32	punct	_	_
 32	Máirtín	Máirtín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	29	appos	_	NamedEntity=Yes
@@ -4333,7 +4333,7 @@
 40	a	a	PART	Inf	PartType=Inf	41	mark	_	_
 41	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	37	csubj:cop	_	_
 42	ag	ag	ADP	Simp	_	43	case	_	_
-43	tuismitheoirí	tuismitheoir	NOUN	Noun	Gender=Masc|Number=Plur	41	xcomp:pred	_	_
+43	tuismitheoirí	tuismitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	41	xcomp:pred	_	_
 44	cé	cé	PRON	Q	PronType=Int	46	nmod	_	_
 45	acu	ag	ADP	Prep	Number=Plur|Person=3	44	obl:prep	_	_
 46	scoil	scoil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	37	nmod	_	_
@@ -4367,7 +4367,7 @@
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
 2	bháine	báine	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 3	idir	idir	ADP	Simp	_	4	case	_	_
-4	dhúch	dúch	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+4	dhúch	dúch	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
 6	bhfocal	focal	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	4	nmod	_	_
 7	mar	mar	SCONJ	Subord	_	9	mark	_	_
@@ -4378,7 +4378,7 @@
 12	ag	ag	ADP	Simp	_	13	case	_	_
 13	trilsiú	trilsiú	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 14	trí	trí	ADP	Simp	_	15	case	_	_
-15	fholt	folt	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
+15	fholt	folt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	obl	_	_
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	gcrann	crann	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Weak|Number=Plur	15	nmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	_	_
@@ -4417,7 +4417,7 @@
 15	Johanna	Johanna	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	12	conj	_	NamedEntity=Yes
 16	McInerney	McInerney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 17	,	,	PUNCT	Punct	_	18	punct	_	_
-18	Teach	teach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+18	Teach	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 19	Cheeverstown	Cheeverstown	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Baile	Baile	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
@@ -4436,8 +4436,8 @@
 7	fúithe	faoi	ADP	Prep	Gender=Fem|Number=Sing|Person=3	6	obl:prep	_	_
 8	nó	nó	CCONJ	Coord	_	10	cc	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
-10	samhailt	samhailt	NOUN	Noun	Gender=Fem|Number=Sing	6	conj	_	_
-11	pisreog	pisreog	NOUN	Noun	Gender=Fem|Number=Sing	10	obj	_	_
+10	samhailt	samhailt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
+11	pisreog	pisreog	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	10	obj	_	_
 12	léithe	le	ADP	Prep	Gender=Fem|Number=Sing|Person=3	10	obl:prep	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	15	punct	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
@@ -4465,11 +4465,11 @@
 7	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	2	csubj:cop	_	_
 8	spéis	spéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	nsubj	_	_
 9	ag	ag	ADP	Simp	_	10	case	_	_
-10	bunáite	bunáite	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
+10	bunáite	bunáite	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	7	obl	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	vótóirí	vótóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
+12	vótóirí	vótóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	10	nmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	mionfhorálacha	mionfhoráil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	7	obl	_	_
+14	mionfhorálacha	mionfhoráil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	7	obl	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
 16	Chonartha	conradh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	_	_
@@ -4485,7 +4485,7 @@
 7	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	10	cop	_	_
 8	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	10	nmod	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	gath	gath	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
+10	gath	gath	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 11	ba	is	PART	Sup	PartType=Sup|Tense=Past|VerbForm=Cop	19	mark:prt	_	_
 12	ghile	geal	ADJ	Adj	Degree=Cmp,Sup|Form=Len	10	amod	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
@@ -4540,20 +4540,20 @@
 # sent_id = 635
 # text = I gceantar Anagaire mar shampla tá ar a laghad deich mbaile fearainn nach dtugtar aitheantas díobhtha i seoladh an vótóra rud a chiallaíonn go mbíonn an seoladh poist céanna ag na vótóirí uilig.
 1	I	I	ADP	Simp	_	2	case	_	_
-2	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
+2	gceantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	6	obl	_	_
 3	Anagaire	Anagaire	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 4	mar	mar	ADP	Simp	_	5	case	_	_
-5	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+5	shampla	sampla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 7	ar	ar	ADP	Simp	_	6	advmod	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	7	fixed	_	_
-9	laghad	laghad	NOUN	Noun	Gender=Masc|Number=Sing	7	fixed	_	_
+9	laghad	laghad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	fixed	_	_
 10	deich	deich	NUM	Num	NumType=Card	11	nummod	_	_
 11	mbaile	baile	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	6	nsubj	_	_
 12	fearainn	fearann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	compound	_	_
 13	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
 14	dtugtar	tabhair	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	6	ccomp	_	_
-15	aitheantas	aitheantas	NOUN	Noun	Gender=Masc|Number=Sing	14	obj	_	_
+15	aitheantas	aitheantas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	obj	_	_
 16	díobhtha	de	ADP	Prep	Number=Plur|Person=3	14	obl:prep	_	_
 17	i	i	ADP	Simp	_	18	case	_	_
 18	seoladh	seoladh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	_
@@ -4570,7 +4570,7 @@
 29	céanna	céanna	ADJ	Adj	Degree=Pos	27	amod	_	_
 30	ag	ag	ADP	Simp	_	32	case	_	_
 31	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	32	det	_	_
-32	vótóirí	vótóir	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	25	obl	_	_
+32	vótóirí	vótóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	25	obl	_	_
 33	uilig	uile	DET	Det	_	32	det	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -4608,7 +4608,7 @@
 16	ar	ar	ADP	Simp	_	17	case	_	_
 17	fáil	fáil	NOUN	Noun	VerbForm=Inf	15	xcomp	_	_
 18	do	do	ADP	Simp	_	19	case	_	_
-19	chompántais	compántas	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	15	obl	_	_
+19	chompántais	compántas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	15	obl	_	_
 20	ceoldrámaíochta	ceoldrámaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
 21	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	19	acl:relcl	_	_
 22	ag	ag	ADP	Simp	_	23	case	_	_
@@ -4627,7 +4627,7 @@
 35	n-éiríonn	éirigh	VERB	VI	Form=Ecl|Mood=Ind|Tense=Pres	23	conj	_	_
 36	leo	le	ADP	Prep	Number=Plur|Person=3	35	obl:prep	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
-38	caighdeáin	caighdeán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	41	obj	_	_
+38	caighdeáin	caighdeán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	41	obj	_	_
 39	seo	seo	DET	Det	PronType=Dem	38	det	_	_
 40	a	a	PART	Inf	PartType=Inf	41	mark	_	_
 41	bhaint	baint	NOUN	Noun	Form=Len|VerbForm=Inf	35	xcomp	_	_
@@ -4642,7 +4642,7 @@
 50	ar	ar	ADP	Simp	_	51	case	_	_
 51	fáil	fáil	NOUN	Noun	VerbForm=Inf	49	xcomp	_	_
 52	chun	chun	ADP	Simp	_	59	case	_	_
-53	ceoldrámaí	ceoldráma	NOUN	Noun	Gender=Masc|Number=Plur	59	obj	_	_
+53	ceoldrámaí	ceoldráma	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	59	obj	_	_
 54	nua	nua	ADJ	Adj	Degree=Pos	53	amod	_	_
 55	agus	agus	CCONJ	Coord	_	59	cc	_	_
 56	tionscnaimh	tionscnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	53	conj	_	_
@@ -4661,11 +4661,11 @@
 6	féin	féin	PRON	Ref	Reflex=Yes	5	nmod	_	_
 7	agus	agus	CCONJ	Coord	_	9	cc	_	_
 8	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	nmod:poss	_	_
-9	bheithíoch	beithíoch	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
+9	bheithíoch	beithíoch	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
 10	féin	féin	PRON	Ref	Reflex=Yes	9	nmod	_	_
 11	ag	ag	ADP	Simp	_	13	case	_	_
 12	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	13	det	_	_
-13	chréatúr	créatúr	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
+13	chréatúr	créatúr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 14	!	!	PUNCT	!	_	2	punct	_	_
 
 # sent_id = 639
@@ -4741,7 +4741,7 @@
 9	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
 10	gréine	grian	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	íomhá	íomhá	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	6	obj	_	_
+12	íomhá	íomhá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	6	obj	_	_
 13	go	go	PART	Ad	PartType=Ad	14	mark:prt	_	_
 14	léir	léir	ADJ	Adj	Degree=Pos	12	amod	_	_
 15	agus	agus	CCONJ	Coord	_	17	cc	_	_
@@ -4752,7 +4752,7 @@
 20	chuairteora	cuairteoir	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	aonair	aonar	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	_
 22	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	case	_	_
-23	chuislí	cuisle	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	17	obl	_	SpaceAfter=No
+23	chuislí	cuisle	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	17	obl	_	SpaceAfter=No
 24	:	:	PUNCT	Punct	_	25	punct	_	_
 25	cloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	parataxis	_	_
 26	gearrtha	gearrtha	ADJ	Adj	VerbForm=Part	25	amod	_	_
@@ -4762,7 +4762,7 @@
 30	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	25	csubj:cleft	_	_
 31	Héaród	Héaród	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	30	nsubj	_	_
 32	nó	nó	CCONJ	Coord	_	33	cc	_	_
-33	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	31	conj	_	_
+33	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	conj	_	_
 34	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	33	amod	_	_
 35	a	a	ADP	Simp	_	36	case	_	_
 36	iompar	iompar	NOUN	Noun	VerbForm=Inf	30	xcomp	_	_
@@ -4793,7 +4793,7 @@
 61	glinnradharcach	glinnradharcach	ADJ	Adj	_	60	amod	_	_
 62	duaisiúil	duaisiúil	ADJ	Adj	Degree=Pos	60	amod	_	_
 63	gan	gan	ADP	Simp	_	64	case	_	_
-64	chorraí	corraí	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	60	nmod	_	SpaceAfter=No
+64	chorraí	corraí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	60	nmod	_	SpaceAfter=No
 65	,	,	PUNCT	Punct	_	66	punct	_	_
 66	ag	ag	ADP	Simp	_	67	case	_	_
 67	stánadh	stánadh	NOUN	Noun	VerbForm=Vnoun	55	xcomp	_	_
@@ -4832,7 +4832,7 @@
 20	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	21	det	_	_
 21	matamaitice	matamaitic	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	18	nmod	_	_
 22	i	i	ADP	Simp	_	23	case	_	_
-23	réimsí	réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
+23	réimsí	réimse	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
 24	eile	eile	DET	Det	PronType=Dem	26	det	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
 26	churaclaim	curaclam	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
@@ -4854,7 +4854,7 @@
 1	Gan	gan	ADP	Simp	_	2	case	_	_
 2	dochar	dochar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	_
 3	d'	do	ADP	Simp	_	4	case	_	SpaceAfter=No
-4	inniúlachtaí	inniúlacht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	2	nmod	_	_
+4	inniúlachtaí	inniúlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	2	nmod	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
 6	Chomhphobail	comhphobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	2	punct	_	_
@@ -4875,15 +4875,15 @@
 22	le	le	ADP	Simp	_	23	case	_	_
 23	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	20	obl	_	_
 24	trína	trí	ADP	Poss	Number=Plur|Person=3|Poss=Yes	25	case	_	_
-25	riaracháin	riarachán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	obl	_	_
+25	riaracháin	riarachán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	20	obl	_	_
 26	chustaim	custam	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
 27	d'	de	ADP	Simp	_	28	case	_	SpaceAfter=No
-28	fhonn	fonn	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
+28	fhonn	fonn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 29	:	:	PUNCT	Punct	_	37	punct	_	_
 30	-	-	PUNCT	Punct	_	37	punct	_	_
-31	sáruithe	sárú	NOUN	Noun	Gender=Masc|Number=Plur	37	obj	_	_
-32	ar	ar	ADP	Simp	_	37	case	_	_
-33	fhorálacha	foráil	NOUN	Noun	Form=Len|Gender=Fem|Number=Plur	31	nmod	_	_
+31	sáruithe	sárú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	37	obj	_	_
+32	ar	ar	ADP	Simp	_	33	case	_	_
+33	fhorálacha	foráil	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Plur	31	nmod	_	_
 34	náisiúnta	náisiúnta	ADJ	Adj	Gender=Masc|Number=Plur	33	amod	_	_
 35	custaim	custam	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	33	nmod	_	_
 36	a	a	PART	Inf	PartType=Inf	37	mark	_	_
@@ -4894,14 +4894,14 @@
 41	,	,	PUNCT	Punct	_	42	punct	_	_
 42	agus	agus	CCONJ	Coord	_	44	cc	_	_
 43	-	-	PUNCT	Punct	_	42	punct	_	_
-44	sáruithe	sárú	NOUN	Noun	Gender=Masc|Number=Plur	37	conj	_	_
+44	sáruithe	sárú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	37	conj	_	_
 45	ar	ar	ADP	Simp	_	46	case	_	_
-46	fhorálacha	foráil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	44	nmod	_	_
+46	fhorálacha	foráil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	44	nmod	_	_
 47	custaim	custam	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	46	nmod	_	_
 48	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	49	det	_	_
 49	Chomhphobail	comhphobal	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	nmod	_	_
 50	agus	agus	CCONJ	Coord	_	51	cc	_	_
-51	forálacha	foráil	NOUN	Noun	Gender=Fem|Number=Plur	46	conj	_	_
+51	forálacha	foráil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	46	conj	_	_
 52	náisiúnta	náisiúnta	ADJ	Adj	Gender=Masc|Number=Plur	51	amod	_	_
 53	custaim	custam	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	51	nmod	_	_
 54	a	a	PART	Inf	PartType=Inf	55	mark	_	_
@@ -4915,7 +4915,7 @@
 # text = Scorfar na fostaithe seo ag deireadh na seachtaine agus rachaidh an chuid eile den fhoireann ar sheachtain ghairid oibre ar an 26ú Márta.
 1	Scorfar	scoir	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 2	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	fostaithe	fostaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
+3	fostaithe	fostaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	ag	ag	ADP	Simp	_	6	case	_	_
 6	deireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
@@ -4964,7 +4964,7 @@
 22	son	son	ADP	Cmpd	PrepForm=Cmpd	21	fixed	_	_
 23	saor-Éireann	saor-Éire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	obl	_	_
 24	sna	i	ADP	Art	Number=Plur|PronType=Art	25	case	_	_
-25	Stáit	stát	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
+25	Stáit	stát	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 648
@@ -4984,10 +4984,10 @@
 1	Cuirfidh	cuir	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 2	gach	gach	DET	Det	Definite=Def	3	det	_	_
 3	imreoir	imreoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
-4	fáilte	fáilte	NOUN	Noun	Gender=Fem|Number=Sing	1	obj	_	_
+4	fáilte	fáilte	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 5	roimh	roimh	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
-7	gnéithe	gné	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	1	obl	_	_
+7	gnéithe	gné	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	1	obl	_	_
 8	nua	nua	ADJ	Adj	Degree=Pos	7	amod	_	_
 9	seo	seo	DET	Det	PronType=Dem	7	det	_	_
 10	ach	ach	SCONJ	Subord	_	11	mark	_	_
@@ -5004,7 +5004,7 @@
 21	tarlaithe	tarlaithe	ADJ	Adj	VerbForm=Part	17	xcomp:pred	_	_
 22	murach	murach	SCONJ	Subord	_	24	mark	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	brú	brú	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
+24	brú	brú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obj	_	_
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	obj	_	_
 26	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	17	xcomp	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
@@ -5024,7 +5024,7 @@
 # text = Aithnítear gur gné thábhachtach i bhforbairt an fhórsa saothair go bhféadfar teacht ar na haltraí rollaithe atá ag iarraidh an cúrsa cláraithe a dhéanamh agus cuidiú leo sin a dhéanamh.
 1	Aithnítear	aithin	VERB	VT	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
-3	gné	gné	NOUN	Noun	Gender=Fem|Number=Sing	1	ccomp	_	_
+3	gné	gné	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	ccomp	_	_
 4	thábhachtach	tábhachtach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	3	amod	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
 6	bhforbairt	forbairt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	3	nmod	_	_
@@ -5042,7 +5042,7 @@
 18	ag	ag	ADP	Simp	_	19	case	_	_
 19	iarraidh	iarraidh	NOUN	Noun	VerbForm=Vnoun	17	xcomp	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	cúrsa	cúrsa	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
+21	cúrsa	cúrsa	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
 22	cláraithe	cláraithe	ADJ	Adj	VerbForm=Part	21	amod	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	11	xcomp	_	_
@@ -5060,7 +5060,7 @@
 2	ansin	ansin	ADV	Loc	_	3	advmod	_	_
 3	chuala	clois	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
-5	ardséideadh	ardséideadh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
+5	ardséideadh	ardséideadh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	dtrumpaí	trumpa	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	5	nmod	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	_	_
@@ -5070,7 +5070,7 @@
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
 2	crochadh	croch	VERB	PastInd	Mood=Ind|Person=0|Tense=Past	0	root	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	tUrramhach	urramach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	2	obj	_	NamedEntity=Yes
+4	tUrramhach	urramach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	2	obj	_	NamedEntity=Yes
 5	James	James	PROPN	Noun	Definite=Def	4	flat	_	NamedEntity=Yes
 6	Porter	Porter	PROPN	Noun	Definite=Def	5	flat:name	_	NamedEntity=Yes
 7	láimh	lámh	NOUN	Noun	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing	2	obl	_	_
@@ -5118,14 +5118,14 @@
 2	té	té	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	parataxis	_	_
 3	ná	nach	PART	Vb	Dialect=Munster|PartType=Vb|PronType=Rel	4	nsubj	_	_
 4	taithíonn	taithigh	VERB	VTI	Mood=Ind|Tense=Pres	2	acl:relcl	_	_
-5	mná	bean	NOUN	Noun	Gender=Fem|Number=Plur	7	obj	_	_
+5	mná	bean	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	7	obj	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	4	xcomp	_	_
 8	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	7	obl:prep	_	_
 9	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	10	advmod	_	_
 10	thaithíonn	taithigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	0	root	_	_
 11	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	10	nsubj	_	_
-12	mná	bean	NOUN	Noun	Gender=Fem|Number=Plur	14	obj	_	_
+12	mná	bean	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	14	obj	_	_
 13	a	a	PART	Inf	PartType=Inf	14	mark	_	_
 14	chailliúint	cailliúint	NOUN	Noun	Form=Len|VerbForm=Inf	10	xcomp	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	10	punct	_	_
@@ -5143,7 +5143,7 @@
 9	is	is	PART	Sup	PartType=Sup|Tense=Pres|VerbForm=Cop	19	mark:prt	_	_
 10	fearr	maith	ADJ	Adj	Degree=Cmp,Sup	8	amod	_	_
 11	ar	ar	ADP	Simp	_	10	nmod	_	_
-12	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	11	fixed	_	_
+12	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	fixed	_	_
 13	le	le	ADP	Simp	_	14	case	_	_
 14	hÉireannaigh	Éireannach	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	6	nmod	_	SpaceAfter=No
 15	;	;	PUNCT	Punct	_	16	punct	_	_
@@ -5155,7 +5155,7 @@
 21	móide	mór	ADJ	Adj	Degree=Cmp,Sup	17	ccomp	_	_
 22	go	go	PART	Vb	PartType=Cmpl	23	mark:prt	_	_
 23	ndéanfar	déan	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	21	csubj:cop	_	_
-24	dearmad	dearmad	NOUN	Noun	Gender=Masc|Number=Sing	23	obj	_	_
+24	dearmad	dearmad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	obj	_	_
 25	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	23	obl:prep	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -5168,10 +5168,10 @@
 5	iomlán	iomlán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	4	amod	_	_
 6	de	de	ADP	Simp	_	8	case	_	_
 7	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
-8	litreacha	litir	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	SpaceAfter=No
+8	litreacha	litir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	SpaceAfter=No
 9	:	:	PUNCT	Punct	_	11	punct	_	_
 10	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	11	cop	_	_
-11	saothar	saothar	NOUN	Noun	Gender=Masc|Number=Sing	3	parataxis	_	_
+11	saothar	saothar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	parataxis	_	_
 12	lae	lá	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	_
 13	eile	eile	DET	Det	PronType=Dem	14	det	_	_
 14	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	11	nsubj	_	_
@@ -5181,7 +5181,7 @@
 18	mhéad	méad	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nsubj	_	_
 19	de	de	ADP	Simp	_	21	case	_	_
 20	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	21	det	_	_
-21	litreacha	litir	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	17	nmod	_	_
+21	litreacha	litir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	17	nmod	_	_
 22	seo	seo	DET	Det	PronType=Dem	21	det	_	_
 23	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	obj	_	_
 24	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	21	acl:relcl	_	_
@@ -5194,9 +5194,9 @@
 31	a	a	PART	Vb	PartType=Vb|PronType=Rel	32	mark:prt	_	_
 32	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	29	csubj:cleft	_	_
 33	ag	ag	ADP	Simp	_	34	case	_	_
-34	folach	folach	NOUN	Noun	Gender=Masc|Number=Sing	32	xcomp	_	_
+34	folach	folach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	xcomp	_	_
 35	faoi	faoi	ADP	Simp	_	36	case	_	_
-36	ainmneacha	ainm	NOUN	Noun	Definite=Ind|Gender=Masc|Number=Plur	32	obl	_	_
+36	ainmneacha	ainm	NOUN	Noun	Case=NomAcc|Definite=Ind|Gender=Masc|Number=Plur	32	obl	_	_
 37	cleite	cleite	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	11	punct	_	_
 
@@ -5207,12 +5207,12 @@
 3	ag	ag	ADP	Simp	_	4	case	_	_
 4	brionglóidigh	brionglóideach	NOUN	Noun	Case=Dat|Gender=Fem|Number=Sing	1	xcomp	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	oíche	oíche	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
+6	oíche	oíche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 7	go	go	PART	Vb	PartType=Cmpl	8	mark:prt	_	_
 8	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 9	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nsubj	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	bord	bord	NOUN	Noun	Gender=Masc|Number=Sing	8	obl	_	_
+11	bord	bord	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obl	_	_
 12	loinge	long	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	11	nmod	_	_
 13	agus	agus	SCONJ	Subord	_	14	mark	_	_
 14	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	8	advcl	_	_
@@ -5220,7 +5220,7 @@
 16	síobadh	síobadh	NOUN	Noun	VerbForm=Vnoun	14	xcomp:pred	_	_
 17	mara	muir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	obj	_	_
 18	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	bord	bord	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
+19	bord	bord	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	SpaceAfter=No
 20	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 658
@@ -5240,7 +5240,7 @@
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	PronType=Art	15	det	_	_
 15	Laighnigh	Laighneach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	obl	_	_
-16	cúl	cúl	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
+16	cúl	cúl	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obj	_	_
 17	cinniúnach	cinniúnach	ADJ	Adj	Degree=Pos	16	amod	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	ghnóthú	gnóthú	NOUN	Noun	Form=Len|VerbForm=Inf	12	xcomp	_	_
@@ -5260,7 +5260,7 @@
 3	ort	ar	ADP	Prep	Number=Sing|Person=2	1	obl:prep	_	_
 4	titim	titim	NOUN	Noun	VerbForm=Inf	1	obj	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	ngrá	grá	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	4	nmod	_	_
+6	ngrá	grá	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	4	nmod	_	_
 7	liom	le	ADP	Prep	Number=Sing|Person=1	4	obl:prep	_	_
 8	tar	tar	ADP	Cmpd	PrepForm=Cmpd	11	case	_	_
 9	éis	éis	ADP	Cmpd	PrepForm=Cmpd	8	fixed	_	_
@@ -5279,7 +5279,7 @@
 # text = Ar an ábhar sin, ba chóir bheith ag smaoineamh ar straitéisí nua maidir le múineadh na teanga.
 1	Ar	ar	ADP	Simp	_	3	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	ábhar	ábhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
+3	ábhar	ábhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 4	sin	sin	DET	Det	PronType=Dem	3	det	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	3	punct	_	_
 6	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	7	cop	_	_
@@ -5288,7 +5288,7 @@
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	smaoineamh	smaoineamh	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 11	ar	ar	ADP	Simp	_	12	case	_	_
-12	straitéisí	straitéis	NOUN	Noun	Gender=Fem|Number=Plur	10	obl	_	_
+12	straitéisí	straitéis	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	10	obl	_	_
 13	nua	nua	ADJ	Adj	Degree=Pos	12	amod	_	_
 14	maidir	maidir	ADP	CmpdNoGen	_	16	case	_	_
 15	le	le	ADP	CmpdNoGen	_	14	fixed	_	_
@@ -5307,7 +5307,7 @@
 6	seachtaine	seachtain	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	5	compound	_	_
 7	Gaelach	gaelach	ADJ	Adj	Degree=Pos	5	amod	_	_
 8	i	i	ADP	Simp	_	9	case	_	_
-9	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+9	gceantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 10	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
 11	scoile	scoil	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
@@ -5331,7 +5331,7 @@
 10	Dhónaill	Dónall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	Bhrocaigh	Brocach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	-	-	PUNCT	Punct	_	13	punct	_	_
-13	cupla	cupla	NOUN	Noun	Gender=Masc|Number=Plur	2	parataxis	_	_
+13	cupla	cupla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	parataxis	_	_
 14	deoch	deoch	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	16	punct	_	_
 16	sin	sin	PRON	Dem	PronType=Dem	2	parataxis	_	_
@@ -5345,7 +5345,7 @@
 1	Líonann	líon	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	suas	suas	ADV	Dir	_	1	advmod	_	_
-4	gloine	gloine	NOUN	Noun	Gender=Fem|Number=Sing	1	obj	_	_
+4	gloine	gloine	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 5	bhreá	breá	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	4	amod	_	_
 6	phint	pint	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 7	de	de	ADP	Prep	Gender=Masc|Number=Sing|Person=3	4	obl:prep	_	SpaceAfter=No
@@ -5355,15 +5355,15 @@
 11	stánadh	stánadh	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	boilgíní	boilgín	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
+14	boilgíní	boilgín	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	11	obl	_	_
 15	sa	i	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
-16	tsiúl	siúl	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
+16	tsiúl	siúl	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
 18	éirí	éirí	NOUN	Noun	VerbForm=Vnoun	11	xcomp	_	_
 19	go	go	PART	Ad	PartType=Ad	20	mark:prt	_	_
 20	hingearach	ingearach	ADJ	Adj	Degree=Pos|Form=HPref	18	advmod	_	_
 21	sa	i	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
-22	ghloine	gloine	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	SpaceAfter=No
+22	ghloine	gloine	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	18	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 665
@@ -5443,7 +5443,7 @@
 6	cleachtadh	cleachtadh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	nsubj	_	_
 7	agam	ag	ADP	Prep	Number=Sing|Person=1	5	obl:prep	_	_
 8	ar	ar	ADP	Simp	_	11	case	_	_
-9	oíche	oíche	NOUN	Noun	Gender=Fem|Number=Sing	5	obl	_	_
+9	oíche	oíche	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
 10	a	a	PART	Inf	PartType=Inf	11	mark	_	_
 11	chaitheamh	caitheamh	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
@@ -5459,7 +5459,7 @@
 5	ag	ag	ADP	Simp	_	6	case	_	_
 6	Ascot	Ascot	PROPN	Noun	Definite=Def|Number=Sing	2	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	tseachain	seachtain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing|Typo=Yes	2	obl:tmod	_	_
+8	tseachain	seachtain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing|Typo=Yes	2	obl:tmod	_	_
 9	seo	seo	DET	Det	PronType=Dem	8	det	_	_
 10	caite	caite	ADJ	Adj	VerbForm=Part	9	fixed	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	_	_
@@ -5503,17 +5503,17 @@
 
 # sent_id = 673
 # text = Lá Mhaghnuis an Phíce, Lá na ngunnaí mór ar Loch Súilighe, Oídhche na Gaoithe Móire, Lá Ghleann Bheithe, An Lá a cuireadh Butt agus An Lá a d'éag Parnell (Rácáil agus Scuabadh (1955) 27).
-1	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	Mhaghnuis	Maghnus	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	Phíce	píce	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Lá	lá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
+6	Lá	lá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
 8	ngunnaí	gunna	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	6	nmod	_	_
 9	mór	mór	ADJ	Adj	Case=Gen|NounType=Weak|Number=Plur	8	amod	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	Loch	loch	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
+11	Loch	loch	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
 12	Súilighe	Súilighe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	Oídhche	oídhche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	conj	_	NamedEntity=Yes
@@ -5521,8 +5521,8 @@
 16	Gaoithe	gaoth	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Móire	mór	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Lá	lá	NOUN	Noun	Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
-20	Ghleann	gleann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+19	Lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
+20	Ghleann	gleann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Bheithe	beith	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -5550,7 +5550,7 @@
 # sent_id = 674
 # text = Faoi lár an 18ú aois baineadh úsáid fhorleathan as inneall Newcomen le huisce a chaidéalú.
 1	Faoi	faoi	ADP	Simp	_	2	case	_	_
-2	lár	lár	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
+2	lár	lár	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 4	18ú	18	NUM	Num	NumType=Ord	5	amod	_	_
 5	aois	aois	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	_
@@ -5558,10 +5558,10 @@
 7	úsáid	úsáid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	obj	_	_
 8	fhorleathan	forleathan	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	7	amod	_	_
 9	as	as	ADP	Simp	_	10	case	_	_
-10	inneall	inneall	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
+10	inneall	inneall	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 11	Newcomen	Newcomen	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 12	le	le	ADP	Simp	_	15	case	_	_
-13	huisce	uisce	NOUN	Noun	Form=HPref|Gender=Masc|Number=Sing	15	obj	_	_
+13	huisce	uisce	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Sing	15	obj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	chaidéalú	caidéalú	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	6	punct	_	_
@@ -5572,13 +5572,13 @@
 2	slad	slad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	ar	ar	ADP	Simp	_	5	case	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	ceantair	ceantar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
+5	ceantair	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 6	is	is	PART	Sup	PartType=Sup	7	mark:prt	_	_
 7	boichte	bocht	ADJ	Adj	Degree=Cmp,Sup	5	amod	_	_
 8	agus	agus	CCONJ	Coord	_	10	cc	_	_
 9	ní	is	AUX	Cop	Tense=Pres|VerbForm=Cop	11	cop	_	_
 10	de	de	ADP	Simp	_	11	case	_	_
-11	thaisme	taisme	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	1	conj	_	_
+11	thaisme	taisme	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	conj	_	_
 12	gur	is	PART	Vb	Tense=Past|VerbForm=Cop	13	mark:prt	_	_
 13	tharla	tarlaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	11	csubj:cop	_	_
 14	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	13	nsubj	_	_
@@ -5590,10 +5590,10 @@
 # text = Thairg sé cupán tae agus ceapaire do Niamh.
 1	Thairg	tairg	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
-3	cupán	cupán	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
+3	cupán	cupán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 4	tae	tae	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	agus	agus	CCONJ	Coord	_	6	cc	_	_
-6	ceapaire	ceapaire	NOUN	Noun	Gender=Masc|Number=Sing	3	conj	_	_
+6	ceapaire	ceapaire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	conj	_	_
 7	do	do	ADP	Simp	_	8	case	_	_
 8	Niamh	Niamh	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	_	_
@@ -5615,7 +5615,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	craiceann	craiceann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obj	_	_
 5	den	de	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	chlóbh	clóbh	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
+6	chlóbh	clóbh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	_
 7	gairleoige	gairleog	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	mionghearr	mionghearr	VERB	VT	Mood=Imp|Number=Sing|Person=2	2	conj	_	_
@@ -5623,7 +5623,7 @@
 11	agus	agus	CCONJ	Coord	_	12	cc	_	_
 12	cuir	cuir	VERB	VTI	Mood=Imp|Number=Sing|Person=2	2	conj	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	14	case	_	_
-14	chorcán	corcán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
+14	chorcán	corcán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	obl	_	_
 15	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	12	obj	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -5638,7 +5638,7 @@
 7	anseo	anseo	ADV	Loc	_	1	advmod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	tugadh	tabhair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
-10	tí	tí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
+10	tí	tí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
 11	Tom	Tom	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	Tommy	Tommy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 13	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	9	obl:prep	_	SpaceAfter=No
@@ -5668,7 +5668,7 @@
 13	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	12	fixed	_	_
 14	ag	ag	ADP	Simp	_	16	case	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	húinéirí	úinéir	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
+16	húinéirí	úinéir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	7	obl	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 681
@@ -5696,12 +5696,12 @@
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	biogóideacht	biogóideacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	conj	_	_
 9	san	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	aer	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
+10	aer	aer	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 11	mar	mar	ADP	Simp	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	5	advcl	_	_
 14	sna	i	ADP	Art	Number=Plur|PronType=Art	15	case	_	_
-15	blianta	bliain	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	13	obl:tmod	_	_
+15	blianta	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	13	obl:tmod	_	_
 16	fada	fada	ADJ	Adj	Gender=Fem|Number=Plur	15	amod	_	_
 17	géara	géar	ADJ	Adj	Gender=Fem|Number=Plur	15	amod	_	_
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	nsubj	_	_
@@ -5735,7 +5735,7 @@
 11	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	6	ccomp	_	_
 12	ballraíocht	ballraíocht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	nsubj	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	gcumann	cumann	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
+14	gcumann	cumann	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 15	The	the	X	Foreign	Foreign=Yes	14	nmod	_	_
 16	Week	Week	X	Foreign	Foreign=Yes	14	flat:foreign	_	_
 17	in	in	X	Foreign	Foreign=Yes	14	flat:foreign	_	_
@@ -5782,7 +5782,7 @@
 25	líonadh	líonadh	NOUN	Noun	Definite=Def|VerbForm=Vnoun	23	xcomp	_	_
 26	amach	amach	ADV	Dir	_	25	advmod	_	_
 27	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	28	det	_	_
-28	seolta	seol	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
+28	seolta	seol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	25	nmod	_	SpaceAfter=No
 29	,	,	PUNCT	Punct	_	30	punct	_	_
 30	bíonn	bí	VERB	PresImp	Aspect=Hab|Mood=Ind|Tense=Pres	2	conj	_	_
 31	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	30	nsubj	_	_
@@ -5804,7 +5804,7 @@
 7	Gael	Gael	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	NamedEntity=Yes
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 9	dara	dara	NUM	Num	NumType=Ord	10	amod	_	_
-10	shuíocán	suíochán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	5	obj	_	_
+10	shuíocán	suíochán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	5	obj	_	_
 11	nuair	nuair	SCONJ	Subord	_	13	mark	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	advcl	_	_
@@ -5829,11 +5829,11 @@
 9	gCathaoir	cathaoir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	5	obl	_	NamedEntity=Yes
 10	Pheadair	Peadar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	9	nmod	_	NamedEntity=Yes
 11	sa	i	ADP	Art	Number=Sing|PronType=Art	12	case	_	_
-12	tréimhse	tréimhse	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
+12	tréimhse	tréimhse	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	obl	_	_
 13	iar-Chomhairleach	iarchomhairleach	ADJ	Adj	Gender=Fem|Number=Sing	12	amod	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	agus	agus	SCONJ	Subord	_	16	mark	_	_
-16	bonn	bonn	NOUN	Noun	Gender=Masc|Number=Sing	1	advcl	_	_
+16	bonn	bonn	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	advcl	_	_
 17	tathagach	tathagach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	16	amod	_	_
 18	ag	ag	ADP	Simp	_	19	case	_	_
 19	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	16	xcomp	_	_
@@ -5866,7 +5866,7 @@
 17	ag	ag	ADP	Simp	_	18	case	_	_
 18	moladh	moladh	NOUN	Noun	VerbForm=Vnoun	16	xcomp	_	_
 19	do	do	ADP	Simp	_	24	case	_	_
-20	dhaoine	duine	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	24	obl	_	_
+20	dhaoine	duine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	24	obl	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	Ghaeilge	Gaeilge	PROPN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	24	obj	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
@@ -5880,7 +5880,7 @@
 3	I	I	ADP	Simp	_	4	case	_	_
 4	gcás	cás	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	19	obl	_	_
 5	nach	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	6	cop	_	_
-6	féidir	féidir	NOUN	Subst	Number=Sing	4	acl:relcl	_	_
+6	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	4	acl:relcl	_	_
 7	ainm	ainm	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	duine	duine	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
@@ -5894,7 +5894,7 @@
 17	réasúnach	réasúnach	ADJ	Adj	Degree=Pos	16	amod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	4	punct	_	_
 19	féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
-20	fógra	fógra	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
+20	fógra	fógra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obj	_	_
 21	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	22	case	_	_
 22	Acht	acht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	_
 23	seo	seo	DET	Det	PronType=Dem	22	det	_	_
@@ -5913,7 +5913,7 @@
 36	nó	nó	CCONJ	Coord	_	39	cc	_	_
 37	'	'	PUNCT	Punct	_	36	punct	_	SpaceAfter=No
 38	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	39	det	_	_
-39	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	conj	_	_
+39	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	25	conj	_	_
 40	i	i	ADP	Simp	_	41	case	_	_
 41	gceannas	ceannas	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	39	nmod	_	SpaceAfter=No
 42	'	'	PUNCT	Punct	_	39	punct	_	SpaceAfter=No
@@ -5960,11 +5960,11 @@
 31	hionadaithe	ionadaí	NOUN	Noun	Case=NomAcc|Form=HPref|Gender=Masc|Number=Plur	6	obl	_	_
 32	ó	ó	ADP	Simp	_	34	case	_	_
 33	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	34	det	_	_
-34	dílseoirí	dílseoir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	31	nmod	_	_
+34	dílseoirí	dílseoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	31	nmod	_	_
 35	agus	agus	CCONJ	Coord	_	38	cc	_	_
 36	ó	ó	ADP	Simp	_	38	case	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
-38	páirtithe	páirtí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	34	conj	_	_
+38	páirtithe	páirtí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	34	conj	_	_
 39	Aontachtaíocha	aontachtaíoch	ADJ	Adj	Gender=Masc|Number=Plur	38	amod	_	_
 40	i	i	ADP	Simp	_	41	case	_	_
 41	mBéal	Béal	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	NamedEntity=Yes
@@ -5981,7 +5981,7 @@
 6	dhul	dul	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 7	go	go	ADP	Cmpd	PrepForm=Cmpd	9	case	_	_
 8	dtí	dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	7	fixed	_	_
-9	rútaí	rúta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
+9	rútaí	rúta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	nmod	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 12	seo	seo	DET	Det	PronType=Dem	11	det	_	SpaceAfter=No
@@ -6001,7 +6001,7 @@
 2	Ag	ag	ADP	Simp	_	3	case	_	_
 3	breathnú	breathnú	NOUN	Noun	VerbForm=Vnoun	0	root	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	mbeithígh	beithíoch	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	3	obj	_	SpaceAfter=No
+5	mbeithígh	beithíoch	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	3	obj	_	SpaceAfter=No
 6	!	!	PUNCT	!	_	3	punct	_	_
 
 # sent_id = 694
@@ -6016,10 +6016,10 @@
 8	réir	réir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	7	fixed	_	_
 9	ag	ag	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	gcleacht	cleacht	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
+11	gcleacht	cleacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
 12	coitianta	coitianta	ADJ	Adj	Gender=Masc|Number=Sing	11	amod	_	_
 13	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	14	case	_	_
-14	gcomhrá	comhrá	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
+14	gcomhrá	comhrá	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	nmod	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
 16	pearsana	pearsa	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	14	nmod	_	_
 17	eile	eile	DET	Det	PronType=Dem	16	det	_	_
@@ -6039,7 +6039,7 @@
 31	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	24	obl	_	_
 32	sin	sin	DET	Det	PronType=Dem	31	det	_	_
 33	dá	de	ADP	Poss	Number=Plur|Person=3|Poss=Yes	34	case	_	_
-34	mbeatha	beatha	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
+34	mbeatha	beatha	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	31	nmod	_	_
 35	mhothálach	mothálach	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	34	amod	_	_
 36	a	a	PART	Vb	PartType=Vb|PronType=Rel	37	obl	_	_
 37	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	34	acl:relcl	_	_
@@ -6050,9 +6050,9 @@
 42	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	37	obl	_	_
 43	eile	eile	DET	Det	PronType=Dem	42	det	_	_
 44	d'	de	ADP	Simp	_	45	case	_	SpaceAfter=No
-45	fhocail	focal	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	42	nmod	_	_
+45	fhocail	focal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	42	nmod	_	_
 46	san	i	ADP	Art	Number=Sing|PronType=Art	47	case	_	_
-47	aigne	aigne	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	37	obl	_	SpaceAfter=No
+47	aigne	aigne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	37	obl	_	SpaceAfter=No
 48	.	.	PUNCT	.	_	24	punct	_	_
 
 # sent_id = 695
@@ -6067,13 +6067,13 @@
 8	cuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	obj	_	_
 9	mhaith	maith	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	8	amod	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	nithe	ní	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
+11	nithe	ní	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
 13	foilsíodh	foilsigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	8	acl:relcl	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	ligean	ligean	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
-17	ndearmad	dearmad	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
+17	ndearmad	dearmad	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	15	obl	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 696
@@ -6216,7 +6216,7 @@
 4	ag	ag	ADP	Simp	_	5	case	_	_
 5	fiach	fiach	NOUN	Noun	VerbForm=Vnoun	3	xcomp	_	_
 6	Ón	ó	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
-7	dTower	dTower	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	obl	_	_
+7	dTower	dTower	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	5	obl	_	_
 8	soir	soir	ADV	Dir	_	5	advmod	_	_
 9	dtí	go_dtí	ADP	Cmpd	Form=Ecl|PrepForm=Cmpd	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
@@ -6266,10 +6266,10 @@
 16	sin	sin	PRON	Dem	PronType=Dem	0	root	_	_
 17	iad	iad	PRON	Pers	Number=Plur|Person=3	16	nsubj	_	_
 18	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	19	det	_	_
-19	cuntais	cuntas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	17	nmod	_	_
+19	cuntais	cuntas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	17	nmod	_	_
 20	curtha	curtha	ADJ	Adj	VerbForm=Part	19	xcomp:pred	_	_
 21	i	i	ADP	Simp	_	22	case	_	_
-22	dtreo	treo	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	20	obl	_	_
+22	dtreo	treo	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	20	obl	_	_
 23	anois	anois	ADV	Gn	_	20	advmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	agus	agus	CCONJ	Coord	_	22	cc	_	SpaceAfter=No
@@ -6279,9 +6279,9 @@
 # sent_id = 704
 # text = Gabhaim fíorbhuíochas le daoine a raibh baint dhíreach acu leis na Cluichí Oilimpeacha agus a rinne agallaimh liom: - An Tiarna Killanin, Uachtarán Oinigh Saoil den COI agus de COÉ.
 1	Gabhaim	gabh	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
-2	fíorbhuíochas	fíorbhuíochas	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
+2	fíorbhuíochas	fíorbhuíochas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 3	le	le	ADP	Simp	_	4	case	_	_
-4	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	1	obl	_	_
+4	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obl	_	_
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	obl	_	_
 6	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	4	acl:relcl	_	_
 7	baint	baint	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	6	nsubj	_	_
@@ -6294,7 +6294,7 @@
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
 16	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	6	conj	_	_
-17	agallaimh	agallamh	NOUN	Noun	Gender=Masc|Number=Plur	16	obj	_	_
+17	agallaimh	agallamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	16	obj	_	_
 18	liom	le	ADP	Prep	Number=Sing|Person=1	16	obl:prep	_	SpaceAfter=No
 19	:	:	PUNCT	Punct	_	22	punct	_	_
 20	-	-	PUNCT	Punct	_	22	punct	_	_
@@ -6302,7 +6302,7 @@
 22	Tiarna	tiarna	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	parataxis	_	_
 23	Killanin	Killanin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	flat	_	NamedEntity=Yes|SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
-25	Uachtarán	uachtarán	NOUN	Noun	Gender=Masc|Number=Sing	22	appos	_	NamedEntity=Yes
+25	Uachtarán	uachtarán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	appos	_	NamedEntity=Yes
 26	Oinigh	oineach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 27	Saoil	saol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
 28	den	de	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
@@ -6315,7 +6315,7 @@
 # sent_id = 705
 # text = Mar bharr ar an donas is gialla iad na saighdiúirí uile.
 1	Mar	mar	ADP	Simp	_	2	case	_	_
-2	bharr	barr	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+2	bharr	barr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 3	ar	ar	ADP	Simp	_	5	case	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 5	donas	donas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
@@ -6323,7 +6323,7 @@
 7	gialla	giall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
 8	iad	iad	PRON	Pers	Number=Plur|Person=3	7	nsubj	_	_
 9	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	10	det	_	_
-10	saighdiúirí	saighdiúir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
+10	saighdiúirí	saighdiúir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	8	nmod	_	_
 11	uile	uile	DET	Det	PronType=Ind	10	det	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	7	punct	_	_
 
@@ -6332,11 +6332,11 @@
 1	Tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	mé	mé	PRON	Pers	Number=Sing|Person=1	1	nsubj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	uachtar	uachtar	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+4	uachtar	uachtar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	bpoll	poll	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+6	bpoll	poll	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	aeir	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
+8	aeir	aer	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	6	nmod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	dhreapaigh	dreap	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 11	mé	mé	PRON	Pers	Number=Sing|Person=1	10	nsubj	_	_
@@ -6368,7 +6368,7 @@
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
 17	chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	conj	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
-19	tréimhse	tréimhse	NOUN	Noun	Gender=Fem|Number=Sing	17	obj	_	_
+19	tréimhse	tréimhse	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obj	_	_
 20	ag	ag	ADP	Simp	_	21	case	_	_
 21	múineadh	múineadh	NOUN	Noun	VerbForm=Vnoun	17	xcomp	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
@@ -6380,7 +6380,7 @@
 3	tAthair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	NamedEntity=Yes
 4	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat	_	NamedEntity=Yes
 5	Lavelle	Lavelle	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
-6	leabhar	leabhar	NOUN	Noun	Gender=Masc|Number=Sing	1	obj	_	_
+6	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obj	_	_
 7	bolscaireachta	bolscaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
 8	The	the	X	_	Foreign=Yes	6	appos	_	NamedEntity=Yes
 9	Irish	Irish	X	_	Foreign=Yes	8	flat:foreign	_	NamedEntity=Yes
@@ -6388,9 +6388,9 @@
 11	lena	le	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	case	_	_
 12	dhearcadh	dearcadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	obj	_	_
 13	san	sin	DET	Det	Dialect=Munster|PronType=Dem	12	det	_	_
-14	ar	ar	ADP	Simp	_	18	case	_	_
+14	ar	ar	ADP	Simp	_	16	case	_	_
 15	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	himeachtaí	imeacht	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	12	nmod	_	_
+16	himeachtaí	imeacht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	12	nmod	_	_
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
 18	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	_
 19	os	os	ADP	Cmpd	PrepForm=Cmpd	22	case	_	_
@@ -6406,29 +6406,29 @@
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
 4	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	fhásach	fásach	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
+6	fhásach	fásach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 710
 # text = Bhí beirt fhear sínte ar a mbolg ag scaoileadh le ceathrar eile a bhí tar éis an abha a thrasnú.
 1	Bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	beirt	beirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
-3	fhear	fear	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
+3	fhear	fear	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Plur	2	nmod	_	_
 4	sínte	sínte	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	7	nmod:poss	_	_
-7	mbolg	bolg	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+7	mbolg	bolg	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
 9	scaoileadh	scaoileadh	NOUN	Noun	VerbForm=Inf	1	xcomp	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
-11	ceathrar	ceathrar	NOUN	Noun	Gender=Masc|Number=Sing	9	obl	_	_
+11	ceathrar	ceathrar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	obl	_	_
 12	eile	eile	DET	Det	PronType=Dem	11	det	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	nsubj	_	_
 14	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	11	acl:relcl	_	_
 15	tar	tar	ADP	Cmpd	PrepForm=Cmpd	20	case	_	_
 16	éis	éis	ADP	Cmpd	PrepForm=Cmpd	15	fixed	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	abha	abha	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
+18	abha	abha	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	20	obj	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
 20	thrasnú	trasnú	NOUN	Noun	Form=Len|VerbForm=Inf	14	xcomp	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
@@ -6447,7 +6447,7 @@
 2	sin	sin	PRON	Dem	PronType=Dem	1	fixed	_	_
 3	's	agus	CCONJ	Coord	_	5	cc	_	_
 4	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	case	_	_
-5	bhrí	brí	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	conj	_	_
+5	bhrí	brí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	conj	_	_
 6	sin	sin	PRON	Dem	PronType=Dem	5	det	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	1	punct	_	_
 8	níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -6460,7 +6460,7 @@
 15	síoraí	síoraí	ADJ	Adj	Degree=Pos	13	xcomp:pred	_	_
 16	ag	ag	ADP	Simp	_	17	case	_	_
 17	cur	cur	NOUN	Noun	VerbForm=Vnoun	13	xcomp	_	_
-18	preab	preab	NOUN	Noun	Gender=Fem|Number=Sing	17	obj	_	_
+18	preab	preab	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	17	obj	_	_
 19	san	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
 20	ól	ól	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	8	punct	_	_
@@ -6490,7 +6490,7 @@
 4	tóin	tóin	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	as	as	ADP	Simp	_	7	case	_	_
 6	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	7	nmod:poss	_	_
-7	mhála	mála	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+7	mhála	mála	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 8	plaisteach	plaisteach	ADJ	Adj	Gender=Masc|Number=Sing	7	amod	_	_
 9	agus	agus	CCONJ	Coord	_	10	cc	_	_
 10	thit	tit	VERB	VI	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
@@ -6539,9 +6539,9 @@
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	leis	le	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	gcomórtas	comórtas	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+7	gcomórtas	comórtas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
-9	foirne	foireann	NOUN	Noun	Gender=Fem|Number=Plur	7	nmod	_	_
+9	foirne	foireann	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	7	nmod	_	_
 10	11	11	NUM	Num	_	9	nmod	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -6557,34 +6557,34 @@
 8	tAire	aire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	11	punct	_	_
 10	as	as	ADP	Simp	_	11	case	_	_
-11	airgead	airgead	NOUN	Noun	Gender=Masc|Number=Sing	8	nmod	_	_
+11	airgead	airgead	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
 13	sholáthróidh	soláthair	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	8	acl:relcl	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	tOireachtas	oireachtas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
-17	deontais	deontas	NOUN	Noun	Gender=Masc|Number=Plur	19	obj	_	_
+17	deontais	deontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	19	obj	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 20	d'	do	ADP	Simp	_	21	case	_	SpaceAfter=No
-21	údaráis	údarás	NOUN	Noun	Gender=Masc|Number=Plur	19	obl	_	_
+21	údaráis	údarás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	19	obl	_	_
 22	phleanála	pleanáil	NOUN	Noun	Case=Gen|Form=Len|VerbForm=Inf	21	nmod	_	_
 23	i	i	ADP	Simp	_	24	case	_	_
 24	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	19	nmod	_	_
 25	aon	aon	DET	Det	PronType=Ind	26	det	_	_
-26	cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	24	nmod	_	_
+26	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	_
 27	nó	nó	CCONJ	Coord	_	29	cc	_	_
 28	gach	gach	DET	Det	Definite=Def	29	det	_	_
-29	ceann	ceann	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	conj	_	_
+29	ceann	ceann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	conj	_	_
 30	dá	de	ADP	Poss	Number=Plur|Person=3|Poss=Yes	31	case	_	_
-31	bhfeidhmeanna	feidhm	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	29	nmod	_	_
+31	bhfeidhmeanna	feidhm	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	29	nmod	_	_
 32	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
 33	Acht	acht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	31	nmod	_	_
 34	seo	seo	DET	Det	PronType=Dem	33	det	_	SpaceAfter=No
 35	,	,	PUNCT	Punct	_	36	punct	_	_
 36	lena	le	PART	Rel	PronType=Rel	6	obl	_	_
 37	n-áirítear	áirigh	VERB	VT	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	6	obl	_	_
-38	deontais	deontas	NOUN	Noun	Gender=Masc|Number=Plur	37	obj	_	_
+38	deontais	deontas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	37	obj	_	_
 39	chun	chun	SCONJ	Subord	_	37	mark	_	_
 40	go	go	SCONJ	Subord	_	39	fixed	_	_
 41	nglanfar	glan	VERB	FutInd	Form=Ecl|Mood=Ind|Person=0|Tense=Fut	6	advcl	_	_
@@ -6604,20 +6604,20 @@
 55	linn	linn	ADP	Cmpd	PrepForm=Cmpd	54	fixed	_	_
 56	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	53	nmod	_	_
 57	le	le	ADP	Simp	_	58	case	_	_
-58	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	56	nmod	_	_
+58	daoine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	56	nmod	_	_
 59	ar	ar	ADP	Simp	_	61	obl	_	_
 60	a	a	PART	Vb	PartType=Vb|PronType=Rel	61	obl	_	_
 61	seirbheáiltear	seirbheáil	VERB	VT	Mood=Ind|Person=0|Tense=Pres	58	acl:relcl	_	_
-62	fógra	fógra	NOUN	Noun	Gender=Masc|Number=Sing	61	obj	_	_
+62	fógra	fógra	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	61	obj	_	_
 63	faoi	faoi	ADP	Simp	_	64	case	_	_
-64	alt	alt	NOUN	Noun	Gender=Masc|Number=Sing	61	obl	_	_
+64	alt	alt	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	61	obl	_	_
 65	10	10	NUM	Num	_	66	nmod	_	SpaceAfter=No
 66	(1)	(1)	NUM	Item	_	64	nmod	_	_
 67	nó	nó	CCONJ	Coord	_	68	cc	_	_
 68	11	11	NUM	Num	_	66	conj	_	SpaceAfter=No
 69	(2)	(2)	NUM	Item	_	66	conj	_	_
 70	agus	agus	CCONJ	Coord	_	71	cc	_	_
-71	oibreacha	obair	NOUN	Noun	Gender=Fem|Number=Plur	58	conj	_	_
+71	oibreacha	obair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	58	conj	_	_
 72	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	73	case	_	_
 73	ndéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	58	xcomp	_	_
 74	acu	ag	ADP	Prep	Number=Plur|Person=3	73	nmod	_	_
@@ -6633,10 +6633,10 @@
 84	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	92	nmod	_	_
 85	le	le	ADP	Simp	_	87	case	_	_
 86	haon	aon	DET	Det	Form=HPref|PronType=Ind	87	det	_	_
-87	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	84	nmod	_	_
+87	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	84	nmod	_	_
 88	eile	eile	DET	Det	PronType=Dem	87	det	_	_
 89	agus	agus	CCONJ	Coord	_	90	cc	_	_
-90	oibreacha	obair	NOUN	Noun	Gender=Fem|Number=Plur	87	conj	_	_
+90	oibreacha	obair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	87	conj	_	_
 91	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	92	case	_	_
 92	ndéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	53	xcomp	_	_
 93	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	92	obl:prep	_	_
@@ -6648,10 +6648,10 @@
 99	de	de	ADP	Cmpd	PrepForm=Cmpd	102	case	_	_
 100	réir	réir	ADP	Cmpd	PrepForm=Cmpd	99	fixed	_	_
 101	cibé	cibé	DET	Det	PronType=Ind	102	det	_	_
-102	coinníollacha	coinníoll	NOUN	Noun	Gender=Masc|Number=Plur	92	nmod	_	_
+102	coinníollacha	coinníoll	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	92	nmod	_	_
 103	a	a	PART	Vb	PartType=Vb|PronType=Rel	104	obj	_	_
 104	shonróidh	sonraigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Fut	102	acl:relcl	_	_
-105	údarás	údarás	NOUN	Noun	Gender=Masc|Number=Sing	104	obj	_	_
+105	údarás	údarás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	104	obj	_	_
 106	pleanála	pleanáil	NOUN	Noun	Case=Gen|VerbForm=Inf	105	nmod	_	_
 107	chun	chun	ADP	Simp	_	104	case	_	_
 108	cúnamh	cúnamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	104	obl	_	_
@@ -6668,7 +6668,7 @@
 2	roinntear	roinn	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	23	advcl	_	_
 3	seo	seo	PRON	Dem	PronType=Dem	2	obj	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
-5	dhaonra	daonra	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+5	dhaonra	daonra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 6	iomlán	iomlán	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	5	amod	_	_
 7	de	de	ADP	Simp	_	8	case	_	_
 8	3,500,000	3,500,000	NUM	Num	_	5	nmod	_	_
@@ -6676,10 +6676,10 @@
 10	má	má	SCONJ	Subord	_	11	mark	_	_
 11	mhéadaítear	méadaigh	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	2	conj	_	_
 12	faoi	faoi	ADP	Simp	_	13	case	_	_
-13	dhaonra	daonra	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	11	obl	_	_
+13	dhaonra	daonra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	11	obl	_	_
 14	bliantúil	bliantúil	ADJ	Adj	Gender=Masc|Number=Sing	13	amod	_	_
-15	tríú	tríú	NOUN	Noun	Gender=Masc|Number=Sing	13	nmod	_	_
-16	leibhéil	leibhéal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	_
+15	tríú	tríú	NUM	_	NumType=Ord	16	amod	_	_
+16	leibhéil	leibhéal	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	_
 17	de	de	ADP	Simp	_	18	case	_	_
 18	34,500	34,500	NUM	Num	_	13	nmod	_	_
 19	do	do	ADP	Simp	_	20	case	_	_
@@ -6691,18 +6691,18 @@
 25	agus	agus	CCONJ	Coord	_	26	cc	_	_
 26	4,200	4,200	NUM	Num	_	24	conj	_	_
 27	de	de	ADP	Simp	_	28	case	_	_
-28	dhaonra	daonra	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	26	nmod	_	_
+28	dhaonra	daonra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	26	nmod	_	_
 29	reatha	rith	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	28	nmod	_	_
 30	scoláirí	scoláire	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	28	nmod	_	SpaceAfter=No
 31	,	,	PUNCT	Punct	_	34	punct	_	_
 32	gan	gan	ADP	Simp	_	34	case	_	_
 33	aon	aon	DET	Det	PronType=Ind	34	det	_	_
-34	socrú	socrú	NOUN	Noun	Gender=Masc|Number=Sing	23	nmod	_	_
+34	socrú	socrú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	23	nmod	_	_
 35	chun	chun	ADP	Simp	_	43	case	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
-37	bhearna	bearna	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	43	obj	_	_
+37	bhearna	bearna	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	43	obj	_	_
 38	idir	idir	ADP	Simp	_	39	case	_	_
-39	éileamh	éileamh	NOUN	Noun	Gender=Masc|Number=Sing	37	nmod	_	_
+39	éileamh	éileamh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	37	nmod	_	_
 40	agus	agus	CCONJ	Coord	_	43	cc	_	_
 41	soláthar	soláthar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	39	conj	_	_
 42	a	a	PART	Inf	PartType=Inf	43	mark	_	_
@@ -6711,7 +6711,7 @@
 45	nó	nó	CCONJ	Coord	_	57	cc	_	_
 46	chun	chun	ADP	Simp	_	57	case	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
-48	céadtadán	céatadán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	57	obj	_	_
+48	céadtadán	céatadán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	57	obj	_	_
 49	íseal	íseal	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	48	amod	_	_
 50	rannpáirtíochta	rannpháirtíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing|Typo=Yes	48	nmod	_	_
 51	i	i	ADP	Simp	_	52	case	_	_
@@ -6739,9 +6739,9 @@
 
 # sent_id = 720
 # text = Línte agus uillinneacha.
-1	Línte	líne	NOUN	Noun	Gender=Fem|Number=Plur	0	root	_	_
+1	Línte	líne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 2	agus	agus	CCONJ	Coord	_	3	cc	_	_
-3	uillinneacha	uillinn	NOUN	Noun	Gender=Fem|Number=Plur	1	conj	_	SpaceAfter=No
+3	uillinneacha	uillinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	1	conj	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 721
@@ -6809,7 +6809,7 @@
 21	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	16	xcomp	_	_
 22	ar	ar	ADP	Simp	_	24	case	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
-24	bhord	bord	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
+24	bhord	bord	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	xcomp:pred	_	_
 25	póilíneachta	póilíneacht	NOUN	Noun	VerbForm=Part	24	nmod	_	_
 26	úr	úr	ADJ	Adj	Degree=Pos	24	amod	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	7	punct	_	_
@@ -6830,11 +6830,11 @@
 6	nó	nó	CCONJ	Coord	_	9	cc	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	ghuthán	guthán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
+9	ghuthán	guthán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
 11	hamazon	amazon	X	Foreign	Foreign=Yes|Form=HPref	9	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
-13	post	post	NOUN	Noun	Gender=Masc|Number=Sing	3	conj	_	_
+13	post	post	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	conj	_	_
 14	ar	ar	ADP	Simp	_	13	nmod	_	_
 15	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	14	fixed	_	_
 16	eile	eile	DET	Det	PronType=Dem	14	det	_	_
@@ -6843,7 +6843,7 @@
 19	-	-	PUNCT	Punct	_	24	punct	_	_
 20	ach	ach	SCONJ	Subord	_	24	mark	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	pá	pá	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
+22	pá	pá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	2	parataxis	_	_
 25	níos	níos	PART	Cmp	PartType=Comp	26	mark:prt	_	_
@@ -6861,7 +6861,7 @@
 7	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	_
 8	rófhada	rófhada	ADJ	Adj	Gender=Masc|Number=Sing	6	xcomp:pred	_	_
 9	san	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
-10	ospidéal	ospidéal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
+10	ospidéal	ospidéal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
 11	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 727
@@ -6907,7 +6907,7 @@
 # text = Os a choinne sin b'fhurasta cás a dhéanamh ar son litríocht na n-aosánach a choinneáil ar deighilt ar fad ó litríocht mhór an tsaoil.
 1	Os	os	ADP	Simp	_	3	case	_	_
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
-3	choinne	coinne	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	obl	_	_
+3	choinne	coinne	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	obl	_	_
 4	sin	sin	PRON	Dem	PronType=Dem	3	det	_	_
 5	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	6	cop	_	SpaceAfter=No
 6	fhurasta	furasta	ADJ	Adj	Degree=Pos|Form=Len	0	root	_	_
@@ -6924,7 +6924,7 @@
 17	ar	ar	ADP	Simp	_	18	case	_	_
 18	deighilt	deighilt	NOUN	Noun	VerbForm=Inf	16	obl	_	_
 19	ar	ar	ADP	Simp	_	20	case	_	_
-20	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	18	nmod	_	_
+20	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
 21	ó	ó	ADP	Simp	_	22	case	_	_
 22	litríocht	litríocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 23	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	22	amod	_	_
@@ -6944,7 +6944,7 @@
 8	sásta	sásta	ADJ	Adj	Degree=Pos	7	xcomp:pred	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	réimse	réimse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
+11	réimse	réimse	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	_
 12	éiginnte	éiginnte	ADJ	Adj	Gender=Masc|Number=Sing	11	amod	_	_
 13	idir	idir	ADP	Simp	_	14	case	_	_
 14	leas	leas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
@@ -6960,7 +6960,7 @@
 3	dhíth	díth	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 4	ach	ach	SCONJ	Subord	_	6	mark	_	_
 5	aon	aon	DET	Det	PronType=Ind	6	det	_	_
-6	fhocal	focal	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	_
+6	fhocal	focal	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	nsubj	_	_
 7	amháin	amháin	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	sin	sin	PRON	Dem	PronType=Dem	1	parataxis	_	_
@@ -6984,7 +6984,7 @@
 # sent_id = 733
 # text = Mar fhreagra soiléir ar an gcáineadh sin tá triúr eile le ceapadh ar an mBord i Mí Eanáir, Seán Noone ón SELC, atá luaite le turasóireacht i gceantar Iorrais, Joe Kennedy, Maigh Eo agus Manchain, tógálaí mór le rá, agus an tÓstóir, Brian McEniff as Dún na nGall.
 1	Mar	mar	ADP	Simp	_	2	case	_	_
-2	fhreagra	freagra	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+2	fhreagra	freagra	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 3	soiléir	soiléir	ADJ	Adj	Gender=Masc|Number=Sing	2	amod	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
@@ -6997,7 +6997,7 @@
 12	ceapadh	ceapadh	NOUN	Noun	VerbForm=Inf	8	xcomp	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	mBord	bord	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
+15	mBord	bord	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 16	i	i	ADP	Simp	_	17	case	_	_
 17	Mí	mí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	NamedEntity=Yes
 18	Eanáir	Eanáir	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -7012,7 +7012,7 @@
 27	le	le	ADP	Simp	_	28	case	_	_
 28	turasóireacht	turasóireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	obl	_	_
 29	i	i	ADP	Simp	_	30	case	_	_
-30	gceantar	ceantar	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	nmod	_	_
+30	gceantar	ceantar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	28	nmod	_	_
 31	Iorrais	Iorras	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	30	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
 33	Joe	Joe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
@@ -7023,14 +7023,14 @@
 38	agus	agus	CCONJ	Coord	_	39	cc	_	_
 39	Manchain	Manchain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	36	conj	_	SpaceAfter=No
 40	,	,	PUNCT	Punct	_	41	punct	_	_
-41	tógálaí	tógálaí	NOUN	Noun	Gender=Masc|Number=Sing	33	nmod	_	_
+41	tógálaí	tógálaí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	appos	_	_
 42	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	41	amod	_	_
 43	le	le	ADP	Simp	_	44	case	_	_
 44	rá	rá	NOUN	Noun	VerbForm=Inf	41	xcomp	_	SpaceAfter=No
 45	,	,	PUNCT	Punct	_	46	punct	_	_
 46	agus	agus	CCONJ	Coord	_	48	cc	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
-48	tÓstóir	óstóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	conj	_	SpaceAfter=No
+48	tÓstóir	óstóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	20	conj	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
 50	Brian	Brian	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	48	appos	_	NamedEntity=Yes
 51	McEniff	McEniff	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	50	flat:name	_	NamedEntity=Yes
@@ -7061,7 +7061,7 @@
 17	nGaillimh	Gaillimh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	15	nmod	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
 19	t-aon	aon	DET	Det	PronType=Ind	20	det	_	_
-20	cheann	ceann	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
+20	cheann	ceann	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	15	nmod	_	_
 21	atá	bí	VERB	PresInd	Mood=Ind|PronType=Rel|Tense=Pres	15	acl:relcl	_	_
 22	ag	ag	ADP	Simp	_	23	case	_	_
 23	freastal	freastal	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
@@ -7097,7 +7097,7 @@
 1	Ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	2	advmod	_	_
 2	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
 3	mórán	mórán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
-4	fonn	fonn	NOUN	Noun	Gender=Masc|Number=Sing	3	nmod	_	_
+4	fonn	fonn	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	nmod	_	_
 5	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	2	obl:prep	_	_
 6	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 7	leis	le	ADP	Simp	_	9	case	_	_
@@ -7109,7 +7109,7 @@
 # text = Insítear na rudaí a rinne sé ach go minic ní insítear cén fáth go ndearna sé iad.
 1	Insítear	inis	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	rudaí	rud	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
+3	rudaí	rud	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	5	nsubj	_	_
 5	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	3	acl:relcl	_	_
 6	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	_
@@ -7150,7 +7150,7 @@
 20	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	19	obl:prep	_	_
 21	ar	ar	ADP	Simp	_	23	case	_	_
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	_
-23	slioscharr	slioscharr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
+23	slioscharr	slioscharr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	19	nmod	_	_
 24	sea	is	AUX	Cop	Tense=Pres|VerbForm=Cop	25	cop	_	_
 25	tharla	tarlaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
@@ -7194,7 +7194,7 @@
 3	mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	ar	ar	ADP	Simp	_	6	case	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	trá	trá	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
+6	trá	trá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 7	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl:tmod	_	_
 8	arna	ar	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	9	case	_	_
 9	mhárach	márach	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	7	nmod	_	SpaceAfter=No
@@ -7212,7 +7212,7 @@
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
 9	bhfíricí	fíric	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	5	nmod	_	_
 10	faoi	faoi	ADP	Simp	_	11	case	_	_
-11	pholasaí	polasaí	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+11	pholasaí	polasaí	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 12	nua	nua	ADJ	Adj	Gender=Masc|Number=Sing	11	amod	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	INTO	INTO	PROPN	Abr	Abbr=Yes	11	nmod	_	_
@@ -7239,9 +7239,9 @@
 # text = Má théitear meascán d'iarann agus de shulfar, breofaidh an meascán.
 1	Má	má	SCONJ	Subord	_	2	mark	_	_
 2	théitear	téigh	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	10	advcl	_	_
-3	meascán	meascán	NOUN	Noun	Gender=Masc|Number=Sing	2	obj	_	_
+3	meascán	meascán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obj	_	_
 4	d'	de	ADP	Simp	_	5	case	_	SpaceAfter=No
-5	iarann	iarann	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	_
+5	iarann	iarann	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
 6	agus	agus	CCONJ	Coord	_	8	cc	_	_
 7	de	de	ADP	Simp	_	8	case	_	_
 8	shulfar	sulfar	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	5	conj	_	SpaceAfter=No
@@ -7258,13 +7258,13 @@
 3	mé	mé	PRON	Pers	Number=Sing|Person=1	2	nsubj	_	_
 4	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	2	obj	_	_
 5	le	le	ADP	Simp	_	6	case	_	_
-6	croí	croí	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	_
+6	croí	croí	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
 7	briste	briste	ADJ	Adj	Gender=Masc|Number=Sing	6	amod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	deora	deoir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	6	conj	_	_
 10	i	i	ADP	Simp	_	12	case	_	_
 11	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	12	nmod:poss	_	_
-12	shúile	súil	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	9	nmod	_	SpaceAfter=No
+12	shúile	súil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	9	nmod	_	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 745
@@ -7273,13 +7273,13 @@
 2	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	3	nmod:poss	_	_
 3	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
-5	chógais	cógas	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	3	nmod	_	_
+5	chógais	cógas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	3	nmod	_	_
 6	anois	anois	ADV	Gn	_	1	advmod	_	_
 7	trí	trí	ADP	Simp	_	8	case	_	_
 8	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	1	obl	_	_
 9	curtha	curtha	ADJ	Adj	VerbForm=Part	8	xcomp:pred	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	dtaisceadáin	taisceadán	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	_
+11	dtaisceadáin	taisceadán	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	obl	_	_
 14	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	11	acl:relcl	_	_
@@ -7289,9 +7289,9 @@
 18	ar	ar	ADP	Simp	_	19	case	_	_
 19	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	15	nmod	_	_
 20	nach	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	21	cop	_	_
-21	féidir	féidir	NOUN	Subst	Number=Sing	15	acl:relcl	_	_
+21	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	15	acl:relcl	_	_
 22	le	le	ADP	Simp	_	26	case	_	_
-23	baill	ball	NOUN	Noun	Gender=Masc|Number=Plur	26	obj	_	_
+23	baill	ball	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	26	obj	_	_
 24	foirne	foireann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	23	nmod	_	_
 25	a	a	PART	Inf	PartType=Inf	26	mark	_	_
 26	shárú	sárú	NOUN	Noun	Form=Len|VerbForm=Inf	21	csubj:cop	_	SpaceAfter=No
@@ -7314,13 +7314,13 @@
 13	City	City	X	_	Foreign=Yes	12	flat:foreign	_	NamedEntity=Yes
 14	anuraidh	anuraidh	ADV	Temp	_	2	advmod	_	_
 15	agus	agus	SCONJ	Subord	_	16	mark	_	_
-16	aithne	aithne	NOUN	Noun	Gender=Fem|Number=Sing	2	advcl	_	_
+16	aithne	aithne	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	advcl	_	_
 17	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	16	obl:prep	_	_
 18	ar	ar	ADP	Simp	_	20	case	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
 20	bhfoireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	16	nmod	_	_
 21	ar	ar	ADP	Simp	_	22	case	_	_
-22	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
+22	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	26	punct	_	_
 24	mar	mar	ADP	Simp	_	26	advmod	_	_
 25	sin	sin	PRON	Dem	PronType=Dem	24	fixed	_	_
@@ -7367,7 +7367,7 @@
 11	léirmheas	léirmheas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obj	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	leabhar	leabhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
+14	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 15	The	the	X	Foreign	Foreign=Yes	14	nmod	_	_
 16	Irish	Irish	X	Foreign	Foreign=Yes|Gender=Masc|Number=Sing	15	flat:foreign	_	_
 17	of	of	X	Foreign	Foreign=Yes|Gender=Masc|Number=Sing	15	flat:foreign	_	_
@@ -7389,7 +7389,7 @@
 33	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 34	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	33	nsubj	_	_
 35	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
-36	méid	méid	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	33	obj	_	_
+36	méid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obj	_	_
 37	seo	seo	DET	Det	PronType=Dem	36	det	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	33	punct	_	_
 
@@ -7446,7 +7446,7 @@
 # text = Is in Áras Chumann Ríoga Bhaile Átha Cliath i nDroichead na Dothra, Baile Átha Cliath 4, a bheidh an spórt seo á imirt.
 1	Is	is	AUX	Cop	VerbForm=Cop	3	cop	_	_
 2	in	i	ADP	Simp	_	3	case	_	_
-3	Áras	áras	NOUN	Noun	Definite=Def	0	root	_	NamedEntity=Yes
+3	Áras	áras	NOUN	Noun	Case=NomAcc|Definite=Def	0	root	_	NamedEntity=Yes
 4	Chumann	cumann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	nmod	_	NamedEntity=Yes
 5	Ríoga	ríoga	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	4	amod	_	NamedEntity=Yes
 6	Bhaile	Baile	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
@@ -7484,7 +7484,7 @@
 9	dul	dul	NOUN	Noun	VerbForm=Vnoun	3	xcomp	_	_
 10	suas	suas	ADV	Dir	_	9	advmod	_	_
 11	go	go	ADP	Simp	_	12	case	_	_
-12	barr	barr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
+12	barr	barr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	chnoic	cnoc	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	nmod	_	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	_	_
@@ -7530,15 +7530,15 @@
 15	mhór	mór	ADJ	Adj	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	14	amod	_	_
 16	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	xcomp:pred	_	_
 17	sna	i	ADP	Art	Number=Plur|PronType=Art	18	case	_	_
-18	hospidéil	ospidéal	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	13	obl	_	_
+18	hospidéil	ospidéal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	13	obl	_	_
 19	maidir	maidir	ADP	CmpdNoGen	_	22	case	_	_
 20	le	le	ADP	CmpdNoGen	_	19	fixed	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
-22	sárvíreas	sárvíreas	NOUN	Noun	Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
+22	sárvíreas	sárvíreas	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 23	'	'	PUNCT	Punct	_	22	punct	_	_
 24	a	a	PART	Vb	PartType=Vb|PronType=Rel	25	nsubj	_	_
 25	ionsaíonn	ionsaigh	VERB	VTI	Mood=Ind|Tense=Pres	22	acl:relcl	_	_
-26	othair	othar	NOUN	Noun	Gender=Masc|Number=Plur	25	obj	_	_
+26	othair	othar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	25	obj	_	_
 27	tar	tar	ADP	Cmpd	PrepForm=Cmpd	30	case	_	_
 28	éis	éis	ADP	Cmpd	PrepForm=Cmpd	27	fixed	_	_
 29	dóibh	do	ADP	Prep	Number=Plur|Person=3	30	obl:prep	_	_
@@ -7563,12 +7563,12 @@
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	siúl	siúl	NOUN	Noun	VerbForm=Inf	10	xcomp	_	_
 14	i	i	ADP	Simp	_	15	case	_	_
-15	dtithe	teach	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	13	obl	_	_
+15	dtithe	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	13	obl	_	_
 16	eile	eile	DET	Det	PronType=Dem	15	det	_	_
-17	Chillín	Cillín	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+17	Chillín	Cillín	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 18	Chaoimhín	Caoimhín	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	17	nmod	_	NamedEntity=Yes
 19	ach	ach	SCONJ	Subord	_	20	mark	_	_
-20	oiread	oiread	NOUN	Subst	Number=Sing	10	advcl	_	SpaceAfter=No
+20	oiread	oiread	NOUN	Subst	Case=NomAcc|Number=Sing	10	advcl	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 758
@@ -7611,7 +7611,7 @@
 4	,	,	PUNCT	Punct	_	5	punct	_	_
 5	anois	anois	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	ionad	ionad	NOUN	Noun	Gender=Masc|Number=Sing	2	nmod	_	_
+7	ionad	ionad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nmod	_	_
 8	iascaireachta	iascaireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
 9	traidisiúnta	traidisiúnta	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	7	amod	_	_
 10	le	le	ADP	Simp	_	12	case	_	_
@@ -7632,10 +7632,10 @@
 25	á	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	26	case	_	_
 26	dhéanamh	déanamh	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	24	xcomp	_	_
 27	don	do	ADP	Art	Number=Sing|PronType=Art	28	case	_	_
-28	dúlra	dúlra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
+28	dúlra	dúlra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	obl	_	_
 29	ag	ag	ADP	Simp	_	31	case	_	_
 30	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	31	det	_	_
-31	comhlachtaí	comhlacht	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	26	obl	_	_
+31	comhlachtaí	comhlacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	26	obl	_	_
 32	ollmhóra	ollmhór	ADJ	Adj	NounType=NotSlender|Number=Plur	31	amod	_	_
 33	ilnáisiúnacha	ilnáisiúnach	ADJ	Adj	NounType=NotSlender|Number=Plur	31	amod	_	SpaceAfter=No
 34	.	.	PUNCT	.	_	1	punct	_	_
@@ -7654,7 +7654,7 @@
 # sent_id = 761
 # text = In aice sin bhí ocras céadtach uirre anois, arae, níor chaith sí mórán ar maidin, agus ba ghnás léithe cupán tae cosnochtuighthe a fhagháil, ag an haon déag gach uile lá i gcaitheamh deich mbliana.
 1	In	i	ADP	Simp	_	2	case	_	_
-2	aice	aice	NOUN	Noun	Gender=Fem|Number=Sing	4	obl	_	_
+2	aice	aice	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obl	_	_
 3	sin	sin	PRON	Dem	PronType=Dem	2	det	_	_
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 5	ocras	ocras	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nsubj	_	_
@@ -7673,9 +7673,9 @@
 18	,	,	PUNCT	Punct	_	21	punct	_	_
 19	agus	agus	CCONJ	Coord	_	21	cc	_	_
 20	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	21	cop	_	_
-21	ghnás	gnás	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	13	conj	_	_
+21	ghnás	gnás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	13	conj	_	_
 22	léithe	le	ADP	Prep	Gender=Fem|Number=Sing|Person=3	21	obl:prep	_	_
-23	cupán	cupán	NOUN	Noun	Gender=Masc|Number=Sing	27	obj	_	_
+23	cupán	cupán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	27	obj	_	_
 24	tae	tae	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	_
 25	cosnochtuighthe	cosnochtuighthe	ADJ	Adj	VerbForm=Part	21	advmod	_	_
 26	a	a	PART	Inf	PartType=Inf	27	mark	_	_
@@ -7703,7 +7703,7 @@
 5	-	-	PUNCT	Punct	_	6	punct	_	_
 6	Druid	druid	NOUN	Noun	Foreign=Yes|Number=Sing	3	appos	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
-8	iar-stiúrthóir	iarstiúrthóir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
+8	iar-stiúrthóir	iarstiúrthóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	conj	_	_
 9	ealaíne	ealaín	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
 10	conspóideach	conspóideach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	8	amod	_	_
 11	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
@@ -7713,12 +7713,12 @@
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	mark:prt	_	_
 16	léirigh	léirigh	VERB	VT	Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 17	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	18	det	_	_
-18	oíche	oíche	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	obj	_	_
+18	oíche	oíche	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	16	obj	_	_
 19	go	go	PART	Ad	PartType=Ad	20	mark:prt	_	_
 20	sár-ábalta	sárábalta	ADJ	Adj	Degree=Pos	16	advmod	_	_
 21	mar	mar	SCONJ	Subord	_	23	mark	_	_
 22	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
-23	dual	dual	NOUN	Subst	Gender=Masc|Number=Sing	16	advcl	_	_
+23	dual	dual	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	16	advcl	_	_
 24	di	do	ADP	Prep	Gender=Fem|Number=Sing|Person=3	23	obl:prep	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -7726,7 +7726,7 @@
 # text = Tarraing an fhíor tugtha.
 1	Tarraing	tarraing	VERB	VTI	Mood=Imp|Number=Sing|Person=2	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	fhíor	fíor	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
+3	fhíor	fíor	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obj	_	_
 4	tugtha	tugtha	ADJ	Adj	VerbForm=Part	3	xcomp:pred	_	SpaceAfter=No
 5	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -7736,14 +7736,14 @@
 2	roinnt	roinnt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	diagairí	diagaire	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
-5	grúpaí	grúpa	NOUN	Noun	Gender=Masc|Number=Plur	2	appos	_	_
+5	grúpaí	grúpa	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	2	appos	_	_
 6	le	le	ADP	Simp	_	7	case	_	_
 7	chéile	céile	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 8	díobh	de	ADP	Prep	Number=Plur|Person=3	1	obl:prep	_	_
 9	uaireanta	uaireanta	ADV	Gn	_	1	advmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	teoraic	teoiric	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
+12	teoraic	teoiric	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 13	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	14	mark:prt	_	_
 14	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	1	ccomp	_	_
 15	gá	gá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -7751,7 +7751,7 @@
 17	mó	mór	ADJ	Adj	Degree=Cmp,Sup	14	amod	_	_
 18	le	le	ADP	Simp	_	20	case	_	_
 19	haon	aon	DET	Det	Form=HPref|PronType=Ind	20	det	_	_
-20	chaiticeasma	caiticeasma	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	obl	_	SpaceAfter=No
+20	chaiticeasma	caiticeasma	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	obl	_	SpaceAfter=No
 21	,	,	PUNCT	Punct	_	23	punct	_	_
 22	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
 23	mhodh	modh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	parataxis	_	_
@@ -7761,7 +7761,7 @@
 27	a	a	PART	Vb	PartType=Vb|PronType=Rel	28	mark:prt	_	_
 28	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	23	csubj:cleft	_	_
 29	as	as	ADP	Simp	_	28	xcomp:pred	_	_
-30	dáta	dáta	NOUN	Noun	Gender=Masc|Number=Sing	29	fixed	_	_
+30	dáta	dáta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	fixed	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	31	punct	_	_
 33	má	má	SCONJ	Subord	_	34	mark	_	_
@@ -7815,7 +7815,7 @@
 16	leagan	leagan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obj	_	_
 17	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 18	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
-19	mhórshaothar	mórshaothar	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
+19	mhórshaothar	mórshaothar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 20	Dancing	Dancing	X	_	Foreign=Yes	19	nmod	_	_
 21	at	at	X	_	Foreign=Yes	20	flat:foreign	_	_
 22	Lughnasa	Lughnasa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:foreign	_	_
@@ -7823,7 +7823,7 @@
 24	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
 25	ar	ar	ADP	Simp	_	27	case	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
-27	ardán	ardán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
+27	ardán	ardán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 768
@@ -7859,7 +7859,7 @@
 11	a	a	PART	Vb	PartType=Vb|PronType=Rel	12	nsubj	_	_
 12	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	4	acl:relcl	_	_
 13	as	as	ADP	Simp	_	14	case	_	_
-14	cló	cló	NOUN	Noun	Gender=Masc|Number=Sing	12	obl	_	_
+14	cló	cló	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obl	_	_
 15	ó	ó	SCONJ	Subord	_	16	mark	_	_
 16	foilsíodh	foilsigh	VERB	VT	Mood=Ind|Person=0|Tense=Past	12	advcl	_	_
 17	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	16	obj	_	_
@@ -7927,7 +7927,7 @@
 22	agus	agus	CCONJ	_	_	23	cc	_	NamedEntity=Yes
 23	Eolaslainne	eolaslann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	21	conj	_	NamedEntity=Yes
 24	san	i	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
-25	áireamh	áireamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
+25	áireamh	áireamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	obl	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 772
@@ -7936,12 +7936,12 @@
 2	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	13	parataxis	_	_
 3	téagar	téagar	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	nsubj	_	_
 4	sna	i	ADP	Art	Number=Plur|PronType=Art	5	case	_	_
-5	páirteanna	páirt	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	2	obl	_	_
+5	páirteanna	páirt	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	2	obl	_	_
 6	a	a	PART	Vb	PartType=Vb|PronType=Rel	7	obj	_	_
 7	fhaigheann	faigh	VERB	VT	Form=Len|Mood=Ind|Tense=Pres	5	acl:relcl	_	_
 8	tú	tú	PRON	Pers	Number=Sing|Person=2	7	nsubj	_	_
 9	i	i	ADP	Simp	_	10	case	_	_
-10	scannán	scannán	NOUN	Noun	Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+10	scannán	scannán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 12	'	'	PUNCT	Punct	_	2	punct	_	_
 13	ar	ar	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
@@ -7954,7 +7954,7 @@
 2	scaoileas	scaoil	VERB	VTI	Mood=Ind|Number=Sing|Person=1|Tense=Past	0	root	_	_
 3	siar	siar	ADV	Dir	_	2	advmod	_	_
 4	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	5	nmod:poss	_	_
-5	shuíochán	suíochán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
+5	shuíochán	suíochán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
 6	féin	féin	PRON	Ref	Reflex=Yes	5	nmod	_	_
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	fada	fada	ADJ	Adj	Degree=Pos	2	amod	_	_
@@ -8000,7 +8000,7 @@
 4	nirt	neart	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	ag	ag	ADP	Simp	_	7	case	_	_
 6	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
-7	fleánna	fleá	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	3	nmod	_	_
+7	fleánna	fleá	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	3	nmod	_	_
 8	sin	sin	DET	Det	PronType=Dem	7	det	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
 10	e.g.	e.g.	ADV	Abr	Abbr=Yes	12	advmod	_	_
@@ -8031,7 +8031,7 @@
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	tomhaltóra	tomhaltóir	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 5	gach	gach	DET	Det	Definite=Def	6	det	_	_
-6	pioc	pioc	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
+6	pioc	pioc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	_
 7	chomh	chomh	ADV	Its	_	8	advmod	_	_
 8	tábhachtach	tábhachtach	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 9	le	le	ADP	Simp	_	10	case	_	_
@@ -8064,7 +8064,7 @@
 
 # sent_id = 779
 # text = Fínéad éifeachtach focalspárálach é scéal Mháire Mhac an tSaoi, 'An Bhean Óg', ina mbraitheann an léitheoir an t-uaigneas céanna anama seo i gcás na mná óige ar cosúil go bhfuil an cliseadh pósta i ndán di.
-1	Fínéad	fínéad	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	Fínéad	fínéad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	éifeachtach	éifeachtach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	focalspárálach	focalspárálach	ADJ	Adj	Gender=Masc|Number=Sing	1	amod	_	_
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nmod	_	_
@@ -8118,7 +8118,7 @@
 # sent_id = 781
 # text = Is gá ardchaighdeán Gaeilge, idir scríofa agus labhartha, a bheith ag na daoine a cheapfar agus tuiscint mhaith acu ar ghramadach na Gaeilge, ar an gCaighdeán Oifigiúil agus ar mhórchanúintí na Gaeilge.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+2	gá	gá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	ardchaighdeán	ardchaighdeán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	12	obj	_	_
 4	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	3	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
@@ -8131,7 +8131,7 @@
 12	bheith	bheith	NOUN	Noun	Form=Len|VerbForm=Inf	2	csubj:cop	_	_
 13	ag	ag	ADP	Simp	_	15	case	_	_
 14	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	15	det	_	_
-15	daoine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	12	obl	_	_
+15	daoine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	12	obl	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	obj	_	_
 17	cheapfar	ceap	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Fut	15	acl:relcl	_	_
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
@@ -8149,7 +8149,7 @@
 30	Oifigiúil	oifigiúil	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	29	amod	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	_
 32	ar	ar	ADP	Simp	_	33	case	_	_
-33	mhórchanúintí	mórchanúint	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	23	conj	_	_
+33	mhórchanúintí	mórchanúint	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	23	conj	_	_
 34	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
 35	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	33	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	2	punct	_	_
@@ -8158,7 +8158,7 @@
 # text = Is ar bhonn na hargóna sin a tháinig de Valera i gceannas ar an Sinn Féin nua 'Poblachtach' i 1917.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 2	ar	ar	ADP	Simp	_	3	case	_	_
-3	bhonn	bonn	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+3	bhonn	bonn	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 4	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	hargóna	argóint	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	3	nmod	_	_
 6	sin	sin	DET	Det	PronType=Dem	5	det	_	_
@@ -8206,11 +8206,11 @@
 8	billiún	billiún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	nsubj	_	_
 9	go	go	ADP	Simp	_	10	case	_	_
 10	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	8	nmod	_	_
-11	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	8	nmod	_	_
+11	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	nmod	_	_
 12	beo	beo	ADJ	Adj	Degree=Pos	7	xcomp:pred	_	_
 13	ar	ar	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	domhan	domhan	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+15	domhan	domhan	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	5	punct	_	_
 
 # sent_id = 785
@@ -8235,7 +8235,7 @@
 7	-	-	PUNCT	Punct	_	8	punct	_	_
 8	a	a	PART	Vb	PartType=Vb|PronType=Rel	9	nsubj	_	_
 9	scríobh	scríobh	VERB	VTI	Mood=Ind|Tense=Past	4	acl:relcl	_	_
-10	Stair	stair	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	9	obj	_	NamedEntity=Yes
+10	Stair	stair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	9	obj	_	NamedEntity=Yes
 11	Iar-Chonnacht	Iar-Chonnachta	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	i	i	ADP	Simp	_	13	case	_	_
 13	1684	1684	NUM	Num	_	9	obl:tmod	_	SpaceAfter=No
@@ -8256,10 +8256,10 @@
 28	a	a	PART	Vb	PartType=Vb|PronType=Rel	29	nsubj	_	_
 29	bhí	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Past	26	acl:relcl	_	_
 30	mar	mar	ADP	Simp	_	31	case	_	_
-31	ainm	ainm	NOUN	Noun	Gender=Masc|Number=Sing	29	xcomp:pred	_	_
+31	ainm	ainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	29	xcomp:pred	_	_
 32	ar	ar	ADP	Simp	_	34	case	_	_
 33	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	34	det	_	_
-34	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	29	obl	_	_
+34	oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	obl	_	_
 35	ach	ach	SCONJ	Subord	_	36	mark	_	_
 36	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	9	advcl	_	_
 37	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	36	nsubj	_	_
@@ -8269,7 +8269,7 @@
 41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	40	nmod	_	NamedEntity=Yes
 42	ar	ar	ADP	Simp	_	44	case	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
-44	oileán	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	39	obl	_	_
+44	oileán	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	39	obl	_	_
 45	freisin	freisin	ADV	Gn	_	39	advmod	_	SpaceAfter=No
 46	.	.	PUNCT	.	_	3	punct	_	_
 
@@ -8288,7 +8288,7 @@
 11	triúr	triúr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nsubj	_	_
 12	de	de	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	comhaltaí	comhalta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	11	nmod	_	_
+14	comhaltaí	comhalta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	11	nmod	_	_
 15	nach	nach	PART	Vb	PartType=Cmpl	16	mark:prt	_	_
 16	bhféadfainnse	féad	VERB	VTI	Form=Ecl,Emp|Mood=Cnd|Number=Sing|Person=1	11	acl:relcl	_	_
 17	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	16	xcomp	_	_
@@ -8301,7 +8301,7 @@
 24	agus	agus	CCONJ	Coord	_	27	cc	_	SpaceAfter=No
 25	,	,	PUNCT	Punct	_	24	punct	_	_
 26	sna	i	ADP	Art	Number=Plur|PronType=Art	27	case	_	_
-27	cúinsí	cúinse	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	31	obl	_	_
+27	cúinsí	cúinse	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	31	obl	_	_
 28	uile	uile	DET	Det	PronType=Ind	27	det	_	SpaceAfter=No
 29	,	,	PUNCT	Punct	_	27	punct	_	_
 30	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	31	advmod	_	_
@@ -8337,14 +8337,14 @@
 16	mílaoise	mílaois	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
 17	)	)	PUNCT	Punct	_	12	punct	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	gceannáras	ceannáras	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
+19	gceannáras	ceannáras	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	12	obl	_	_
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	Roinne	roinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	agus	agus	CCONJ	Coord	_	26	cc	_	_
 23	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	26	cop	_	_
 24	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	26	nmod	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
-26	traidisiún	traidisiún	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	conj	_	_
+26	traidisiún	traidisiún	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	conj	_	_
 27	go	go	PART	Vb	PartType=Cmpl	28	mark:prt	_	_
 28	gclúdaítear	clúdaigh	VERB	VT	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	26	csubj:cop	_	_
 29	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	30	nmod:poss	_	_
@@ -8379,7 +8379,7 @@
 10	nádúrtha	nádúrtha	ADJ	Adj	Degree=Pos	6	advmod	_	_
 11	as	as	ADP	Simp	_	13	case	_	_
 12	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	13	det	_	_
-13	teagasc	teagasc	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
+13	teagasc	teagasc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	obl	_	_
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	as	as	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
@@ -8399,16 +8399,16 @@
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	múinteoir	múinteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	29	nsubj	_	_
 32	ar	ar	ADP	Simp	_	33	case	_	_
-33	bhreathnóireacht	breathnóireacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	31	nmod	_	SpaceAfter=No
+33	bhreathnóireacht	breathnóireacht	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	29	obl	_	SpaceAfter=No
 34	,	,	PUNCT	Punct	_	36	punct	_	_
 35	ar	ar	ADP	Simp	_	36	case	_	_
 36	éisteacht	éisteacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	33	conj	_	SpaceAfter=No
 37	,	,	PUNCT	Punct	_	39	punct	_	_
 38	ar	ar	ADP	Simp	_	39	case	_	_
-39	idirghníomhú	idirghníomhú	NOUN	Noun	VerbForm=Inf	33	conj	_	_
+39	idirghníomhú	idirghníomhú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	33	conj	_	_
 40	leis	le	ADP	Simp	_	42	case	_	_
 41	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	42	det	_	_
-42	daltaí	dalta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	39	nmod	_	_
+42	daltaí	dalta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	39	nmod	_	_
 43	agus	agus	CCONJ	Coord	_	45	cc	_	_
 44	ar	ar	ADP	Simp	_	45	case	_	_
 45	thorthaí	toradh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Plur	52	obj	_	_
@@ -8430,10 +8430,10 @@
 5	Cúng	cúng	ADJ	Adj	Case=Gen|NounType=Weak|Number=Plur	4	amod	_	NamedEntity=Yes
 6	an-obair	an-obair	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	obj	_	_
 7	chun	chun	ADP	Simp	_	13	case	_	_
-8	feirmeacha	feirm	NOUN	Noun	Gender=Fem|Number=Plur	13	obj	_	_
+8	feirmeacha	feirm	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	13	obj	_	_
 9	bídeacha	bídeach	ADJ	Adj	NounType=NotSlender|Number=Plur	8	amod	_	_
 10	san	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	iarthar	iarthar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
+11	iarthar	iarthar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	8	nmod	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
 13	chónascadh	cónascadh	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
@@ -8450,7 +8450,7 @@
 # sent_id = 793
 # text = Is cúlbhrát dainséarach é seo le haghaidh cluichí polaitiúla atá á n-imirt ag easaontóirí i bpáirtí David Trimble.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	cúlbhrát	cúlbhrat	NOUN	Noun	Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
+2	cúlbhrát	cúlbhrat	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
 3	dainséarach	dainséarach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	_
 4	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 5	seo	seo	PRON	Dem	PronType=Dem	4	det	_	_
@@ -8462,9 +8462,9 @@
 11	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	12	case	_	_
 12	n-imirt	imirt	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	10	xcomp	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
-14	easaontóirí	easaontóir	NOUN	Noun	Gender=Masc|Number=Plur	12	nmod	_	_
+14	easaontóirí	easaontóir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	12	nmod	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
-16	bpáirtí	páirtí	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
+16	bpáirtí	páirtí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
 17	David	David	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	Trimble	Trimble	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
@@ -8472,7 +8472,7 @@
 # sent_id = 794
 # text = Gan dabht chun iad a chur ar an sráid, bheadh orthu iad a thabhairt isteach sa chathair ar dtúis.
 1	Gan	gan	ADP	Simp	_	2	case	_	_
-2	dabht	dabht	NOUN	Noun	Gender=Masc|Number=Sing	11	obl	_	_
+2	dabht	dabht	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obl	_	_
 3	chun	chun	ADP	Simp	_	6	case	_	_
 4	iad	iad	PRON	Pers	Number=Plur|Person=3	6	obj	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
@@ -8523,7 +8523,7 @@
 13	Kaji-htu	Kaji-htu	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	19	punct	_	_
 15	chun	chun	ADP	Simp	_	19	case	_	_
-16	misean	misean	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
+16	misean	misean	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obj	_	_
 17	nua	nua	ADJ	Adj	Degree=Pos	16	amod	_	_
 18	a	a	PART	Inf	PartType=Inf	19	mark	_	_
 19	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	7	xcomp	_	_
@@ -8556,7 +8556,7 @@
 9	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	10	nmod:poss	_	_
 10	leithéid	leithéid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	nsubj	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
-12	scéala	scéala	NOUN	Noun	Gender=Masc|Number=Sing	10	nmod	_	_
+12	scéala	scéala	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	nmod	_	_
 13	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	8	xcomp:pred	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	_	_
 
@@ -8606,15 +8606,15 @@
 
 # sent_id = 802
 # text = Díomá Dúirt Antaine Ó Faracháin, duine de choiste eagraithe Fhéile Sean-Nós Cois Life go raibh díomá ar lucht na féile faoin bpolasaí nua.
-1	Díomá	díomá	NOUN	Noun	Gender=Fem|Number=Sing	2	parataxis	_	_
+1	Díomá	díomá	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	parataxis	_	_
 2	Dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 3	Antaine	Antaine	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	NamedEntity=Yes
 4	Ó	ó	PART	Pat	PartType=Pat	3	flat:name	_	NamedEntity=Yes
 5	Faracháin	Faracháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	3	appos	_	_
+7	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	appos	_	_
 8	de	de	ADP	Simp	_	9	case	_	_
-9	choiste	coiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
+9	choiste	coiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	_
 10	eagraithe	eagrú	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	nmod	_	_
 11	Fhéile	féile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
 12	Sean-Nós	sean-nós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
@@ -8628,14 +8628,14 @@
 20	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	féile	féile	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	19	nmod	_	_
 22	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	bpolasaí	polasaí	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	16	obl	_	_
+23	bpolasaí	polasaí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	16	obl	_	_
 24	nua	nua	ADJ	Adj	Gender=Masc|Number=Sing	23	amod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 803
 # text = Is Gaeilgeoirí ó dhúchas isteach is amach ar dheich faoin gcéad de na mic léinn a thagann isteach go Coláiste Phádraig, Droim Conrach gach bliain.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	Gaeilgeoirí	Gaeilgeoir	NOUN	Noun	Gender=Masc|Number=Plur	0	root	_	_
+2	Gaeilgeoirí	Gaeilgeoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	0	root	_	_
 3	ó	ó	ADP	Simp	_	4	case	_	_
 4	dhúchas	dúchas	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
 5	isteach	isteach	ADV	Dir	_	2	advmod	_	_
@@ -8647,13 +8647,13 @@
 11	gcéad	céad	NUM	Num	Form=Ecl|NumType=Card	2	nmod	_	_
 12	de	de	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	mic	mac	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	9	nmod	_	_
+14	mic	mac	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	9	nmod	_	_
 15	léinn	léann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	compound	_	_
 16	a	a	PART	Vb	PartType=Vb|PronType=Rel	17	nsubj	_	_
 17	thagann	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Pres	14	acl:relcl	_	_
 18	isteach	isteach	ADV	Dir	_	17	advmod	_	_
 19	go	go	ADP	Simp	_	20	case	_	_
-20	Coláiste	coláiste	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	obl	_	NamedEntity=Yes
+20	Coláiste	coláiste	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	18	obl	_	NamedEntity=Yes
 21	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	23	punct	_	_
 23	Droim	droim	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
@@ -8673,14 +8673,14 @@
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	pobal	pobal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	i	i	ADP	Simp	_	10	case	_	_
-10	gcoitinne	coitinne	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Sing	8	nmod	_	_
+10	gcoitinne	coitinne	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	8	nmod	_	_
 11	nach	nach	PART	Vb	PartType=Cmpl	12	mark:prt	_	_
 12	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	6	ccomp	_	_
 13	aon	aon	DET	Det	PronType=Ind	14	det	_	_
 14	teora	teora	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	12	nsubj	_	_
 15	leis	le	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	méid	méid	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
+17	méid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 18	daoine	duine	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	17	nmod	_	_
 19	a	a	PART	Vb	PartType=Vb|PronType=Rel	20	nsubj	_	_
 20	bheadh	bí	VERB	Cond	Form=Len|Mood=Cnd	18	acl:relcl	_	_
@@ -8693,7 +8693,7 @@
 27	roimh	roimh	ADP	Simp	_	28	case	_	_
 28	dheireadh	deireadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	_
 29	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-30	h-aoise	aois	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Sing	28	nmod	_	_
+30	h-aoise	aois	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	28	nmod	_	_
 31	seo	seo	DET	Det	PronType=Dem	30	det	_	SpaceAfter=No
 32	.	.	PUNCT	.	_	6	punct	_	_
 
@@ -8731,17 +8731,17 @@
 7	tSeirbhís	seirbhís	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nsubj	_	NamedEntity=Yes
 8	Uisce	uisce	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	10	det	_	_
-10	fógraí	fógra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obj	_	_
+10	fógraí	fógra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	obj	_	_
 11	ar	ar	ADP	Simp	_	13	case	_	_
 12	gach	gach	DET	Det	Definite=Def	13	det	_	_
 13	teach	teach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 14	agus	agus	CCONJ	Coord	_	17	cc	_	_
 15	ar	ar	ADP	Simp	_	17	case	_	_
 16	gach	gach	DET	Det	Definite=Def	17	det	_	_
-17	foirgneamh	foirgneamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	conj	_	_
+17	foirgneamh	foirgneamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	conj	_	_
 18	a	a	PART	Vb	PartType=Vb|PronType=Rel	19	nsubj	_	_
 19	fhaigheann	faigh	VERB	VT	Form=Len|Mood=Ind|Tense=Pres	13	acl:relcl	_	_
-20	uisce	uisce	NOUN	Noun	Gender=Masc|Number=Sing	19	obj	_	_
+20	uisce	uisce	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	19	obj	_	_
 21	ó	ó	ADP	Simp	_	22	case	_	_
 22	Thaiscumar	taiscumar	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	obl	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -8765,13 +8765,13 @@
 12	agus	agus	CCONJ	Coord	_	14	cc	_	_
 13	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	14	case	_	_
 14	dteannta	teannta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	15	nmod	_	_
-15	altóirí	altóir	NOUN	Noun	Gender=Fem|Number=Plur	7	conj	_	_
+15	altóirí	altóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	7	conj	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	a	a	PART	Vb	PartType=Vb|PronType=Rel	18	obl	_	_
 18	ndéanadh	déan	VERB	VTI	Aspect=Imp|Form=Ecl|Tense=Past	15	acl:relcl	_	_
 19	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-20	draoithe	draoi	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	18	obj	_	_
-21	íobairtí	íobairt	NOUN	Noun	Gender=Fem|Number=Plur	20	nmod	_	SpaceAfter=No
+20	draoithe	draoi	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	18	nsubj	_	_
+21	íobairtí	íobairt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	18	obj	_	SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 809
@@ -8787,7 +8787,7 @@
 9	gach	gach	DET	Det	Definite=Def	10	det	_	_
 10	foireann	foireann	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
 11	:	:	PUNCT	Punct	_	12	punct	_	_
-12	éide	éide	NOUN	Noun	Gender=Fem|Number=Sing	1	parataxis	_	_
+12	éide	éide	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	parataxis	_	_
 13	a	a	PART	Vb	PartType=Vb|PronType=Rel	14	obl	_	_
 14	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	12	acl:relcl	_	_
 15	dath	dath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	nsubj	_	_
@@ -8801,10 +8801,10 @@
 23	ag	ag	ADP	Simp	_	24	case	_	_
 24	imirt	imirt	NOUN	Noun	VerbForm=Vnoun	22	xcomp	_	_
 25	sa	i	ADP	Art	Number=Sing|PronType=Art	26	case	_	_
-26	bhaile	baile	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
+26	bhaile	baile	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	obl	_	SpaceAfter=No
 27	;	;	PUNCT	Punct	_	28	punct	_	_
 28	agus	agus	CCONJ	Coord	_	29	cc	_	_
-29	éide	éide	NOUN	Noun	Gender=Fem|Number=Sing	12	conj	_	_
+29	éide	éide	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	12	conj	_	_
 30	a	a	PART	Vb	PartType=Vb|PronType=Rel	31	obl	_	_
 31	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	29	acl:relcl	_	_
 32	dath	dath	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	31	nsubj	_	_
@@ -8819,7 +8819,7 @@
 41	imirt	imirt	NOUN	Noun	VerbForm=Vnoun	39	xcomp	_	_
 42	'	'	PUNCT	Punct	_	44	punct	_	SpaceAfter=No
 43	as	as	ADP	Simp	_	44	case	_	_
-44	baile	baile	NOUN	Noun	Gender=Masc|Number=Sing	41	obl	_	SpaceAfter=No
+44	baile	baile	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	41	obl	_	SpaceAfter=No
 45	'	'	PUNCT	Punct	_	44	punct	_	SpaceAfter=No
 46	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -8866,7 +8866,7 @@
 5	eile	eile	DET	Det	PronType=Dem	4	det	_	_
 6	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	obj	_	_
 7	ar	ar	ADP	Simp	_	8	case	_	_
-8	ball	ball	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	_
+8	ball	ball	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
 9	cé	cé	SCONJ	Subord	_	11	mark	_	_
 10	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	11	cop	_	_
 11	bheag	beag	ADJ	Adj	Degree=Pos|Form=Len	2	advcl	_	_
@@ -8889,14 +8889,14 @@
 4	,	,	PUNCT	Punct	_	3	punct	_	_
 5	tharraing	tarraing	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	siad	siad	PRON	Pers	Number=Plur|Person=3	5	nsubj	_	_
-7	gorta	gorta	NOUN	Noun	Gender=Masc|Number=Sing	5	obj	_	SpaceAfter=No
+7	gorta	gorta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obj	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	léirscrios	léirscrios	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	conj	_	_
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
 11	bás	bás	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	7	conj	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	14	det	_	_
-14	daoine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
+14	daoine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
 15	a	a	PART	Vb	PartType=Vb|PronType=Rel	16	nsubj	_	_
 16	thogh	togh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	14	acl:relcl	_	_
 17	iad	iad	PRON	Pers	Number=Plur|Person=3	16	obj	_	SpaceAfter=No
@@ -8914,7 +8914,7 @@
 8	baint	baint	NOUN	Noun	VerbForm=Vnoun	6	xcomp	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	PronType=Art	11	det	_	_
-11	imirce	imirce	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
+11	imirce	imirce	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	8	obl	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 815
@@ -8927,7 +8927,7 @@
 6	dul	dul	NOUN	Noun	VerbForm=Inf	2	xcomp	_	_
 7	tríd	trí	ADP	Simp	_	9	case	_	_
 8	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
-9	heachtraí	eachtra	NOUN	Noun	Definite=Def|Form=HPref|Gender=Fem|Number=Plur	6	obl	_	_
+9	heachtraí	eachtra	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Fem|Number=Plur	6	obl	_	_
 10	peannaideacha	peannaideach	ADJ	Adj	NounType=NotSlender|Number=Plur	9	amod	_	_
 11	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 12	a	a	PART	Vb	PartType=Vb|PronType=Rel	13	obj	_	_
@@ -8940,15 +8940,15 @@
 19	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	18	nsubj	_	_
 20	orthu	ar	ADP	Prep	Number=Plur|Person=3	18	obl:prep	_	_
 21	faoi	faoi	ADP	Simp	_	22	case	_	_
-22	mheascán	meascán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	18	obl	_	_
+22	mheascán	meascán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	18	obl	_	_
 23	den	de	ADP	Art	Number=Sing|PronType=Art	24	case	_	_
 24	anacair	anacair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	_
 25	agus	agus	CCONJ	Coord	_	27	cc	_	_
 26	den	de	ADP	Art	Number=Sing|PronType=Art	27	case	_	_
-27	eagla	eagla	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	24	conj	_	SpaceAfter=No
+27	eagla	eagla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	24	conj	_	SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	go	go	ADP	Simp	_	30	case	_	_
-30	fiú	fiú	NOUN	Subst	Number=Sing	18	obl	_	SpaceAfter=No
+30	fiú	fiú	NOUN	Subst	Case=NomAcc|Number=Sing	18	obl	_	SpaceAfter=No
 31	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 816
@@ -8979,10 +8979,10 @@
 8	teacht	teacht	NOUN	Noun	VerbForm=Vnoun	4	xcomp	_	_
 9	fríd	trí	ADP	Simp	_	11	case	_	_
 10	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	11	nmod:poss	_	_
-11	cheann	ceann	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+11	cheann	ceann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 12	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	14	cop	_	_
 13	trí	trí	ADP	Simp	_	14	case	_	_
-14	ghné	gné	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	4	ccomp	_	_
+14	ghné	gné	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	4	ccomp	_	_
 15	den	de	ADP	Art	Number=Sing|PronType=Art	16	case	_	_
 16	anam	anam	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	_
 17	amháin	amháin	ADJ	Adj	Degree=Pos	16	amod	_	_
@@ -9014,7 +9014,7 @@
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	fhilíocht	filíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	35	obl	_	_
 45	agus	agus	CCONJ	Coord	_	46	cc	_	_
-46	éachtaí	éacht	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	44	conj	_	_
+46	éachtaí	éacht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	44	conj	_	_
 47	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
 48	tsaoil	saol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	,	,	PUNCT	Punct	_	50	punct	_	_
@@ -9029,7 +9029,7 @@
 58	throid	troid	NOUN	Noun	Form=Len|VerbForm=Inf	51	xcomp	_	_
 59	thart	thart	ADV	Dir	_	58	advmod	_	_
 60	ceithre	ceathair	NUM	Num	NumType=Card	61	nummod	_	_
-61	ceathrúna	ceathrú	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	58	obl	_	_
+61	ceathrúna	ceathrú	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	58	obl	_	_
 62	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	63	det	_	_
 63	domhain	domhan	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	61	nmod	_	SpaceAfter=No
 64	.	.	PUNCT	.	_	4	punct	_	_
@@ -9037,7 +9037,7 @@
 # sent_id = 818
 # text = Is fiaile go minic é.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	fiaile	fiaile	NOUN	Noun	Gender=Fem|Number=Sing	0	root	_	_
+2	fiaile	fiaile	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	0	root	_	_
 3	go	go	PART	Ad	PartType=Ad	4	mark:prt	_	_
 4	minic	minic	ADJ	Adj	Degree=Pos	2	advmod	_	_
 5	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	SpaceAfter=No
@@ -9048,7 +9048,7 @@
 1	Taispeánann	taispeáin	VERB	VT	Mood=Ind|Tense=Pres	0	root	_	_
 2	suimiú	suimiú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	fhigiúirí	figiúr	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	1	obl	_	_
+4	fhigiúirí	figiúr	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	1	obl	_	_
 5	'	'	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
 6	tally	tally	X	Foreign	Foreign=Yes	4	appos	_	SpaceAfter=No
 7	'	'	PUNCT	Punct	_	6	punct	_	_
@@ -9057,7 +9057,7 @@
 10	6,900	6,900	NUM	Num	_	11	nummod	_	_
 11	vóta	vóta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	9	nsubj	_	_
 12	ar	ar	ADP	Simp	_	13	case	_	_
-13	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	11	nmod	_	_
+13	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
 14	ag	ag	ADP	Simp	_	15	case	_	_
 15	Éamon	Éamon	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
 16	Ó	ó	PART	Pat	PartType=Pat	15	flat:name	_	NamedEntity=Yes
@@ -9076,17 +9076,17 @@
 29	cathrach	cathair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
-32	oileáin	oileán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	23	conj	_	NamedEntity=Yes
+32	oileáin	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	23	conj	_	NamedEntity=Yes
 33	Árann	Árainn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	32	nmod	_	NamedEntity=Yes
 34	san	i	ADP	Art	Number=Sing|PronType=Art	35	case	_	_
-35	áireamh	áireamh	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	SpaceAfter=No
+35	áireamh	áireamh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	32	nmod	_	SpaceAfter=No
 36	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 820
 # text = Faightear na sliogáin fholmha caite aníos ar an trá.
 1	Faightear	faigh	VERB	VT	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
 2	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	sliogáin	sliogán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
+3	sliogáin	sliogán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obj	_	_
 4	fholmha	folamh	ADJ	Adj	Form=Len|Number=Plur	3	amod	_	_
 5	caite	caite	ADJ	Adj	VerbForm=Part	3	amod	_	_
 6	aníos	aníos	ADV	Dir	_	1	advmod	_	_
@@ -9108,7 +9108,7 @@
 9	bhliana	bliain	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	5	conj	_	_
 10	measúnachta	measúnacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
 11	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	12	case	_	_
-12	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	10	nmod	_	SpaceAfter=No
+12	éis	éis	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	10	nmod	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	3	punct	_	_
 14	féadfaidh	féad	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -9120,8 +9120,8 @@
 21	áirithe	áirithe	ADJ	Adj	Gender=Masc|Number=Sing	20	amod	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	d'	de	ADP	Simp	_	24	case	_	SpaceAfter=No
-24	fhonn	fonn	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	33	obj	_	_
-25	íoc	íoc	NOUN	Noun	Gender=Masc|Number=Sing	24	nmod	_	_
+24	fhonn	fonn	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	33	obj	_	_
+25	íoc	íoc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	24	nmod	_	_
 26	réamhchánach	réamhcháin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	25	nmod	_	_
 27	de	de	ADP	Cmpd	PrepForm=Cmpd	30	case	_	_
 28	réir	réir	ADP	Cmpd	PrepForm=Cmpd	27	fixed	_	_
@@ -9164,20 +9164,20 @@
 65	,	,	PUNCT	Punct	_	60	punct	_	_
 66	aontú	aontú	NOUN	Noun	VerbForm=Inf	36	nmod	_	_
 67	le	le	ADP	Simp	_	68	case	_	_
-68	méadú	méadú	NOUN	Noun	Gender=Masc|Number=Sing	66	obl	_	_
+68	méadú	méadú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	66	obl	_	_
 69	nó	nó	CCONJ	Coord	_	70	cc	_	_
 70	laghdú	laghdú	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	68	conj	_	_
 71	ar	ar	ADP	Simp	_	73	case	_	_
 72	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	73	det	_	_
-73	méid	méid	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	70	nmod	_	_
+73	méid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	70	nmod	_	_
 74	a	a	PART	Vb	PartType=Vb|PronType=Rel	75	obl	_	_
 75	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	73	acl:relcl	_	_
 76	le	le	ADP	Simp	_	77	case	_	_
 77	bailiú	bailiú	NOUN	Noun	VerbForm=Inf	75	xcomp	_	_
 78	i	i	ADP	Simp	_	79	case	_	_
-79	dtráthchodanna	tráthchuid	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	77	obl	_	_
+79	dtráthchodanna	tráthchuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Plur	77	obl	_	_
 80	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	81	case	_	_
-81	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	75	obl	_	_
+81	éis	éis	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	75	obl	_	_
 82	sin	sin	PRON	Dem	PronType=Dem	81	det	_	_
 83	sa	i	ADP	Art	Number=Sing|PronType=Art	84	case	_	_
 84	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	75	obl	_	_
@@ -9187,10 +9187,10 @@
 88	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	89	advmod	_	_
 89	dhéileálfar	déileáil	VERB	VI	Form=Len|Mood=Ind|Person=0|Tense=Fut	14	advcl	_	_
 90	le	le	ADP	Simp	_	91	case	_	_
-91	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	89	obl	_	_
+91	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	89	obl	_	_
 92	inmhuirearaithe	inmhuirearaithe	ADJ	Adj	Gender=Masc|Number=Sing	91	amod	_	_
 93	mar	mar	ADP	Simp	_	94	case	_	_
-94	dhuine	duine	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	92	nmod	_	_
+94	dhuine	duine	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	92	nmod	_	_
 95	a	a	PART	Vb	PartType=Vb|PronType=Rel	96	obl	_	_
 96	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	94	acl:relcl	_	_
 97	méid	méid	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	96	nsubj	_	_
@@ -9215,14 +9215,14 @@
 116	10	10	NUM	Num	_	117	nummod	_	_
 117	líon	líon	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	114	conj	_	_
 118	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	119	det	_	_
-119	dtráthchodanna	tráthchuid	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	117	nmod	_	_
+119	dtráthchodanna	tráthchuid	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|Number=Plur	117	nmod	_	_
 120	míosúla	míosúil	ADJ	Adj	NounType=NotSlender|Number=Plur	119	amod	_	_
 121	a	a	PART	Vb	PartType=Vb|PronType=Rel	122	nsubj	_	_
 122	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	119	acl:relcl	_	_
 123	íoctha	íoctha	ADJ	Adj	VerbForm=Part	122	xcomp:pred	_	_
 124	ag	ag	ADP	Simp	_	126	case	_	_
 125	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	126	det	_	_
-126	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	123	obl	_	_
+126	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	123	obl	_	_
 127	sin	sin	DET	Det	PronType=Dem	126	det	_	_
 128	sa	i	ADP	Art	Number=Sing|PronType=Art	129	case	_	_
 129	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	122	obl:tmod	_	_
@@ -9232,7 +9232,7 @@
 133	(II)	(II)	NUM	Item	_	112	conj	_	_
 134	go	go	PART	Vb	PartType=Cmpl	135	mark:prt	_	_
 135	ndéantar	déan	VERB	VTI	Form=Ecl|Mood=Ind|Person=0|Tense=Pres	112	advcl	_	_
-136	méid	méid	NOUN	Noun	Gender=Masc|Number=Sing	135	obj	_	_
+136	méid	méid	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	135	obj	_	_
 137	nach	is	AUX	Cop	PronType=Rel|Tense=Pres|VerbForm=Cop	138	cop	_	_
 138	lú	beag	ADJ	Adj	Degree=Cmp,Sup	136	acl:relcl	_	_
 139	ná	ná	CCONJ	Coord	_	140	cc	_	_
@@ -9240,14 +9240,14 @@
 141	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	142	case	_	_
 142	gcéad	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	136	nmod	_	_
 143	de	de	ADP	Simp	_	144	case	_	_
-144	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	142	nmod	_	_
+144	mhéid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	142	nmod	_	_
 145	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	146	det	_	_
 146	réamhchánach	réamhcháin	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	144	nmod	_	_
 147	is	is	PART	Sup	PartType=Sup	148	mark:prt	_	_
 148	iníoctha	iníoctha	ADJ	Adj	Degree=Cmp,Sup	146	amod	_	_
 149	ag	ag	ADP	Simp	_	151	case	_	_
 150	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	151	det	_	_
-151	duine	duine	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	135	obl	_	_
+151	duine	duine	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	135	obl	_	_
 152	sin	sin	DET	Det	PronType=Dem	151	det	_	_
 153	don	do	ADP	Art	Number=Sing|PronType=Art	154	case	_	_
 154	bhliain	bliain	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	157	obj	_	_
@@ -9255,7 +9255,7 @@
 156	a	a	PART	Inf	PartType=Inf	157	mark	_	_
 157	íoc	íoc	NOUN	Noun	VerbForm=Inf	135	xcomp	_	_
 158	i	i	ADP	Simp	_	159	case	_	_
-159	dtráthchodanna	tráthchuid	NOUN	Noun	Form=Ecl|Gender=Fem|Number=Plur	157	obl	_	_
+159	dtráthchodanna	tráthchuid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Plur	157	obl	_	_
 160	ar	ar	ADP	Simp	_	159	case	_	_
 161	nó	nó	CCONJ	Coord	_	165	cc	_	_
 162	roimh	roimh	ADP	Simp	_	165	case	_	_
@@ -9292,7 +9292,7 @@
 2	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 3	ceart	ceart	ADJ	Adj	Degree=Pos	0	root	_	_
 4	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-5	hionsaithe	ionsaí	NOUN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Plur	7	obj	_	_
+5	hionsaithe	ionsaí	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	7	obj	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	cháineadh	cáineadh	NOUN	Noun	Form=Len|VerbForm=Inf	3	csubj:cop	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
@@ -9333,7 +9333,7 @@
 5	dó	dó	NUM	Num	NumType=Card	8	nummod	_	_
 6	dhéag	déag	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	5	nmod	_	_
 7	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
-8	chlog	clog	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl:tmod	_	SpaceAfter=No
+8	chlog	clog	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl:tmod	_	SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 826
@@ -9358,7 +9358,7 @@
 18	huaighe	uaigh	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	14	obl	_	_
 19	is	agus	SCONJ	Subord	_	21	mark	_	_
 20	gan	gan	ADP	Simp	_	21	case	_	_
-21	tórramh	tórramh	NOUN	Noun	Gender=Masc|Number=Sing	14	advcl	_	_
+21	tórramh	tórramh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	14	advcl	_	_
 22	ceart	ceart	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	21	amod	_	_
 23	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	21	obl:prep	_	SpaceAfter=No
 24	.	.	PUNCT	.	_	2	punct	_	_
@@ -9396,7 +9396,7 @@
 4	raimhre	raimhre	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	2	nsubj	_	_
 5	fós	fós	ADV	Gn	_	2	advmod	_	_
 6	sna	i	ADP	Art	Number=Plur|PronType=Art	7	case	_	_
-7	prátaí	práta	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	2	obl	_	_
+7	prátaí	práta	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	2	obl	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
 9	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	2	conj	_	_
 10	formhór	formhór	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	nsubj	_	_
@@ -9404,7 +9404,7 @@
 12	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	13	det	_	_
 13	dtornapaí	tornapa	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	10	nmod	_	_
 14	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	15	case	_	_
-15	bpóiríní	póirín	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	SpaceAfter=No
+15	bpóiríní	póirín	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	9	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 829
@@ -9428,7 +9428,7 @@
 4	Richard	Richard	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	conj	_	_
 5	go	go	PART	Vb	PartType=Cmpl	7	mark:prt	_	_
 6	mb'	is	AUX	Cop	Form=Ecl,VF|Tense=Past|VerbForm=Cop	7	cop	_	SpaceAfter=No
-7	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	1	ccomp	_	_
+7	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	1	ccomp	_	_
 8	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	9	cop	_	_
 9	cheart	ceart	ADJ	Adj	Degree=Pos|Form=Len	7	csubj:cop	_	_
 10	dúinn	do	ADP	Prep	Number=Plur|Person=1	9	obl:prep	_	_
@@ -9445,9 +9445,9 @@
 21	chuadar	téigh	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=3|Tense=Past	1	parataxis	_	_
 22	timpeall	timpeall	ADV	Dir	_	21	advmod	_	_
 23	ag	ag	ADP	Simp	_	24	case	_	_
-24	tógaint	tógáil	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	21	xcomp	_	_
+24	tógaint	tógáil	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	xcomp	_	_
 25	ár	ár	DET	Det	Number=Plur|Person=1|Poss=Yes	26	nmod:poss	_	_
-26	seoltaí	seol	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
+26	seoltaí	seol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	24	nmod	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	30	punct	_	_
 28	ach	ach	SCONJ	Subord	_	30	mark	_	_
 29	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	30	advmod	_	_
@@ -9462,15 +9462,15 @@
 # text = 'Is féidir libh troid amárach, más gá ar chor ar bith é,' a dúirt an tOllamh go fuinniúil.
 1	'	'	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 2	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
-3	féidir	féidir	NOUN	Subst	Number=Sing	18	parataxis	_	_
+3	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	18	parataxis	_	_
 4	libh	le	ADP	Prep	Number=Plur|Person=2	3	obl:prep	_	_
 5	troid	troid	NOUN	Noun	VerbForm=Inf	3	csubj:cop	_	_
 6	amárach	amárach	ADV	Temp	_	5	advmod	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	9	punct	_	_
 8	más	má	SCONJ	Subord	VerbForm=Cop	9	mark	_	_
-9	gá	gá	NOUN	Noun	Gender=Masc|Number=Sing	3	advcl	_	_
+9	gá	gá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	advcl	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	chor	cor	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+11	chor	cor	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 12	ar	ar	ADP	Simp	_	11	nmod	_	_
 13	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	12	fixed	_	_
 14	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	9	nsubj	_	SpaceAfter=No
@@ -9509,7 +9509,7 @@
 21	airigh	airigh	VERB	VT	Mood=Ind|Tense=Past	15	advcl	_	_
 22	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	21	nsubj	_	_
 23	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	24	nmod:poss	_	_
-24	coisméig	coisméig	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	21	obj	_	_
+24	coisméig	coisméig	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	obj	_	_
 25	éadrom	éadrom	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	24	amod	_	_
 26	ag	ag	ADP	Simp	_	27	case	_	_
 27	teannadh	teannadh	NOUN	Noun	VerbForm=Vnoun	21	xcomp	_	_
@@ -9523,7 +9523,7 @@
 35	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	_
 36	dhoras	doras	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	_
 37	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	38	det	_	_
-38	agaird	agard	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
+38	agaird	agard	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 39	.	.	PUNCT	.	_	9	punct	_	_
 
 # sent_id = 833
@@ -9532,13 +9532,13 @@
 2	Chuardaíomar	cuardaigh	VERB	VTI	Form=Len|Mood=Ind|Number=Plur|Person=1|Tense=Past	0	root	_	_
 3	gach	gach	DET	Det	Definite=Def	5	det	_	_
 4	aon	aon	DET	Det	PronType=Ind	5	det	_	_
-5	chuas	cuas	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
+5	chuas	cuas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obj	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
 7	leith	leith	NOUN	Noun	Gender=Fem|Number=Sing	2	obl	_	_
 8	chomh	chomh	ADV	Its	_	9	advmod	_	_
 9	fada	fada	ADJ	Adj	Degree=Pos	2	advmod	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
-11	Cuas	cuas	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	NamedEntity=Yes
+11	Cuas	cuas	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	NamedEntity=Yes
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	NamedEntity=Yes
 13	Naoi	naoi	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	_	_
@@ -9555,7 +9555,7 @@
 8	contráilte	contráilte	ADJ	Adj	Degree=Pos	5	xcomp:pred	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	11	det	_	_
-11	marcanna	marc	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
+11	marcanna	marc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	5	obl	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	mbliana	bliain	NOUN	Noun	Case=Dat|Form=Ecl|Gender=Fem|Number=Sing	5	obl:tmod	_	_
 14	agus	agus	CCONJ	Coord	_	15	cc	_	_
@@ -9595,11 +9595,11 @@
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	SpaceAfter=No
 2	ait	ait	ADJ	Adj	Degree=Pos	0	root	_	_
 3	ar	ar	ADP	Simp	_	4	case	_	_
-4	fad	fad	NOUN	Noun	Gender=Masc|Number=Sing	2	obl	_	_
+4	fad	fad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	obl	_	_
 5	go	go	PART	Vb	PartType=Cmpl	6	mark:prt	_	_
 6	bhféadfadh	féad	VERB	VTI	Form=Ecl|Mood=Cnd	2	csubj:cop	_	_
 7	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	nsubj	_	_
-8	leasainm	leasainm	NOUN	Noun	Gender=Masc|Number=Sing	10	obj	_	_
+8	leasainm	leasainm	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	obj	_	_
 9	a	a	PART	Inf	PartType=Inf	10	mark	_	_
 10	mhearú	mearú	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 11	ar	ar	ADP	Cmpd	PrepForm=Cmpd	13	case	_	_
@@ -9664,7 +9664,7 @@
 27	1920-	1920-	NUM	Num	_	24	nmod	_	SpaceAfter=No
 28	)	)	PUNCT	Punct	_	27	punct	_	_
 29	dar	dar	SCONJ	Subord	Mood=Ind|Tense=Pres	18	obl	_	_
-30	teideal	teideal	NOUN	Noun	Gender=Masc|Number=Sing	22	nmod	_	_
+30	teideal	teideal	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	nmod	_	_
 31	'	'	PUNCT	Punct	_	32	punct	_	SpaceAfter=No
 32	The	the	X	Foreign	Foreign=Yes	30	nmod	_	_
 33	End	End	X	Foreign	Foreign=Yes	32	flat:foreign	_	_
@@ -9676,12 +9676,12 @@
 39	in	i	ADP	Simp	_	40	case	_	_
 40	ómós	ómós	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	obl	_	_
 41	don	do	ADP	Art	Number=Sing|PronType=Art	42	case	_	_
-42	phrionsa	prionsa	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	nmod	_	_
+42	phrionsa	prionsa	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	nmod	_	_
 43	fir	fear	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	42	nmod	_	_
 44	a	a	PART	Vb	PartType=Vb|PronType=Rel	45	nsubj	_	_
 45	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	42	acl:relcl	_	_
 46	ar	ar	ADP	Simp	_	47	case	_	_
-47	lár	lár	NOUN	Noun	Gender=Masc|Number=Sing	45	obl	_	SpaceAfter=No
+47	lár	lár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	45	obl	_	SpaceAfter=No
 48	.	.	PUNCT	.	_	18	punct	_	_
 
 # sent_id = 839
@@ -9689,7 +9689,7 @@
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	4	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nmod	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
-4	Ceannfort	ceannfort	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+4	Ceannfort	ceannfort	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 5	Mac	mac	PART	Pat	PartType=Pat	4	flat	_	NamedEntity=Yes
 6	a'	an	PART	Pat	Definite=Def|Number=Sing|PronType=Art	4	flat:name	_	NamedEntity=Yes
 7	Bhaird	Baird	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
@@ -9702,14 +9702,14 @@
 14	seo	seo	DET	Det	PronType=Dem	13	det	_	_
 15	roimh	roimh	ADP	Simp	_	17	case	_	_
 16	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	17	det	_	_
-17	gCigirt	cigirt	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
+17	gCigirt	cigirt	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
 18	Mac	mac	PART	Pat	PartType=Pat	17	flat	_	NamedEntity=Yes
 19	Fhionnlaoich	Fionnlaoch	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 20	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 840
 # text = Tuaisceart na Mór-Roinne ón bhFrainc soir go dtí an Áise.
-1	Tuaisceart	tuaisceart	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+1	Tuaisceart	tuaisceart	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 2	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	NamedEntity=Yes
 3	Mór-Roinne	Mór-Roinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 4	ón	ó	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
@@ -9728,14 +9728,14 @@
 3	Mac	mac	PART	Pat	PartType=Pat	2	flat:name	_	NamedEntity=Yes
 4	Piarais	Piarais	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	appos	_	_
+6	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	appos	_	_
 7	cumasach	cumasach	ADJ	Adj	Degree=Pos	6	amod	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	9	punct	_	_
 9	díograiseach	díograiseach	ADJ	Adj	Degree=Pos	7	conj	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
 11	dúthrachtach	dúthrachtach	ADJ	Adj	Degree=Pos	7	conj	_	_
 12	ach	ach	SCONJ	Subord	_	13	mark	_	_
-13	duine	duine	NOUN	Noun	Gender=Masc|Number=Sing	2	advcl	_	_
+13	duine	duine	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	2	advcl	_	_
 14	nach	nach	PART	Vb	PartType=Vb|PronType=Rel	15	mark:prt	_	_
 15	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	13	acl:relcl	_	_
 16	ceird	ceird	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	15	nsubj	_	_
@@ -9743,7 +9743,7 @@
 18	ionramhálaí	ionramhálaí	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	_
 19	ná	ná	CCONJ	Coord	_	21	cc	_	_
 20	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	det	_	_
-21	teagmhálaí	teagmhálaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
+21	teagmhálaí	teagmhálaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 22	dhioplómaitiúil	dioplómaitiúil	ADJ	Adj	Form=Len|Gender=Masc|Number=Sing	21	amod	_	_
 23	riamh	riamh	ADV	Gn	_	15	advmod	_	_
 24	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	SpaceAfter=No
@@ -9759,9 +9759,9 @@
 6	gur	gur	PART	Vb	PartType=Vb|Tense=Past	7	mark:prt	_	_
 7	cuireadh	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	2	acl:relcl	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	leabhar	leabhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
+9	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 10	i	i	ADP	Simp	_	11	case	_	_
-11	gcló	cló	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
+11	gcló	cló	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	7	obl	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	2	punct	_	_
 13	faighimid	faigh	VERB	VT	Mood=Ind|Number=Plur|Person=1|Tense=Pres	0	root	_	_
 14	tráchtaireacht	tráchtaireacht	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	13	obj	_	_
@@ -9782,7 +9782,7 @@
 29	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	28	obl:prep	_	_
 30	ach	ach	SCONJ	Subord	_	32	mark:prt	_	_
 31	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	det	_	_
-32	buille	buille	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	advcl	_	_
+32	buille	buille	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	24	advcl	_	_
 33	faoi	faoi	ADP	Simp	_	34	case	_	_
 34	thuairim	tuairim	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	32	nmod	_	SpaceAfter=No
 35	.	.	PUNCT	.	_	13	punct	_	_
@@ -9839,11 +9839,11 @@
 # sent_id = 845
 # text = Is ball é de Rúnaíocht Institiúid na hÉireann, 27 Sráid an Phiarsaigh, Baile Átha Cliath.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	ball	ball	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+2	ball	ball	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 3	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	de	de	ADP	Simp	_	5	case	_	_
-5	Rúnaíocht	rúnaíocht	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
-6	Institiúid	institiúid	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
+5	Rúnaíocht	rúnaíocht	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	2	nmod	_	NamedEntity=Yes
+6	Institiúid	institiúid	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	NamedEntity=Yes
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	NamedEntity=Yes
 8	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
@@ -9876,14 +9876,14 @@
 15	díreach	díreach	ADJ	Adj	Degree=Pos	13	amod	_	_
 16	ar	ar	ADP	Simp	_	18	case	_	_
 17	mo	mo	DET	Det	Number=Sing|Person=1|Poss=Yes	18	nmod:poss	_	_
-18	ghlúine	glúin	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Plur	15	obl	_	_
+18	ghlúine	glúin	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Plur	15	obl	_	_
 19	roimpi	roimh	ADP	Prep	Gender=Fem|Number=Sing|Person=3	13	obl:prep	_	_
 20	go	go	PART	Vb	PartType=Cmpl	21	mark:prt	_	_
 21	bpógfainn	póg	VERB	VTI	Form=Ecl|Mood=Cnd|Number=Sing|Person=1	13	ccomp	_	_
 22	le	le	ADP	Simp	_	23	case	_	_
-23	mire	mire	NOUN	Noun	Gender=Fem|Number=Sing	21	obl	_	_
+23	mire	mire	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	21	obl	_	_
 24	chuile	gach_uile	DET	Det	Definite=Def|Form=Len	25	det	_	_
-25	mhiongán	miongán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	23	nmod	_	_
+25	mhiongán	miongán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	21	obj	_	_
 26	orlaigh	orlach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
 27	di	de	ADP	Prep	Gender=Fem|Number=Sing|Person=3	21	obl:prep	_	SpaceAfter=No
 28	.	.	PUNCT	.	_	1	punct	_	_
@@ -9928,10 +9928,10 @@
 
 # sent_id = 849
 # text = ceathramhna storramhla, buille fánánach...
-1	ceathramhna	ceathramha	NOUN	Noun	Gender=Fem|Number=Plur	0	root	_	_
+1	ceathramhna	ceathramha	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	0	root	_	_
 2	storramhla	storramhail	ADJ	Adj	Gender=Fem|Number=Plur	1	amod	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	4	punct	_	_
-4	buille	buille	NOUN	Noun	Gender=Masc|Number=Sing	1	conj	_	_
+4	buille	buille	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
 5	fánánach	fánánach	ADJ	Adj	Case=NomAcc|Number=Sing	4	amod	_	SpaceAfter=No
 6	...	...	PUNCT	...	_	1	punct	_	_
 
@@ -9957,7 +9957,7 @@
 # text = nó ó láithreán gréasáin na 10 gCéim: www.10steps.ie Nuair a bheidh an próiseas athbhreithnithe críochnaithe go hiomlán measann na Coimisinéirí Ioncaim gur tuairim is 850,000 (669,429) a bheidh sa mhéid a bheidh aisíoctha maidir le haisíoc breosla agus aisíoc cánach bóthair.
 1	nó	nó	CCONJ	Coord	_	3	cc	_	_
 2	ó	ó	ADP	Simp	_	3	case	_	_
-3	láithreán	láithreán	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+3	láithreán	láithreán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 4	gréasáin	gréasán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
 5	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	6	det	_	_
 6	10	10	NUM	Num	_	7	nummod	_	_
@@ -9987,14 +9987,14 @@
 30	a	a	PART	Vb	PartType=Vb|PronType=Rel	31	nsubj	_	_
 31	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	24	acl:relcl	_	_
 32	sa	i	ADP	Art	Number=Sing|PronType=Art	33	case	_	_
-33	mhéid	méid	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
+33	mhéid	méid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	31	obl	_	_
 34	a	a	PART	Vb	PartType=Vb|PronType=Rel	35	obl	_	_
 35	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	33	acl:relcl	_	_
 36	aisíoctha	aisíoctha	ADJ	Adj	VerbForm=Part	35	xcomp:pred	_	_
 37	maidir	maidir	ADP	CmpdNoGen	_	39	case	_	_
 38	le	le	ADP	CmpdNoGen	_	37	fixed	_	_
 39	haisíoc	aisíoc	NOUN	Noun	Form=HPref|VerbForm=Inf	36	obl	_	_
-40	breosla	breosla	NOUN	Noun	Gender=Masc|Number=Sing	39	nmod	_	_
+40	breosla	breosla	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	39	nmod	_	_
 41	agus	agus	CCONJ	Coord	_	42	cc	_	_
 42	aisíoc	aisíoc	NOUN	Noun	VerbForm=Inf	39	conj	_	_
 43	cánach	cáin	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	42	nmod	_	_
@@ -10026,7 +10026,7 @@
 16	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	17	det	_	_
 17	sciarshealbhóirí	sciarshealbhóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	15	nsubj	_	_
 18	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	19	case	_	_
-19	n-úinéirí	úinéir	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	15	xcomp:pred	_	_
+19	n-úinéirí	úinéir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Plur	15	xcomp:pred	_	_
 20	cláraithe	cláraithe	ADJ	Adj	VerbForm=Part	19	amod	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10039,13 +10039,13 @@
 5	bhéaloideas	béaloideas	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 6	leis	le	ADP	Simp	_	8	case	_	_
 7	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	8	det	_	_
-8	céadta	céad	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obl:tmod	_	_
+8	céadta	céad	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obl:tmod	_	_
 9	bliain	bliain	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	8	nmod	_	_
 10	agus	agus	CCONJ	Coord	_	12	cc	_	_
 11	ansin	ansin	ADV	Loc	_	12	advmod	_	_
 12	scríobhadh	scríobh	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	conj	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
-14	lámhscríbhinní	lámhscríbhinn	NOUN	Noun	Gender=Fem|Number=Plur	12	obl	_	_
+14	lámhscríbhinní	lámhscríbhinn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	12	obl	_	_
 15	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	12	obj	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -10056,19 +10056,19 @@
 3	hoileáin	oileán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=HPref|Gender=Masc|Number=Plur	1	nsubj	_	_
 4	seo	seo	DET	Det	PronType=Dem	3	det	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
-6	bheagán	beagán	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
+6	bheagán	beagán	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
 7	daonra	daonra	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	-	-	PUNCT	Punct	_	9	punct	_	_
 9	Inis	inis	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	parataxis	_	NamedEntity=Yes
 10	Bhigil	bigil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	amach	amach	ADV	Dir	_	9	advmod	_	_
-12	ó	ó	ADP	Simp	_	14	case	_	_
-13	chósta	cósta	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
+12	ó	ó	ADP	Simp	_	13	case	_	_
+13	chósta	cósta	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
 14	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
 15	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
-18	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
+18	shampla	sampla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	SpaceAfter=No
 19	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 856
@@ -10079,15 +10079,15 @@
 4	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 5	cosc	cosc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nsubj	_	_
 6	ar	ar	ADP	Simp	_	7	case	_	_
-7	aisteoirí	aisteoir	NOUN	Noun	Gender=Masc|Number=Plur	4	obl	_	_
+7	aisteoirí	aisteoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	4	obl	_	_
 8	nár	is	AUX	Cop	PronType=Rel|Tense=Past|VerbForm=Cop	9	cop	_	_
-9	Bhriotanaigh	Briotanach	NOUN	Noun	Form=Len|Gender=Masc|Number=Plur	7	acl:relcl	_	_
+9	Bhriotanaigh	Briotanach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Plur	7	acl:relcl	_	_
 10	iad	iad	PRON	Pers	Number=Plur|Person=3	9	nsubj	_	_
 11	páirt	páirt	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	4	obj	_	_
 12	a	a	PART	Inf	PartType=Inf	13	mark	_	_
 13	ghlacadh	glacadh	NOUN	Noun	Form=Len|VerbForm=Inf	4	xcomp:pred	_	_
 14	sa	i	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
-15	scannán	scannán	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
+15	scannán	scannán	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	_	_
 
 # sent_id = 857
@@ -10096,7 +10096,7 @@
 2	leoicéime	leoicéime	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
 3	-	-	PUNCT	Punct	_	5	punct	_	_
 4	nó	nó	CCONJ	Coord	_	5	cc	_	_
-5	ailse	ailse	NOUN	Noun	Gender=Fem|Number=Sing	1	conj	_	_
+5	ailse	ailse	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	1	conj	_	_
 6	san	i	ADP	Art	Number=Sing|PronType=Art	7	case	_	_
 7	fhuil	fuil	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 8	-	-	PUNCT	Punct	_	10	punct	_	_
@@ -10109,13 +10109,13 @@
 15	i	i	ADP	Simp	_	16	case	_	_
 16	gcomparáid	comparáid	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Fem|Number=Sing	18	nmod	_	_
 17	le	le	ADP	Simp	_	18	case	_	_
-18	páiste	páiste	NOUN	Noun	Gender=Masc|Number=Sing	1	obl	_	_
+18	páiste	páiste	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl	_	_
 19	i	i	ADP	Simp	_	20	case	_	_
-20	gcontae	contae	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	18	nmod	_	_
+20	gcontae	contae	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	18	nmod	_	_
 21	Mhaigh	Maigh	PROPN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	21	nmod	_	NamedEntity=Yes
 23	mar	mar	ADP	Simp	_	24	case	_	_
-24	shampla	sampla	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
+24	shampla	sampla	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 858
@@ -10131,7 +10131,7 @@
 2	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 3	geall	geall	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 4	le	le	ADP	Simp	_	5	case	_	_
-5	peaca	peaca	NOUN	Noun	Gender=Masc|Number=Sing	3	obl	_	_
+5	peaca	peaca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	3	obl	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	mheabhair	meabhair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	3	nsubj	_	_
 8	cinn	ceann	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	SpaceAfter=No
@@ -10156,10 +10156,10 @@
 15	sin	sin	DET	Det	PronType=Dem	14	det	_	_
 16	agus	agus	CCONJ	Coord	_	18	cc	_	_
 17	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	18	det	_	_
-18	scoláirí	scoláire	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	14	conj	_	SpaceAfter=No
+18	scoláirí	scoláire	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	14	conj	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	21	punct	_	_
 20	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	21	det	_	_
-21	scríobhaithe	scríobhaí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	18	appos	_	SpaceAfter=No
+21	scríobhaithe	scríobhaí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	18	appos	_	SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	a	a	PART	Vb	PartType=Vb|PronType=Rel	24	nsubj	_	_
 24	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	18	acl:relcl	_	_
@@ -10179,13 +10179,13 @@
 38	beo	beo	ADJ	Adj	Gender=Fem|Number=Sing	37	amod	_	_
 39	agus	agus	CCONJ	Coord	_	41	cc	_	_
 40	don	do	ADP	Art	Number=Sing|PronType=Art	41	case	_	_
-41	aigne	aigne	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	33	obl	_	_
+41	aigne	aigne	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	33	obl	_	_
 42	shinseartha	sinseartha	ADJ	Adj	Form=Len|Gender=Fem|Number=Sing	41	amod	_	SpaceAfter=No
 43	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 861
 # text = comhthionól orgánach agus an gaol a bhíonn acu lena chéile agus lena n-imshaol.
-1	comhthionól	comhthionól	NOUN	Noun	Gender=Masc|Number=Sing	0	root	_	_
+1	comhthionól	comhthionól	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	0	root	_	_
 2	orgánach	orgánach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	1	amod	_	_
 3	agus	agus	CCONJ	Coord	_	5	cc	_	_
 4	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
@@ -10212,7 +10212,7 @@
 8	ag	ag	ADP	Simp	_	9	case	_	_
 9	dreapadóireacht	dreapadóireacht	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 10	in	in	ADP	Simp	_	11	case	_	_
-11	áirde	áirde	NOUN	Noun	Gender=Fem|Number=Sing	9	nmod	_	_
+11	áirde	áirde	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	9	nmod	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	nmod:poss	_	_
 14	chuid	cuid	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	_
@@ -10236,7 +10236,7 @@
 32	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	31	nsubj	_	_
 33	dho	do	ADP	Simp	Form=Len|Gender=Fem|Number=Sing|Person=3|Typo=Yes	31	obl:prep	_	_
 34	i	i	ADP	Simp	_	35	case	_	_
-35	mbarra	barra	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
+35	mbarra	barra	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	obl	_	_
 36	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	37	nmod:poss	_	_
 37	shróna	srón	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
@@ -10262,7 +10262,7 @@
 17	go	go	PART	Vb	PartType=Cmpl	18	mark:prt	_	_
 18	mbeidh	bí	VERB	FutInd	Form=Ecl|Mood=Ind|Tense=Fut	16	csubj:cop	_	_
 19	go	go	ADP	Simp	_	18	advmod	_	_
-20	deo	deo	NOUN	Subst	Number=Sing	19	fixed	_	SpaceAfter=No
+20	deo	deo	NOUN	Subst	Case=NomAcc|Number=Sing	19	fixed	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 864
@@ -10273,7 +10273,7 @@
 4	mhóra	mór	ADJ	Adj	Case=NomAcc|Form=Len|Number=Plur	3	amod	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	slí	slí	NOUN	Noun	Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
+7	slí	slí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obl	_	_
 8	isteach	isteach	ADV	Dir	_	1	advmod	_	_
 9	go	go	ADP	Cmpd	_	12	case	_	_
 10	dtí	dtí	ADP	Cmpd	Form=Ecl	9	fixed	_	_
@@ -10286,7 +10286,7 @@
 17	Ard	ard	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc	12	conj	_	NamedEntity=Yes
 18	Bhaile	Baile	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	NamedEntity=Yes
-20	nÁith	áith	NOUN	Noun	Definite=Def|Form=Ecl	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	nÁith	áith	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 865
@@ -10303,7 +10303,7 @@
 10	grean	grean	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	15	obj	_	_
 11	duán	duán	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	compound	_	_
 12	is	agus	CCONJ	Coord	_	13	cc	_	_
-13	gúta	gúta	NOUN	Noun	Gender=Masc|Number=Sing	10	conj	_	_
+13	gúta	gúta	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	10	conj	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	chóireáil	cóireáil	NOUN	Noun	Form=Len|VerbForm=Inf	1	xcomp	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
@@ -10325,7 +10325,7 @@
 13	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	11	obl:prep	_	_
 14	ar	ar	ADP	Simp	_	16	case	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	sagart	sagart	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
+16	sagart	sagart	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
 17	Sandeman	Sandeman	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 18	is	agus	SCONJ	Subord	_	19	mark	_	_
 19	dúil	dúil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	11	advcl	_	_
@@ -10334,7 +10334,7 @@
 22	dtiocfadh	tar	VERB	VI	Form=Ecl|Mood=Cnd	11	ccomp	_	_
 23	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	22	nsubj	_	_
 24	as	as	ADP	Simp	_	25	case	_	_
-25	treo	treo	NOUN	Noun	Gender=Masc|Number=Sing	22	obl	_	_
+25	treo	treo	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	22	obl	_	_
 26	éigin	éigin	ADJ	Adj	Case=NomAcc|Gender=Fem|Number=Sing	25	amod	_	_
 27	ar	ar	ADP	Simp	_	29	case	_	_
 28	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	29	nmod:poss	_	_
@@ -10343,8 +10343,8 @@
 31	a	a	DET	Det	Gender=Fem|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
 32	botháin	bothán	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	22	obj	_	_
 33	ag	ag	ADP	Simp	_	34	case	_	_
-34	cúl	cúl	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	obl	_	_
-35	halla	halla	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
+34	cúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	22	obl	_	_
+35	halla	halla	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	34	nmod	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
 37	bhaile	baile	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	35	nmod	_	SpaceAfter=No
 38	.	.	PUNCT	.	_	2	punct	_	_
@@ -10373,7 +10373,7 @@
 # sent_id = 868
 # text = B'fhíor gur chodail sé oícheanta dá raibh istigh sa ghluaisteán sa gharáiste, mar dhein a mháthair dearmad go raibh sé ar a chúl aici.
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	SpaceAfter=No
-2	fhíor	fíor	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	0	root	_	_
+2	fhíor	fíor	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
 3	gur	gur	PART	Vb	PartType=Vb|Tense=Past	4	mark:prt	_	_
 4	chodail	codail	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	ccomp	_	_
 5	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	4	nsubj	_	_
@@ -10382,21 +10382,21 @@
 8	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	6	acl:relcl	_	_
 9	istigh	istigh	ADV	Dir	_	8	advmod	_	_
 10	sa	i	ADP	Art	Number=Sing|PronType=Art	11	case	_	_
-11	ghluaisteán	gluaisteán	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
+11	ghluaisteán	gluaisteán	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	_
 12	sa	i	ADP	Art	Number=Sing|PronType=Art	13	case	_	_
-13	gharáiste	garáiste	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
+13	gharáiste	garáiste	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 14	,	,	PUNCT	Punct	_	16	punct	_	_
 15	mar	mar	SCONJ	Subord	_	16	mark	_	_
 16	dhein	déan	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Tense=Past	2	advcl	_	_
 17	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	18	nmod:poss	_	_
 18	mháthair	máthair	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	nsubj	_	_
-19	dearmad	dearmad	NOUN	Noun	Gender=Masc|Number=Sing	16	obj	_	_
+19	dearmad	dearmad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	16	obj	_	_
 20	go	go	PART	Vb	PartType=Cmpl	21	mark:prt	_	_
 21	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	16	ccomp	_	_
 22	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	21	nsubj	_	_
 23	ar	ar	ADP	Simp	_	25	case	_	_
 24	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	25	nmod:poss	_	_
-25	chúl	cúl	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
+25	chúl	cúl	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	obl	_	_
 26	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	21	obl:prep	_	SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -10426,7 +10426,7 @@
 13	féin	féin	PRON	Ref	_	12	nmod	_	_
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	a	a	DET	Det	Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
-16	thriúr	triúr	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	conj	_	_
+16	thriúr	triúr	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	12	conj	_	_
 17	mac	mac	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	16	nmod	_	_
 18	amach	amach	ADV	Dir	_	11	advmod	_	_
 19	a	a	PART	Inf	_	20	mark:prt	_	_
@@ -10476,12 +10476,12 @@
 11	Chorrabháin	Chorrabháin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	Muilteoir	muilteoir	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	9	appos	_	_
+14	Muilteoir	muilteoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	9	appos	_	_
 15	Rua	Rua	ADJ	Adj	Gender=Masc|Number=Sing	14	amod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	19	punct	_	_
 17	ar	ar	ADP	Simp	_	19	case	_	_
 18	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	19	det	_	_
-19	mílte	míle	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	6	obl	_	_
+19	mílte	míle	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	obl	_	_
 20	a	a	PART	Vb	PartType=Vb|PronType=Rel	22	nsubj	_	_
 21	d'	do	PART	Vb	PartType=Vb	22	mark:prt	_	SpaceAfter=No
 22	fhulaing	fulaing	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	19	acl:relcl	_	_
@@ -10490,8 +10490,8 @@
 25	a	a	PART	Vb	PartType=Vb|PronType=Rel	26	obj	_	_
 26	rinneadh	déan	VERB	VTI	Mood=Ind|Person=0|Tense=Past	24	acl:relcl	_	_
 27	ar	ar	ADP	Simp	_	28	case	_	_
-28	chaitlicigh	caitliceach	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl	_	_
-29	Ard	ard	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
+28	chaitlicigh	caitliceach	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	26	obl	_	_
+29	Ard	ard	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	NamedEntity=Yes
 30	Macha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Plur	29	nmod	_	NamedEntity=Yes
 31	idir	idir	ADP	Simp	_	32	case	_	_
 32	1780	1780	NUM	Num	_	26	obl:tmod	_	_
@@ -10516,7 +10516,7 @@
 13	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	obl:prep	_	_
 14	a	a	PART	Inf	PartType=Inf	15	mark	_	_
 15	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	12	xcomp	_	_
-16	cupla	cupla	NOUN	Noun	Gender=Masc|Number=Plur	20	obj	_	_
+16	cupla	cupla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	20	obj	_	_
 17	béic	béic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	16	nmod	_	_
 18	chreathnaitheach	creathnaitheach	ADJ	Adj	Degree=Pos|Form=Len	16	amod	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
@@ -10540,7 +10540,7 @@
 37	go	go	PART	Vb	PartType=Cmpl	38	mark:prt	_	_
 38	dtiocfadh	tar	VERB	VI	Form=Ecl|Mood=Cnd	7	conj	_	_
 39	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	38	obl:prep	_	_
-40	éaló	éaló	NOUN	Noun	Gender=Masc|Number=Sing	38	xcomp	_	_
+40	éaló	éaló	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	38	xcomp	_	_
 41	amach	amach	ADV	Dir	_	40	advmod	_	_
 42	sula	sula	SCONJ	Subord	_	43	mark	_	_
 43	bhfaighfí	faigh	VERB	VT	Form=Ecl|Mood=Cnd|Person=0	38	advcl	_	_
@@ -10607,7 +10607,7 @@
 8	tIndiach	Indiach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	6	nsubj	_	_
 9	leis	le	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Iosánach	Íosánach	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	6	obl	_	_
+11	Iosánach	Íosánach	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	6	obl	_	_
 12	ansin	ansin	ADV	Loc	_	6	advmod	_	SpaceAfter=No
 13	:	:	PUNCT	Punct	_	15	punct	_	_
 14	'	'	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
@@ -10661,7 +10661,7 @@
 4	anois	anois	ADV	Gn	_	1	advmod	_	_
 5	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	7	cop	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	bPáirc	páirc	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	ccomp	_	NamedEntity=Yes
+7	bPáirc	páirc	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	1	ccomp	_	NamedEntity=Yes
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	NamedEntity=Yes
 9	Chrócaigh	Crócach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 10	Dé	Dé	PROPN	Subst	Definite=Def	7	obl:tmod	_	NamedEntity=Yes
@@ -10685,7 +10685,7 @@
 10	a	a	PART	Inf	PartType=Inf	11	mark:prt	_	_
 11	dhul	dul	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
 12	taobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
-13	Chondae	contae	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
+13	Chondae	contae	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	NamedEntity=Yes
 15	Chláir	Clár	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	...	...	PUNCT	...	_	3	punct	_	_
@@ -10700,7 +10700,7 @@
 6	chuici	chuig	ADP	Prep	Gender=Fem|Number=Sing|Person=3	2	obl:prep	_	_
 7	aníos	aníos	ADV	Dir	_	2	advmod	_	_
 8	ón	ó	ADP	Art	Number=Sing|PronType=Art	9	case	_	_
-9	seomra	seomra	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
+9	seomra	seomra	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 880
@@ -10710,13 +10710,13 @@
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
 4	aonar	aonar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	i	i	ADP	Simp	_	6	case	_	_
-6	gclós	clós	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
+6	gclós	clós	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	1	obl	_	_
 7	mhuintir	muintir	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	_
 8	Bhraonáin	Braonáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	7	nmod	_	_
 9	-	-	PUNCT	Punct	_	10	punct	_	_
 10	níl	bí	VERB	PresInd	Mood=Ind|Tense=Pres	1	parataxis	_	_
 11	de	de	ADP	Simp	_	12	case	_	_
-12	chompánach	compánach	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
+12	chompánach	compánach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	10	obl	_	_
 13	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	10	obl:prep	_	_
 14	ach	ach	SCONJ	Subord	_	15	mark:prt	_	_
 15	cearc	cearc	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	10	nsubj	_	_
@@ -10765,7 +10765,7 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Fem|Number=Sing|Person=3|Poss=Yes	4	case	_	_
-4	suí	suí	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
+4	suí	suí	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	xcomp:pred	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	fhiacail	fiacail	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 7	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
@@ -10780,7 +10780,7 @@
 16	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	farraige	farraige	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	6	nmod	_	_
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
-19	nádúr	nádúr	NOUN	Noun	Gender=Masc|Number=Sing	1	conj	_	_
+19	nádúr	nádúr	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	conj	_	_
 20	tarraingteach	tarraingteach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	19	amod	_	_
 21	aici	ag	ADP	Prep	Gender=Fem|Number=Sing|Person=3	19	obl:prep	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	nsubj	_	_
@@ -10811,7 +10811,7 @@
 1	'	'	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 2	Ná	ná	PART	Vb	Mood=Imp|PartType=Vb	3	advmod	_	_
 3	bíodh	bí	VERB	Imper	Mood=Imp|Number=Sing|Person=3	8	parataxis	_	_
-4	eagla	eagla	NOUN	Noun	Gender=Fem|Number=Sing	3	obj	_	_
+4	eagla	eagla	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	3	obj	_	_
 5	ort	ar	ADP	Prep	Number=Sing|Person=2	3	obl:prep	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 7	'	'	PUNCT	Punct	_	3	punct	_	_
@@ -10830,7 +10830,7 @@
 # sent_id = 886
 # text = An plúr dubh.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	plúr	plúr	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
+2	plúr	plúr	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	0	root	_	_
 3	dubh	dubh	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	2	amod	_	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -10847,7 +10847,7 @@
 9	tá	bí	VERB	VI	Mood=Ind|Tense=Pres	0	root	_	_
 10	(	(	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 11	ó	ó	ADP	Simp	_	12	case	_	_
-12	chlé	clé	NOUN	Noun	Form=Len|Gender=Fem|Number=Sing	9	obl	_	SpaceAfter=No
+12	chlé	clé	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Fem|Number=Sing	9	obl	_	SpaceAfter=No
 13	)	)	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 14	:	:	PUNCT	Punct	_	16	punct	_	_
 15	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
@@ -10857,11 +10857,11 @@
 19	Giolla	Giolla	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 20	Riabhaigh	Riabhaigh	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	Easpag	easpag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
+22	Easpag	easpag	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 23	Dhroim	droim	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
 24	Mór	mór	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	23	amod	_	NamedEntity=Yes|SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
-26	Ardeaspag	ardeaspag	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
+26	Ardeaspag	ardeaspag	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 27	Ard	Ard	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
 28	Mhacha	Mhacha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
@@ -10872,7 +10872,7 @@
 34	Brádaigh	Brádaigh	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
 35	agus	agus	CCONJ	Coord	_	37	cc	_	_
 36	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	37	det	_	_
-37	tAthair	athair	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
+37	tAthair	athair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
 38	Tomás	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
 39	Mac	mac	PART	Pat	PartType=Pat	37	flat:name	_	NamedEntity=Yes
 40	Parthaláin	Parthaláin	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes|SpaceAfter=No
@@ -10923,7 +10923,7 @@
 8	Buidhe	Buidhe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	chósta	cósta	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+11	chósta	cósta	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
 12	taobh	taobh	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	nmod	_	_
 13	ó	ó	ADP	Simp	_	14	case	_	_
 14	thuaidh	thuaidh	ADV	Dir	_	11	advmod	_	_
@@ -10946,10 +10946,10 @@
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
 4	chloigeann	cloigeann	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obj	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
-6	aer	aer	NOUN	Noun	Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
+6	aer	aer	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	1	conj	_	_
-9	gáire	gáire	NOUN	Noun	Gender=Masc|Number=Sing	8	obj	_	_
+9	gáire	gáire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	obj	_	_
 10	faoina	faoi	PART	Rel	PronType=Rel	8	obl	_	_
 11	ndúirt	abair	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	8	acl:relcl	_	_
 12	Learaí	Learaí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
@@ -10964,7 +10964,7 @@
 4	t-am	am	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	do	do	ADP	Simp	_	7	case	_	SpaceAfter=No
 6	'n	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	phréamh	préamh	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
+7	phréamh	préamh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	2	obl	_	_
 8	féin	féin	PRON	Ref	Reflex=Yes	7	nmod	_	_
 9	nuair	nuair	SCONJ	Subord	_	11	mark	_	_
 10	ná	nach	PART	Vb	PartType=Cmpl|Polarity=Neg	11	mark:prt	_	_
@@ -10985,7 +10985,7 @@
 5	laghdaigh	laghdaigh	VERB	VTI	Mood=Ind|Tense=Past	3	conj	_	_
 6	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	5	nsubj	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
-8	fiú	fiú	NOUN	Subst	Number=Sing	5	advmod	_	_
+8	fiú	fiú	NOUN	Subst	Case=NomAcc|Number=Sing	5	advmod	_	_
 9	amháin	amháin	ADJ	Adj	Degree=Pos	8	fixed	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -11014,10 +11014,10 @@
 6	ann	i	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	xcomp:pred	_	_
 7	d'	do	ADP	Simp	_	8	case	_	SpaceAfter=No
 8	an-chuid	an-chuid	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	5	obl	_	_
-9	daoine	duine	NOUN	Noun	Gender=Masc|Number=Plur	8	nmod	_	_
+9	daoine	duine	NOUN	Noun	Case=Gen|Gender=Masc|Number=Plur	8	nmod	_	_
 10	agus	agus	CCONJ	Coord	_	14	cc	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
-12	measc	measc	NOUN	Noun	Gender=Masc|Number=Sing	5	obl	_	_
+12	measc	measc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 13	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
 14	n-iardhaltaí	iardhalta	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	12	nmod	_	_
 15	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	5	parataxis	_	_
@@ -11025,7 +11025,7 @@
 17	Uí	uí	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
 18	Dhrisceoil	Drisceoil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	flat:name	_	NamedEntity=Yes
 19	as	as	ADP	Simp	_	20	case	_	_
-20	Béal	béal	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
+20	Béal	béal	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	15	obl	_	NamedEntity=Yes
 21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	23	det	_	NamedEntity=Yes
 23	Ghaorthaigh	Gaorthach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -11055,7 +11055,7 @@
 47	Ní	ní	PART	Pat	PartType=Pat	46	flat:name	_	NamedEntity=Yes
 48	Chéilleachair	Céilleachar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	flat:name	_	NamedEntity=Yes
 49	as	as	ADP	Simp	_	50	case	_	_
-50	Raidió	raidió	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	NamedEntity=Yes
+50	Raidió	raidió	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	46	nmod	_	NamedEntity=Yes
 51	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	52	det	_	_
 52	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	50	nmod	_	NamedEntity=Yes|SpaceAfter=No
 53	.	.	PUNCT	.	_	1	punct	_	_
@@ -11086,7 +11086,7 @@
 2	Riain	Riain	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	flat:name	_	NamedEntity=Yes
 3	faoi	faoi	ADP	Prep	Gender=Masc|Number=Sing|Person=3	5	case	_	_
 4	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	5	case	_	_
-5	leabhar	leabhar	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
+5	leabhar	leabhar	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 6	The	the	X	_	Foreign=Yes	5	appos	_	_
 7	Pope's	Pope's	X	_	Foreign=Yes	6	flat:foreign	_	_
 8	Green	Green	X	_	Foreign=Yes	6	flat:foreign	_	_
@@ -11103,14 +11103,14 @@
 19	Liam	Liam	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
 20	Bhid	Bhid	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
-22	fear	fear	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	_
+22	fear	fear	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	17	appos	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	bhearna	bearna	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	22	nmod	_	_
 25	mhíl	míol	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	24	compound	_	_
 26	a	a	PART	Vb	PartType=Vb|PronType=Rel	27	obj	_	_
 27	luaitear	luaigh	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	22	acl:relcl	_	_
 28	i	i	ADP	Simp	_	29	case	_	_
-29	dteideal	teideal	NOUN	Noun	Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
+29	dteideal	teideal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	27	obl	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	29	nmod	_	_
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
@@ -11118,14 +11118,14 @@
 34	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	27	conj	_	_
 35	Nóra	Nóra	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	34	nsubj	_	_
 36	ag	ag	ADP	Simp	_	37	case	_	_
-37	suirí	suirí	NOUN	Noun	Gender=Fem|Number=Sing	34	xcomp:pred	_	_
+37	suirí	suirí	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	34	xcomp:pred	_	_
 38	go	go	PART	Ad	PartType=Ad	39	mark:prt	_	_
 39	soineanta	soineanta	ADJ	Adj	Degree=Pos	37	advmod	_	_
 40	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	37	obl:prep	_	SpaceAfter=No
 41	:	:	PUNCT	Punct	_	43	punct	_	_
 42	Ná	ná	PART	Vb	Mood=Imp|PartType=Vb	43	mark:prt	_	_
 43	bíodh	bí	VERB	Imper	Mood=Imp|Number=Sing|Person=3	14	parataxis	_	_
-44	cumha	cumha	NOUN	Noun	Gender=Masc|Number=Sing	43	obj	_	_
+44	cumha	cumha	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	43	obj	_	_
 45	ar	ar	ADP	Simp	_	44	nmod	_	_
 46	bith	bith	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	45	fixed	_	_
 47	ort	ar	ADP	Prep	Number=Sing|Person=2	43	obl:prep	_	SpaceAfter=No
@@ -11152,7 +11152,7 @@
 17	,	,	PUNCT	Punct	_	20	punct	_	_
 18	gan	gan	ADP	Simp	_	20	case	_	_
 19	do	do	DET	Det	Number=Sing|Person=2|Poss=Yes	20	nmod:poss	_	_
-20	gheallúint	geallúint	NOUN	Noun	Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
+20	gheallúint	geallúint	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	obl	_	_
 21	i	i	ADP	Simp	_	22	case	_	_
 22	dtaobh	taobh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	20	nmod	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -11186,14 +11186,14 @@
 11	-	-	PUNCT	Punct	_	14	punct	_	_
 12	agus	agus	SCONJ	Coord	_	14	mark	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	oiread	oiread	NOUN	Subst	Definite=Def|Number=Sing	27	advcl	_	_
+14	oiread	oiread	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	27	advcl	_	_
 15	sin	sin	DET	Det	PronType=Dem	14	det	_	_
 16	amhrais	amhras	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	_
 17	ar	ar	ADP	Simp	_	18	case	_	_
-18	infheisteoirí	infheisteoir	NOUN	Noun	Gender=Masc|Number=Plur	16	nmod	_	_
+18	infheisteoirí	infheisteoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	16	nmod	_	_
 19	móra	mór	ADJ	Adj	NounType=NotSlender|Number=Plur	18	amod	_	_
 20	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	21	case	_	_
-21	gcomhnascadh	comhnascadh	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	16	nmod	_	_
+21	gcomhnascadh	comhnascadh	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	16	nmod	_	_
 22	ón	ó	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
 23	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	24	amod	_	_
 24	lá	lá	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	1	obl:tmod	_	SpaceAfter=No
@@ -11210,15 +11210,15 @@
 35	luach	luach	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	32	obl	_	_
 36	ar	ar	ADP	Simp	_	38	case	_	_
 37	na	na	DET	Art	Definite=Def|Number=Plur|PronType=Art	38	det	_	_
-38	scaranna	scair	NOUN	Noun	Definite=Def|Gender=Fem|Number=Plur	32	obl	_	_
+38	scaranna	scair	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Plur	32	obl	_	_
 39	a	a	PART	Vb	PartType=Vb|PronType=Rel	40	nsubj	_	_
 40	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	38	acl:relcl	_	_
 41	ag	ag	ADP	Simp	_	42	case	_	_
 42	Ruairí	Ruairí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	40	obj	_	_
 43	sa	i	ADP	Art	Number=Sing|PronType=Art	44	case	_	_
-44	Bhainc	banc	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
+44	Bhainc	banc	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
 45	de	de	ADP	Simp	_	46	case	_	_
-46	los	los	NOUN	Noun	Definite=Def|Gender=Masc|Number=Sing	40	obl	_	_
+46	los	los	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	40	obl	_	_
 47	a	a	DET	Det	Number=Plur|Person=3|Poss=Yes	48	nmod:poss	_	_
 48	bhfaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	46	nmod	_	SpaceAfter=No
 49	;	;	PUNCT	Punct	_	50	punct	_	_
@@ -11226,7 +11226,7 @@
 51	gearrthréimhseach	gearrthréimhseach	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	50	amod	_	_
 52	ar	ar	ADP	Simp	_	50	advmod	_	_
 53	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	52	fixed	_	_
-54	laghad	laghad	NOUN	Noun	Gender=Masc|Number=Sing	52	fixed	_	SpaceAfter=No
+54	laghad	laghad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	52	fixed	_	SpaceAfter=No
 55	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 901
@@ -11250,7 +11250,7 @@
 2	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	4	nmod	_	_
 3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	bhean	bean	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Fem|Number=Sing	0	root	_	_
-5	cruthaitheóir	cruthaitheoir	NOUN	Noun	Gender=Masc|Number=Sing	4	nmod	_	_
+5	cruthaitheóir	cruthaitheoir	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	_
 6	agus	agus	CCONJ	Coord	_	7	cc	_	_
 7	cosantóir	cosantóir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	conj	_	_
 8	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
@@ -11282,12 +11282,12 @@
 10	Ach	ach	SCONJ	Subord	_	11	mark	_	_
 11	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	advcl	_	_
 12	uime	um	ADP	Prep	Gender=Masc|Number=Sing|Person=3	13	case	_	_
-13	masc	masc	NOUN	Noun	Gender=Masc|Number=Sing	11	obj	_	_
+13	masc	masc	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	11	obj	_	_
 14	is	agus	CCONJ	Coord	_	15	cc	_	_
-15	clóca	clóca	NOUN	Noun	Gender=Masc|Number=Sing	13	conj	_	SpaceAfter=No
+15	clóca	clóca	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	13	conj	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	Théadaigh	téadaigh	VERB	VT	Form=Len|Mood=Ind|Tense=Past	4	parataxis	_	_
-18	giotár	giotár	NOUN	Noun	Gender=Masc|Number=Sing	17	obj	_	_
+18	giotár	giotár	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	17	obj	_	_
 19	Is	agus	CCONJ	Coord	_	20	cc	_	_
 20	chuaigh	téigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	17	conj	_	_
 21	síos	síos	ADV	Dir	_	20	advmod	_	_
@@ -11306,10 +11306,10 @@
 5	léaró	léaró	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 6	dóchais	dóchas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
 7	san	i	ADP	Art	Number=Sing|PronType=Art	8	case	_	_
-8	fhocal	focal	NOUN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
+8	fhocal	focal	NOUN	Noun	Case=NomAcc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	2	obl	_	_
 9	sin	sin	DET	Det	PronType=Dem	8	det	_	_
 10	'	'	PUNCT	Punct	_	11	punct	_	SpaceAfter=No
-11	bán	bán	NOUN	Noun	Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
+11	bán	bán	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	8	appos	_	SpaceAfter=No
 12	'	'	PUNCT	Punct	_	11	punct	_	_
 13	le	le	ADP	Cmpd	PrepForm=Cmpd	16	case	_	_
 14	cois	cois	ADP	Cmpd	PrepForm=Cmpd	13	fixed	_	_
@@ -11322,11 +11322,11 @@
 # text = Is fíor- chorr-Óglach a d'fhág baile an Luan sin a raibh fhios aige gur ag dul chun troda i ndáiríre a bhí sé agus nach ag cleachtadh cogaíochta.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
 2	fíor-	fíor-	ADV	Its	_	3	amod	_	_
-3	chorr-Óglach	corr-óglach	NOUN	Noun	Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+3	chorr-Óglach	corr-óglach	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
 4	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	mark:prt	_	_
 5	d'	do	PART	Vb	PartType=Vb	6	mark:prt	_	SpaceAfter=No
 6	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
-7	baile	baile	NOUN	Noun	Gender=Masc|Number=Sing	6	obj	_	_
+7	baile	baile	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	6	obj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl:tmod	_	_
 10	sin	sin	DET	Det	PronType=Dem	9	det	_	_
@@ -11340,7 +11340,7 @@
 18	chun	chun	ADP	Simp	_	19	case	_	_
 19	troda	troid	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	obl	_	_
 20	i	i	ADP	Simp	_	21	case	_	_
-21	ndáiríre	dáiríre	NOUN	Noun	Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
+21	ndáiríre	dáiríre	NOUN	Noun	Case=NomAcc|Form=Ecl|Gender=Masc|Number=Sing	17	obl	_	_
 22	a	a	PART	Vb	PartType=Vb|PronType=Rel	23	mark:prt	_	_
 23	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	17	csubj:cleft	_	_
 24	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	23	nsubj	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -694,7 +694,7 @@
 31	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	33	obj	_	_
 32	a	a	PART	Inf	PartType=Inf	33	mark	_	_
 33	sheoladh	seoladh	NOUN	Noun	Form=Len|VerbForm=Inf	27	xcomp	_	_
-34	láithreach	láithreach	ADJ	Adj	Degree=Pos	33	advmod	_	_
+34	láithreach	láithreach	ADV	_	_	33	advmod	_	_
 35	chuig	chuig	ADP	Simp	_	36	case	_	_
 36	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	33	obl	_	NamedEntity=Yes
 37	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	NamedEntity=Yes
@@ -736,7 +736,7 @@
 73	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	75	obj	_	_
 74	a	a	PART	Inf	PartType=Inf	75	mark	_	_
 75	sheoladh	seoladh	NOUN	Noun	Form=Len|VerbForm=Inf	69	xcomp	_	_
-76	láithreach	láithreach	ADJ	Adj	Degree=Pos	75	advmod	_	_
+76	láithreach	láithreach	ADV	_	_	75	advmod	_	_
 77	chuig	chuig	ADP	Simp	_	78	case	_	_
 78	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	75	obl	_	NamedEntity=Yes
 79	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	80	det	_	NamedEntity=Yes

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -489,7 +489,7 @@
 7	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	6	nsubj	_	_
 8	tugtha	tugtha	ADJ	Adj	VerbForm=Part	6	xcomp:pred	_	_
 9	faoi	faoi	ADP	Simp	_	10	case	_	_
-10	deara	deara	NOUN	Subst	Number=Sing	8	obl	_	_
+10	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	8	obl	_	_
 11	agat	ag	ADP	Prep	Number=Sing|Person=2	8	obl:prep	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	14	cop	_	_
@@ -527,7 +527,7 @@
 12	na	na	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	difríochta	difríocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	11	obj	_	_
 14	faoi	faoi	ADP	Simp	_	15	case	_	_
-15	deara	deara	NOUN	Subst	Number=Sing	11	obl	_	SpaceAfter=No
+15	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	11	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 24
@@ -851,7 +851,7 @@
 20	seo	seo	DET	Det	PronType=Dem	19	det	_	_
 21	ach	ach	SCONJ	Subord	_	23	mark	_	_
 22	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	23	cop	_	_
-23	fiú	fiú	NOUN	Subst	Number=Sing	1	advcl	_	_
+23	fiú	fiú	NOUN	Subst	Case=NomAcc|Number=Sing	1	advcl	_	_
 24	súil	súil	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	26	obj	_	_
 25	a	a	PART	Inf	PartType=Inf	26	mark	_	_
 26	chaitheamh	caitheamh	NOUN	Noun	Form=Len|VerbForm=Inf	23	csubj:cop	_	_
@@ -1713,7 +1713,7 @@
 # sent_id = 70
 # text = B'fhéidir go mba shólás leis sin, cá bhfios - i ndiaidh a raibh céasta aige ag smeara gúscéimhe thar ghaimh ghránna a chnis.
 1	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	2	cop	_	SpaceAfter=No
-2	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	0	root	_	_
+2	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	0	root	_	_
 3	go	go	PART	Vb	PartType=Cmpl	5	mark:prt	_	_
 4	mba	is	AUX	Cop	Form=Ecl|Tense=Past|VerbForm=Cop	5	cop	_	_
 5	shólás	sólás	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	2	csubj:cop	_	_
@@ -2928,7 +2928,7 @@
 # text = 'B'fhéidir go mbeadh uibheacha áil agat féin an t-earrach seo chugainn,' a dúirt sí.
 1	'	'	PUNCT	Punct	_	3	punct	_	SpaceAfter=No
 2	B'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	3	cop	_	SpaceAfter=No
-3	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	17	parataxis	_	_
+3	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	17	parataxis	_	_
 4	go	go	PART	Vb	PartType=Cmpl	5	mark:prt	_	_
 5	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	3	csubj:cop	_	_
 6	uibheacha	ubh	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	5	nsubj	_	_
@@ -4341,7 +4341,7 @@
 5	a	a	PART	Vb	PartType=Vb|PronType=Rel	6	nsubj	_	_
 6	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	4	acl:relcl	_	_
 7	faoi	faoi	ADP	Simp	_	8	case	_	_
-8	deara	deara	NOUN	Subst	Number=Sing	6	obl	_	_
+8	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	6	obl	_	_
 9	go	go	PART	Ad	PartType=Ad	10	mark:prt	_	_
 10	luath	luath	ADJ	Adj	Degree=Pos	6	advmod	_	_
 11	buanna	bua	NOUN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Plur	6	obj	_	_
@@ -5760,7 +5760,7 @@
 8	réidhchúiseach	réidhchúiseach	ADJ	Adj	Degree=Pos	5	xcomp:pred	_	SpaceAfter=No
 9	,	,	PUNCT	Punct	_	11	punct	_	_
 10	gan	gan	ADP	Simp	_	11	case	_	_
-11	buaileam	buaileam	NOUN	Subst	Gender=Masc|Number=Sing	5	obl	_	_
+11	buaileam	buaileam	NOUN	Subst	Case=NomAcc|Gender=Masc|Number=Sing	5	obl	_	_
 12	sciath	sciath	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Weak|Number=Plur	11	nmod	_	_
 13	gan	gan	ADP	Simp	_	14	case	_	_
 14	cóirí	cóir	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	5	obl	_	_
@@ -6656,7 +6656,7 @@
 58	,	,	PUNCT	Punct	_	61	punct	_	_
 59	nó	nó	CCONJ	Coord	_	61	mark	_	_
 60	dá	do	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	61	case	_	_
-61	éis	éis	NOUN	Subst	Definite=Def|Number=Sing	25	nmod	_	SpaceAfter=No
+61	éis	éis	NOUN	Subst	Case=NomAcc|Definite=Def|Number=Sing	25	nmod	_	SpaceAfter=No
 62	,	,	PUNCT	Punct	_	64	punct	_	_
 63	ar	ar	ADP	Simp	_	64	case	_	_
 64	fhoirgneamh	foirgneamh	NOUN	Noun	Case=NomAcc|Form=Len|Gender=Masc|Number=Sing	25	nmod	_	_
@@ -6928,7 +6928,7 @@
 2	chruthaigh	cruthaigh	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 3	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	2	nsubj	_	_
 4	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	5	cop	_	_
-5	féidir	féidir	NOUN	Subst	Number=Sing	2	ccomp	_	_
+5	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	2	ccomp	_	_
 6	a	a	PART	Inf	PartType=Inf	7	mark	_	_
 7	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	5	csubj:cop	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
@@ -6971,7 +6971,7 @@
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 2	Tabhair	tabhair	VERB	VTI	Mood=Imp|Number=Sing|Person=2	0	root	_	_
 3	faoi	faoi	ADP	Simp	_	4	case	_	_
-4	deara	deara	NOUN	Subst	Number=Sing	2	obl	_	_
+4	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	2	obl	_	_
 5	freisin	freisin	ADV	Gn	_	2	advmod	_	_
 6	gur	gur	PART	Vb	PartType=Vb|Tense=Past	7	mark:prt	_	_
 7	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	2	ccomp	_	_
@@ -7990,7 +7990,7 @@
 25	fhágfadh	fág	VERB	VTI	Form=Len|Mood=Cnd	21	acl:relcl	_	_
 26	fear	fear	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	25	nsubj	_	_
 27	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	28	case	_	_
-28	dhiaidh	diaidh	NOUN	Subst	Definite=Def|Form=Len|Number=Sing	25	obl	_	_
+28	dhiaidh	diaidh	NOUN	Subst	Case=NomAcc|Definite=Def|Form=Len|Number=Sing	25	obl	_	_
 29	a	a	PART	Vb	PartType=Vb|PronType=Rel	30	nsubj	_	_
 30	nochtfadh	nocht	VERB	VTI	Mood=Cnd	18	acl:relcl	_	_
 31	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
@@ -9373,7 +9373,7 @@
 26	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	23	obl:prep	_	SpaceAfter=No
 27	,	,	PUNCT	Punct	_	28	punct	_	_
 28	ná	ná	SCONJ	Coord	_	29	mark	_	_
-29	fiú	fiú	NOUN	Subst	Number=Sing	30	nmod	_	_
+29	fiú	fiú	NOUN	Subst	Case=Gen|Number=Sing	30	nmod	_	_
 30	Gaeilge	Gaeilge	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	21	orphan	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
 32	Béarla	Béarla	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	30	conj	_	SpaceAfter=No
@@ -9617,7 +9617,7 @@
 # sent_id = 377
 # text = Is féidir acmhainní nádúrtha a roinnt ina dhá gcineál, idir acmhainní in-athnuaite agus acmhainní neamh-athnuaite.
 1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	féidir	féidir	NOUN	Subst	Number=Sing	0	root	_	_
+2	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	0	root	_	_
 3	acmhainní	acmhainn	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Plur	6	obj	_	_
 4	nádúrtha	nádúrtha	ADJ	Adj	Case=NomAcc|Gender=Masc|Number=Sing	3	amod	_	_
 5	a	a	PART	Inf	PartType=Inf	6	mark	_	_
@@ -9679,7 +9679,7 @@
 3	(a)	(a)	NUM	Item	_	4	list	_	_
 4	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 5	a	a	NOUN	Subst	Number=Sing	4	nsubj	_	_
-6	lán	lán	NOUN	Subst	Gender=Masc	5	fixed	_	_
+6	lán	lán	NOUN	Subst	Case=NomAcc|Gender=Masc	5	fixed	_	_
 7	scríofa	scríofa	ADJ	Adj	VerbForm=Part	4	xcomp:pred	_	_
 8	ar	ar	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
@@ -9927,7 +9927,7 @@
 19	thug	tabhair	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	14	conj	_	_
 20	mé	mé	PRON	Pers	Number=Sing|Person=1	19	nsubj	_	_
 21	faoi	faoi	ADP	Simp	_	22	case	_	_
-22	deara	deara	NOUN	Subst	Number=Sing	19	obl	_	_
+22	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	19	obl	_	_
 23	go	go	PART	Vb	PartType=Cmpl	24	mark:prt	_	_
 24	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	19	ccomp	_	_
 25	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	26	det	_	_
@@ -10141,7 +10141,7 @@
 # sent_id = 401
 # text = An féidir leatsa pé rud atá idir lámha agat a bhailiú le chéile agus bogadh isteach san oifig thosaigh le Susan ar feadh leathuaire nó mar sin?
 1	An	is	AUX	Cop	Mood=Int|Tense=Pres|VerbForm=Cop	2	cop	_	_
-2	féidir	féidir	NOUN	Subst	Number=Sing	0	root	_	_
+2	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	0	root	_	_
 3	leatsa	le	ADP	Prep	Number=Sing|Person=2|PronType=Emp	2	obl:prep	_	_
 4	pé	pé	PRON	Idf	PronType=Ind	11	obj	_	_
 5	rud	rud	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	4	nmod	_	_
@@ -10294,7 +10294,7 @@
 26	faide	fada	ADJ	Adj	Degree=Cmp,Sup	24	amod	_	_
 27	mar	mar	SCONJ	Subord	_	29	mark	_	_
 28	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	29	cop	_	SpaceAfter=No
-29	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	14	advcl	_	_
+29	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	14	advcl	_	_
 30	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	31	cop	_	_
 31	raic	raic	NOUN	Noun	Case=NomAcc|Gender=Fem|Number=Sing	29	csubj:cop	_	_
 32	eile	eile	DET	Det	PronType=Dem	31	det	_	_
@@ -10380,7 +10380,7 @@
 21	,	,	PUNCT	Punct	_	24	punct	_	_
 22	gach	gach	DET	Det	Definite=Def	23	det	_	_
 23	aon	aon	DET	Det	PronType=Ind	24	det	_	_
-24	rite	rite	NOUN	Subst	_	10	nmod	_	_
+24	rite	rite	NOUN	Subst	Case=Gen	10	nmod	_	_
 25	reaite	reaite	ADJ	Adj	VerbForm=Part	24	xcomp:pred	_	_
 26	tríd	trí	ADP	Simp	_	28	case	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
@@ -10559,7 +10559,7 @@
 13	meánteistiméireachta	meánteistiméireacht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
 14	agus	agus	CCONJ	Coord	_	16	mark	_	_
 15	más	má	SCONJ	Subord	VerbForm=Cop	16	mark	_	_
-16	féidir	féidir	NOUN	Subst	Number=Sing	1	advcl	_	_
+16	féidir	féidir	NOUN	Subst	Case=NomAcc|Number=Sing	1	advcl	_	_
 17	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	16	obl:prep	_	_
 18	cúpla	cúpla	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	28	obj	_	_
 19	céad	céad	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Sing	18	nmod	_	_
@@ -10590,7 +10590,7 @@
 4	nó	nó	CCONJ	Coord	_	5	cc	_	_
 5	spiairí	spiaire	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	3	conj	_	_
 6	faoi	faoi	ADP	Simp	_	7	case	_	_
-7	deara	deara	NOUN	Subst	Number=Sing	2	obl	_	_
+7	deara	deara	NOUN	Subst	Case=NomAcc|Number=Sing	2	obl	_	_
 8	go	go	PART	Vb	PartType=Cmpl	9	mark:prt	_	_
 9	rabhthas	bí	VERB	VI	Mood=Ind|Person=0|Tense=Past	2	ccomp	_	_
 10	ag	ag	ADP	Simp	_	11	case	_	_
@@ -11124,7 +11124,7 @@
 1	'	'	PUNCT	Punct	_	4	punct	_	SpaceAfter=No
 2	Conas	conas	ADV	Q	PronType=Int	4	advmod	_	_
 3	ab	is	AUX	Cop	Form=VF|PronType=Rel|Tense=Past|VerbForm=Cop	4	cop	_	_
-4	fhéidir	féidir	NOUN	Subst	Form=Len|Number=Sing	0	root	_	_
+4	fhéidir	féidir	NOUN	Subst	Case=NomAcc|Form=Len|Number=Sing	0	root	_	_
 5	liom	le	ADP	Prep	Number=Sing|Person=1	4	obl:prep	_	_
 6	sin	sin	PRON	Dem	PronType=Dem	8	obj	_	_
 7	a	a	PART	Inf	PartType=Inf	8	mark	_	_
@@ -11389,7 +11389,7 @@
 4	scriosfaidh	scrios	VERB	VTI	Mood=Ind|Tense=Fut	1	conj	_	_
 5	tú	tú	PRON	Pers	Number=Sing|Person=2	4	nsubj	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
-7	aiste	aiste	NOUN	Subst	Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
+7	aiste	aiste	NOUN	Subst	Case=NomAcc|Definite=Def|Gender=Fem|Number=Sing	1	obj	_	_
 8	le	le	ADP	Simp	_	9	case	_	_
 9	botúin	botún	NOUN	Noun	Case=NomAcc|Gender=Masc|Number=Plur	1	obl	_	_
 10	mar	mar	ADP	Simp	_	11	case	_	_
@@ -11399,7 +11399,7 @@
 # sent_id = 452
 # text = Ach oiread le Jurassic Park tá bunchlocha an scéil seo an-áiféiseach.
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
-2	oiread	oiread	NOUN	Subst	Number=Sing	6	advcl	_	_
+2	oiread	oiread	NOUN	Subst	Case=NomAcc|Number=Sing	6	advcl	_	_
 3	le	le	ADP	Simp	_	4	case	_	_
 4	Jurassic	Jurassic	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 5	Park	Park	PROPN	Noun	Case=NomAcc|Definite=Def|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes


### PR DESCRIPTION
Fixes #44 and #45. More or less I implemented all the many rules for determining cases of nouns to do this — this will become part of the QA script I'm writing for #52. The painful part was that I still had to scan things manually because there are plenty of grammatical errors among the sentences in the treebank, e.g. places where one would expect a genitive but the surface form is the common form... following our conventions elsewhere such examples are tagged Case=NomAcc, based on the surface form. Together the parser + QA script comprise a not-terrible grammar checker.