### PR TITLE
Various fixes based on QA scripts

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -402,8 +402,8 @@
 3	i	i	ADP	Simp	_	4	case	_	_
 4	gceantar	ceantar	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 5	poist	post	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
-6	Dhoirí	Doire	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|NounType=Strong|Number=Plur	4	nmod	_	NamedEntity=Yes
-7	Beaga	beag	ADJ	Adj	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	6	amod	_	NamedEntity=Yes
+6	Dhoirí	Doire	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Plur	4	nmod	_	NamedEntity=Yes
+7	Beaga	beag	ADJ	Adj	Case=Nom|Gender=Masc|NounType=NotSlender|Number=Plur	6	amod	_	NamedEntity=Yes
 8	i	i	ADP	Simp	_	9	case	_	_
 9	dTír	tír	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	11	obl	_	NamedEntity=Yes
 10	Chonaill	Conall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
@@ -1077,7 +1077,7 @@
 12	,	,	PUNCT	Punct	_	14	punct	_	_
 13	Go	go	PART	Vb	PartType=Cmpl	14	mark:prt	_	_
 14	mbeimis	bí	VERB	Cond	Form=Ecl|Mood=Cnd|Number=Plur|Person=1	7	advcl	_	_
-15	id	i_do	ADP	Det	Number=Sing|Person=2|Poss=Yes	16	case	_	_
+15	id	i	ADP	Det	Number=Sing|Person=2|Poss=Yes	16	case	_	_
 16	shamhailt	samhailt	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	xcomp:pred	_	_
 17	gach	gach	DET	Det	Definite=Def	18	det	_	_
 18	uair	uair	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	14	obl:tmod	_	_
@@ -2401,7 +2401,7 @@
 11	Láirge	Láirge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes
 12	ar	ar	ADP	Simp	_	13	case	_	_
 13	cosa-in-airde	cosa-in-airde	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	8	obl	_	_
-14	im	i_mo	ADP	_	Number=Sing|Person=1|Poss=Yes	15	case	_	_
+14	im	i	ADP	Poss	Number=Sing|Person=1|Poss=Yes	15	case	_	_
 15	aonar	aonar	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	8	obl	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -2695,7 +2695,7 @@
 28	crapadh	crapadh	NOUN	Noun	VerbForm=Inf	1	parataxis	_	_
 29	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	28	obl:prep	_	_
 30	as	as	ADP	Simp	_	32	case	_	_
-31	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	32	nmod:poss	_	_
+31	a	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	32	nmod:poss	_	_
 32	siopa	siopa	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	28	obl	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	36	punct	_	_
 34	nó	nó	CCONJ	Coord	_	36	cc	_	_
@@ -2902,7 +2902,7 @@
 54	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	51	nmod	_	_
 55	agus	agus	CCONJ	Coord	_	57	cc	_	_
 56	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
-57	Dr.	dochtúir	NOUN	Abr	Abbr=Yes	20	conj	_	NamedEntity=Yes
+57	Dr.	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	20	conj	_	NamedEntity=Yes
 58	Pádraig	Pádraig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat	_	NamedEntity=Yes
 59	Ó	ó	PART	Pat	PartType=Pat	57	flat:name	_	NamedEntity=Yes
 60	Criomhthainn	Criomhthainn	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	57	flat:name	_	NamedEntity=Yes
@@ -4158,7 +4158,7 @@
 14	toirmisc	toirmeasc	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	_
 15	de	de	ADP	Cmpd	PrepForm=Cmpd	17	case	_	_
 16	réir	réir	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	15	fixed	_	_
-17	fho-alt	fo-alt	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|NounType=Weak|Number=Plur	3	obl	_	_
+17	fho-alt	fo-alt	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
 18	(4)	(4)	NUM	Item	_	17	nmod	_	_
 19	oibriú	oibriú	NOUN	Noun	Definite=Def|VerbForm=Inf	23	obj	_	_
 20	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
@@ -4764,7 +4764,7 @@
 32	nó	nó	CCONJ	Coord	_	33	cc	_	_
 33	duine	duine	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	31	conj	_	_
 34	éigin	éigin	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	33	amod	_	_
-35	a	a	ADP	Simp	_	36	case	_	_
+35	a	a	PART	Inf	PartType=Inf	36	mark	_	_
 36	iompar	iompar	NOUN	Noun	VerbForm=Inf	30	xcomp	_	_
 37	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	38	case	_	_
 38	lámha	lámh	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	36	obl	_	SpaceAfter=No
@@ -5008,7 +5008,7 @@
 25	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	26	obj	_	_
 26	chuir	cuir	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	17	xcomp	_	_
 27	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
-28	GPA	GPA	PROPN	Abr	Abbr=Yes	26	nsubj	_	_
+28	GPA	GPA	PROPN	Abr	Abbr=Yes|Definite=Def	26	nsubj	_	_
 29	orthu	ar	ADP	Prep	Number=Plur|Person=3	26	obl:prep	_	SpaceAfter=No
 30	,	,	PUNCT	Punct	_	31	punct	_	_
 31	agus	agus	CCONJ	Coord	_	33	cc	_	_
@@ -5329,7 +5329,7 @@
 8	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
 9	dtigh	teach	NOUN	Noun	Case=Dat|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	2	obl	_	_
 10	Dhónaill	Dónall	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-11	Bhrocaigh	Brocach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
+11	Bhrocaigh	brocach	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	10	amod	_	NamedEntity=Yes
 12	-	-	PUNCT	Punct	_	13	punct	_	_
 13	cupla	cupla	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	2	parataxis	_	_
 14	deoch	deoch	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
@@ -5521,8 +5521,8 @@
 16	Gaoithe	gaoth	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	NamedEntity=Yes
 17	Móire	mór	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Lá	lá	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
-20	Ghleann	gleann	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
+19	Lá	lá	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
+20	Ghleann	gleann	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Bheithe	beith	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 22	,	,	PUNCT	Punct	_	24	punct	_	_
 23	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -5779,7 +5779,7 @@
 22	agus	agus	CCONJ	Coord	_	23	mark	_	_
 23	í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	16	advcl	_	_
 24	ag	ag	ADP	Simp	_	25	case	_	_
-25	líonadh	líonadh	NOUN	Noun	Definite=Def|VerbForm=Vnoun	23	xcomp	_	_
+25	líonadh	líonadh	NOUN	Noun	VerbForm=Vnoun	23	xcomp	_	_
 26	amach	amach	ADV	Dir	_	25	advmod	_	_
 27	na	an	DET	Art	Case=Gen|Definite=Def|Number=Plur|PronType=Art	28	det	_	_
 28	seolta	seol	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	25	obj	_	SpaceAfter=No
@@ -5890,8 +5890,8 @@
 13	fháil	fáil	NOUN	Noun	Form=Len|VerbForm=Inf	6	csubj:cop	_	_
 14	amach	amach	ADV	Dir	_	13	advmod	_	_
 15	le	le	ADP	Simp	_	16	case	_	_
-16	fiosrú	fiosrú	NOUN	Noun	VerbForm=Inf	13	obl	_	_
-17	réasúnach	réasúnach	ADJ	Adj	Degree=Pos	16	amod	_	SpaceAfter=No
+16	fiosrú	fiosrú	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	13	obl	_	_
+17	réasúnach	réasúnach	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	16	amod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	4	punct	_	_
 19	féadfar	féad	VERB	VTI	Mood=Ind|Person=0|Tense=Fut	0	root	_	_
 20	fógra	fógra	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	19	obj	_	_
@@ -6163,7 +6163,7 @@
 8	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	9	obj	_	_
 9	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	7	acl:relcl	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
-11	Dr	dochtúir	NOUN	Abr	Abbr=Yes	9	nsubj	_	NamedEntity=Yes
+11	Dr	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	9	nsubj	_	NamedEntity=Yes
 12	O'	o	PART	Pat	PartType=Pat	11	flat	_	NamedEntity=Yes|SpaceAfter=No
 13	Meara	Meara	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes
 14	díobháil	díobháil	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	4	obj	_	SpaceAfter=No
@@ -6227,7 +6227,7 @@
 15	éin	éan	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	_
 16	Le	le	ADP	Simp	_	17	case	_	_
 17	cloisint	cloisint	NOUN	Noun	VerbForm=Inf	14	xcomp	_	_
-18	im	i_mo	ADP	Det	Number=Sing|Person=1|Poss=Yes	19	case	_	_
+18	im	i	ADP	Det	Number=Sing|Person=1|Poss=Yes	19	case	_	_
 19	thimpeall	timpeall	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	obl	_	SpaceAfter=No
 20	,	,	PUNCT	Punct	_	21	punct	_	_
 21	Cluasa	cluas	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	14	parataxis	_	_
@@ -6568,7 +6568,7 @@
 19	thabhairt	tabhairt	NOUN	Noun	Form=Len|VerbForm=Inf	6	xcomp	_	_
 20	d'	do	ADP	Simp	_	21	case	_	SpaceAfter=No
 21	údaráis	údarás	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	19	obl	_	_
-22	phleanála	pleanáil	NOUN	Noun	Case=Gen|Form=Len|VerbForm=Inf	21	nmod	_	_
+22	phleanála	pleanáil	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	21	nmod	_	_
 23	i	i	ADP	Cmpd	PrepForm=Cmpd	26	case	_	_
 24	leith	leath	NOUN	Cmpd	Case=Dat|Gender=Fem|Number=Sing|PrepForm=Cmpd	23	fixed	_	_
 25	aon	aon	DET	Det	PronType=Ind	26	det	_	_
@@ -7021,7 +7021,7 @@
 36	Maigh	Maigh	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
 37	Eo	Eo	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	36	nmod	_	NamedEntity=Yes
 38	agus	agus	CCONJ	Coord	_	39	cc	_	_
-39	Manchain	Manchain	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	36	conj	_	SpaceAfter=No
+39	Manchain	Manchain	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	36	conj	_	SpaceAfter=No
 40	,	,	PUNCT	Punct	_	41	punct	_	_
 41	tógálaí	tógálaí	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	33	appos	_	_
 42	mór	mór	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	41	amod	_	_
@@ -8014,7 +8014,7 @@
 18	Seoighe	Seoighe	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
 19	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	15	obl:prep	_	_
 20	acu	ag	ADP	Prep	Number=Plur|Person=3	15	obl:prep	_	_
-21	fá	fá	ADP	Cmpd	Dialect=Ulster|PrepForm=Cmpd	28	case	_	_
+21	fá	faoi	ADP	Cmpd	Dialect=Ulster|PrepForm=Cmpd	28	case	_	_
 22	choinne	coinne	NOUN	Cmpd	Case=Nom|Dialect=Ulster|Form=Len|Gender=Fem|Number=Sing|PrepForm=Cmpd	21	fixed	_	_
 23	obair	obair	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	28	obj	_	_
 24	den	de	ADP	Art	Number=Sing|PronType=Art	25	case	_	_
@@ -8050,7 +8050,7 @@
 6	:	:	PUNCT	Punct	_	7	punct	_	_
 7	C.B.É.	C.B.É.	NOUN	Abr	Abbr=Yes	2	parataxis	_	_
 8	AN	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	DR	dochtúir	NOUN	Abr	Abbr=Yes	7	nmod	_	NamedEntity=Yes
+9	DR	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	7	nmod	_	NamedEntity=Yes
 10	UÍ	uí	PART	Pat	PartType=Pat	9	flat	_	NamedEntity=Yes
 11	SHÚILLEABHÁIN	Súilleabháin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	:	:	PUNCT	Punct	_	13	punct	_	_
@@ -9562,7 +9562,7 @@
 15	beidh	bí	VERB	FutInd	Mood=Ind|Tense=Fut	2	conj	_	_
 16	muid	muid	PRON	Pers	Number=Plur|Person=1	15	nsubj	_	_
 17	ag	ag	ADP	Simp	_	18	case	_	_
-18	fiosrú	fiosrú	NOUN	Noun	Definite=Def|VerbForm=Vnoun	15	xcomp	_	_
+18	fiosrú	fiosrú	NOUN	Noun	VerbForm=Vnoun	15	xcomp	_	_
 19	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
 20	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	18	obj	_	_
 21	leis	le	ADP	Simp	_	23	case	_	_
@@ -10063,8 +10063,8 @@
 10	Bhigil	bigil	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	9	nmod	_	NamedEntity=Yes
 11	amach	amach	ADV	Dir	_	9	advmod	_	_
 12	ó	ó	ADP	Simp	_	13	case	_	_
-13	chósta	cósta	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	_
-14	Mhaigh	Maigh	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	obl	_	NamedEntity=Yes
+13	chósta	cósta	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+14	Mhaigh	Maigh	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	Eo	Eo	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	mar	mar	ADP	Simp	_	18	case	_	_
@@ -10284,7 +10284,7 @@
 15	Leataoibh	leataobh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	agus	agus	CCONJ	Coord	_	17	cc	_	_
 17	Ard	ard	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc	12	conj	_	NamedEntity=Yes
-18	Bhaile	baile	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
+18	Bhaile	baile	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	NamedEntity=Yes
 20	nÁith	áith	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Weak|Number=Plur	18	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	1	punct	_	_
@@ -10851,7 +10851,7 @@
 13	)	)	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 14	:	:	PUNCT	Punct	_	16	punct	_	_
 15	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	Dr.	dochtúir	NOUN	Abr	Abbr=Yes	9	parataxis	_	NamedEntity=Yes
+16	Dr.	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	9	parataxis	_	NamedEntity=Yes
 17	Seán	Seán	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
 18	Mac	mac	PART	Pat	PartType=Pat	16	flat:name	_	NamedEntity=Yes
 19	Giolla	Giolla	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	flat:name	_	NamedEntity=Yes
@@ -10866,7 +10866,7 @@
 28	Mhacha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
-31	Dr	dochtúir	NOUN	Abr	Abbr=Yes	16	conj	_	NamedEntity=Yes
+31	Dr	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	16	conj	_	NamedEntity=Yes
 32	Seán	Seán	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	31	flat:name	_	NamedEntity=Yes
 33	Ó	ó	PART	Pat	PartType=Pat	32	flat:name	_	NamedEntity=Yes
 34	Brádaigh	Brádaigh	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	32	flat:name	_	NamedEntity=Yes
@@ -11320,18 +11320,18 @@
 
 # sent_id = 905
 # text = Is fíor- chorr-Óglach a d'fhág baile an Luan sin a raibh fhios aige gur ag dul chun troda i ndáiríre a bhí sé agus nach ag cleachtadh cogaíochta.
-1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	3	cop	_	_
-2	fíor-	fíor-	ADV	Its	_	3	amod	_	_
-3	chorr-Óglach	corr-óglach	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	0	root	_	_
+1	Is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	2	cop	_	_
+2	fíor-	fíor-chorr-Óglach	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
+3	chorr-Óglach	_	X	_	_	2	goeswith	_	_
 4	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	6	mark:prt	_	_
 5	d'	do	PART	Vb	PartType=Vb	6	mark:prt	_	SpaceAfter=No
-6	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
+6	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 7	baile	baile	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	6	obj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl:tmod	_	_
 10	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 11	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	12	mark:prt	_	_
-12	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	3	acl:relcl	_	_
+12	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	2	acl:relcl	_	_
 13	fhios	fios	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	12	nsubj	_	_
 14	aige	ag	ADP	Prep	Gender=Masc|Number=Sing|Person=3	12	obl:prep	_	_
 15	gur	is	AUX	Cop	Tense=Past|VerbForm=Cop	17	cop	_	_
@@ -11349,5 +11349,5 @@
 27	ag	ag	ADP	Simp	_	28	case	_	_
 28	cleachtadh	cleachtadh	NOUN	Noun	VerbForm=Vnoun	23	conj	_	_
 29	cogaíochta	cogaíocht	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	28	obj	_	SpaceAfter=No
-30	.	.	PUNCT	.	_	3	punct	_	_
+30	.	.	PUNCT	.	_	2	punct	_	_
 

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -1128,7 +1128,7 @@
 15	teideal	teideal	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	18	punct	_	_
 17	'	'	PUNCT	Punct	_	18	punct	_	SpaceAfter=No
-18	Monsieur	Monsieur	NOUN	Noun	Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	15	appos	_	NamedEntity=Yes
+18	Monsieur	Monsieur	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	15	appos	_	NamedEntity=Yes
 19	Dupont	Dupont	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	18	flat	_	NamedEntity=Yes|SpaceAfter=No
 20	'	'	PUNCT	Punct	_	18	punct	_	SpaceAfter=No
 21	.	.	PUNCT	.	_	9	punct	_	_
@@ -3638,9 +3638,9 @@
 2	mé	mé	PRON	Pers	Number=Sing|Person=1	1	nsubj	_	_
 3	cuairt	cuairt	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	1	obj	_	_
 4	ghasta	gasta	ADJ	Adj	Case=Nom|Form=Len|Gender=Fem|Number=Sing	3	amod	_	_
-5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
+5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 6	chéad	céad	NUM	Num	Form=Len|NumType=Ord	7	nummod	_	_
-7	uair	uair	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	1	obl:tmod	_	_
+7	uair	uair	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	1	obl:tmod	_	_
 8	sin	sin	DET	Det	PronType=Dem	7	det	_	_
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
@@ -6629,7 +6629,7 @@
 80	agus	agus	CCONJ	Coord	_	81	cc	_	_
 81	(b)	(b)	NUM	Item	_	53	conj	_	_
 82	le	le	ADP	Cmpd	PrepForm=Cmpd	84	case	_	_
-83	linn	linn	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	82	fixed	_	_
+83	linn	linn	NOUN	Cmpd	Case=Nom|Gender=Fem|Number=Sing|PrepForm=Cmpd	82	fixed	_	_
 84	cúnamh	cúnamh	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	92	nmod	_	_
 85	le	le	ADP	Simp	_	87	case	_	_
 86	haon	aon	DET	Det	Form=HPref|PronType=Ind	87	det	_	_
@@ -10932,10 +10932,10 @@
 17	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	18	obj	_	_
 18	tréigeadh	tréig	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	acl:relcl	_	_
 19	ag	ag	ADP	Simp	_	20	case	_	_
-20	deireadh	deireadh	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	18	obl	_	_
-21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
-22	Chéad	céad	NUM	Num	Form=Len|NumType=Ord	20	nmod	_	NamedEntity=Yes
-23	Chogaidh	cogadh	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
+20	deireadh	deireadh	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	18	obl	_	_
+21	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+22	Chéad	céad	NUM	Num	Form=Len|NumType=Ord	23	amod	_	NamedEntity=Yes
+23	Chogaidh	cogadh	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 24	Dhomhanda	domhanda	ADJ	Adj	Case=Gen|Form=Len|Gender=Masc|Number=Sing	23	amod	_	NamedEntity=Yes|SpaceAfter=No
 25	.	.	PUNCT	.	_	1	punct	_	_
 

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -665,14 +665,14 @@
 2	47	47	NUM	Num	_	1	nmod	_	_
 3	Má	má	SCONJ	Subord	_	4	mark	_	_
 4	dhéantar	déan	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	27	advcl	_	_
-5	iarratas	iarratas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	4	obj	_	_
+5	iarratas	iarratas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	18	obj	_	_
 6	nó	nó	CCONJ	Coord	_	7	cc	_	_
 7	doiciméad	doiciméad	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	5	conj	_	_
 8	eile	eile	DET	Det	PronType=Dem	7	det	_	_
 9	nós	nós	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	7	nmod	_	_
 10	imeachta	imeacht	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
-11	a	a	PART	Inf	PartType=Inf	12	obj	_	_
-12	seoladh	seoladh	NOUN	Noun	VerbForm=Inf	5	acl:relcl	_	_
+11	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	12	obj	_	_
+12	seoladh	seol	VERB	VTI	Mood=Ind|Person=0|Tense=Past	5	acl:relcl	_	_
 13	chuig	chuig	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
 15	gCúirt	cúirt	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
@@ -707,14 +707,14 @@
 44	,	,	PUNCT	Punct	_	43	punct	_	_
 45	má	má	SCONJ	Subord	_	46	mark	_	_
 46	dhéantar	déan	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Pres	69	advcl	_	_
-47	iarratas	iarratas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	46	obj	_	_
+47	iarratas	iarratas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	60	obj	_	_
 48	nó	nó	CCONJ	Coord	_	49	cc	_	_
 49	doiciméad	doiciméad	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	47	conj	_	_
 50	eile	eile	DET	Det	PronType=Dem	49	det	_	_
 51	nós	nós	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	49	nmod	_	_
 52	imeachta	imeacht	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	51	nmod	_	_
-53	a	a	PART	Inf	PartType=Inf	54	obj	_	_
-54	seoladh	seoladh	NOUN	Noun	VerbForm=Inf	47	acl:relcl	_	_
+53	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	54	obj	_	_
+54	seoladh	seol	VERB	VTI	Mood=Ind|Person=0|Tense=Past	47	acl:relcl	_	_
 55	chuig	chuig	ADP	Simp	_	57	case	_	_
 56	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
 57	gCúirt	cúirt	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	54	nmod	_	NamedEntity=Yes
@@ -2153,7 +2153,7 @@
 22	agus	agus	CCONJ	Coord	_	24	cc	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
 24	Lucht	lucht	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	20	conj	_	NamedEntity=Yes
-25	Oibre	obair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	24	nmod	_	NamedEntity=Yes
+25	Oibre	obair	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	24	nmod	_	NamedEntity=Yes
 26	sa	i	ADP	Art	Number=Sing|PronType=Art	27	case	_	_
 27	bhliain	bliain	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	obl:tmod	_	_
 28	1992	1992	NUM	Num	_	27	nmod	_	SpaceAfter=No
@@ -4148,7 +4148,7 @@
 4	imeacht	imeacht	NOUN	Noun	VerbForm=Inf	2	csubj:cop	_	_
 5	isteach	isteach	ADV	Dir	_	4	advmod	_	_
 6	a	a	PART	Voc	PartType=Voc	7	case:voc	_	_
-7	Tom	Tom	PROPN	Noun	Case=Voc|Definite=Def|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
+7	Tom	Tom	PROPN	Noun	Case=Voc|Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	2	vocative	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 170
@@ -7481,9 +7481,9 @@
 # text = Seo díreach an dara huair riamh a chasfar na contaetha seo ar a chéile sa chluiche ceannais.
 1	Seo	seo	PRON	Dem	PronType=Dem	0	root	_	_
 2	díreach	díreach	ADJ	Adj	Degree=Pos	1	amod	_	_
-3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
+3	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	5	det	_	_
 4	dara	dara	NUM	Num	NumType=Ord	5	amod	_	_
-5	huair	uair	NOUN	Noun	Case=Nom|Form=HPref|Gender=Fem|Number=Sing	1	nsubj	_	_
+5	huair	uair	NOUN	Noun	Case=Nom|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	1	nsubj	_	_
 6	riamh	riamh	ADV	Gn	_	5	advmod	_	_
 7	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	8	obl:tmod	_	_
 8	chasfar	cas	VERB	VTI	Form=Len|Mood=Ind|Person=0|Tense=Fut	5	acl:relcl	_	_
@@ -8012,7 +8012,7 @@
 6	chun	chun	ADP	Simp	_	7	case	_	_
 7	Leighis	leigheas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
 8	agus	agus	CCONJ	Coord	_	9	cc	_	_
-9	Máin-liaghais	máin-liaghas	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	conj	_	_
+9	Máin-liaghais	máin-liaghas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	7	conj	_	_
 10	do	do	ADP	Simp	_	11	case	_	_
 11	leigheas	leigheas	NOUN	Noun	VerbForm=Inf	7	nmod	_	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	_	_
@@ -8765,7 +8765,7 @@
 21	n-aimsir	aimsir	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	19	obl	_	_
 22	féin	féin	PRON	Ref	Reflex=Yes	21	nmod	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
-24	fhorbairt	forbairt	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	12	conj	_	SpaceAfter=No
+24	fhorbairt	forbairt	NOUN	Noun	Form=Len|VerbForm=Inf	12	conj	_	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 342
@@ -9413,7 +9413,7 @@
 # sent_id = 369
 # text = Cuirtear scéal agus stair an raidió in Éirinn le 75 bliain anuas os ár gcomhair sa taispeántas, ó bunaíodh 2RN i 1926 go dtí na forbairtí is deireanaí ar an idirlíon.
 1	Cuirtear	cuir	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	0	root	_	_
-2	scéal	scéal	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	1	obj	_	_
+2	scéal	scéal	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	_
 3	agus	agus	CCONJ	Coord	_	4	cc	_	_
 4	stair	stair	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	2	conj	_	_
 5	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -684,8 +684,8 @@
 21	le	le	ADP	Simp	_	22	case	_	_
 22	Cláraitheoir	cláraitheoir	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	18	obl	_	_
 23	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
-24	Cúirte	cúirt	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	NamedEntity=Yes
-25	Breithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
+24	Cúirte	cúirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	22	nmod	_	NamedEntity=Yes
+25	Breithiúnais	breithiúnas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 26	,	,	PUNCT	Punct	_	4	punct	_	_
 27	déanfaidh	déan	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
@@ -2336,7 +2336,7 @@
 12	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	_
 13	i	i	ADP	Simp	_	14	case	_	_
 14	láthair	láthair	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	9	obl	_	_
-15	tré	tré	ADP	Simp	_	16	case	_	_
+15	tré	trí	ADP	Simp	_	16	case	_	_
 16	shúile	súil	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Plur	9	obl	_	_
 17	Mhairéid	Mairéad	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
 18	cuid	cuid	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	9	obl	_	_
@@ -2616,8 +2616,8 @@
 42	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	36	xcomp	_	_
 43	chun	chun	ADP	Simp	_	45	case	_	_
 44	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	45	det	_	_
-45	Cúirte	cúirt	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	42	obl	_	NamedEntity=Yes
-46	Dúiche	dúiche	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	45	nmod	_	NamedEntity=Yes
+45	Cúirte	cúirt	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	42	obl	_	NamedEntity=Yes
+46	Dúiche	dúiche	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	45	nmod	_	NamedEntity=Yes
 47	go	go	ADP	Cmpd	PrepForm=Cmpd	50	mark	_	_
 48	dtí	dtí	NOUN	Cmpd	Form=Ecl|PrepForm=Cmpd	47	fixed	_	_
 49	go	go	SCONJ	Subord	_	50	mark:prt	_	_
@@ -3191,7 +3191,7 @@
 
 # sent_id = 131
 # text = A Dhochtúir Van Helsing, má thagann a chothrom de chaoi i do chomhair agus a tharla i gcás Laoise, beidh mé ag brath ort go bhfágfaidh tú mar shuairc-chuimhne ag m'fhear i gcaitheamh a shaoil gurbh é a dheaslámh féin a shaor a bhanchéile mhuirneach ón mám millteach a bhí uirthi.
-1	A	a	PART	Voc	PartType=Voc	3	case:voc	_	_
+1	A	a	PART	Voc	PartType=Voc	2	case:voc	_	_
 2	Dhochtúir	dochtúir	NOUN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	22	vocative	_	NamedEntity=Yes
 3	Van	Van	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	2	flat	_	NamedEntity=Yes
 4	Helsing	Helsing	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes|SpaceAfter=No
@@ -4042,7 +4042,7 @@
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	dlí	dlí	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	7	obj	_	_
 10	ar	ar	ADP	Simp	_	11	case	_	_
-11	Burton	Burton	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
+11	Burton	Burton	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	7	obl	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	iarradh	iarr	VERB	_	Mood=Ind|Person=0|Tense=Past	7	conj	_	_
 14	uirthi	ar	ADP	Prep	Gender=Fem|Number=Sing|Person=3	13	obl:prep	_	_
@@ -5769,7 +5769,7 @@
 17	gan	gan	ADP	Simp	_	20	case	_	_
 18	stoc	stoc	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	20	obj	_	_
 19	a	a	PART	Inf	PartType=Inf	20	mark	_	_
-20	shéide	séideadh	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
+20	shéide	séideadh	NOUN	Noun	Form=Len|VerbForm=Inf	5	obl	_	_
 21	ná	ná	CCONJ	Coord	_	25	cc	_	_
 22	cuaille	cuaille	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	25	obj	_	_
 23	comhraic	comhrac	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	_
@@ -6126,7 +6126,7 @@
 187	maidir	maidir	ADP	CmpdNoGen	_	189	case	_	_
 188	le	le	ADP	CmpdNoGen	_	187	fixed	_	_
 189	víosa	víosa	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	186	nmod	_	_
-190	chomhionanu	comhionannú	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing|Typo=Yes	189	nmod	_	SpaceAfter=No
+190	chomhionanu	comhionann	ADJ	Adj	Case=Nom|Form=Len|Gender=Fem|Number=Sing|Typo=Yes	189	nmod	_	SpaceAfter=No
 191	;	;	PUNCT	Punct	_	192	punct	_	_
 192	(3)	(3)	NUM	Item	_	19	list	_	_
 193	bearta	beart	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	192	appos	_	_
@@ -6742,7 +6742,7 @@
 144	i	i	ADP	Simp	_	145	case	_	_
 145	gcuntas	cuntas	NOUN	Noun	Case=Nom|Form=Ecl|Gender=Masc|Number=Sing	143	obl	_	_
 146	chun	chun	ADP	Simp	_	147	case	_	_
-147	críocha	críoch	NOUN	Noun	Case=Nom|Gender=Fem|Number=Plur	141	obl	_	_
+147	críocha	críoch	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	141	obl	_	_
 148	alt	alt	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	147	nmod	_	_
 149	392	392	NUM	Num	_	148	nmod	_	_
 150	(1)	(1)	NUM	Num	_	148	nmod	_	_
@@ -7140,7 +7140,7 @@
 22	sásta	sásta	ADJ	Adj	Degree=Pos	20	xcomp:pred	_	_
 23	seo	seo	PRON	Dem	PronType=Dem	25	obj	_	_
 24	a	a	PART	Inf	PartType=Inf	25	mark	_	_
-25	dhéanamh	déanamh	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	20	xcomp	_	_
+25	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	20	xcomp	_	_
 26	agus	agus	CCONJ	Coord	_	27	cc	_	_
 27	fuair	faigh	VERB	VT	Mood=Ind|Tense=Past	20	conj	_	_
 28	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	29	det	_	_
@@ -7426,7 +7426,7 @@
 12	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	11	nsubj	_	_
 13	sa	i	ADP	Art	Number=Sing|PronType=Art	15	case	_	_
 14	5,000	5,000	NUM	Num	_	15	nummod	_	_
-15	m	m	NOUN	Abr	Abbr=Yes	11	obl	_	_
+15	m	m	NOUN	Abr	Abbr=Yes|Definite=Def	11	obl	_	_
 16	-	-	PUNCT	Punct	_	17	punct	_	_
 17	tháinig	tar	VERB	VI	Form=Len|Mood=Ind|Tense=Past	5	parataxis	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
@@ -7448,7 +7448,7 @@
 34	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	33	nsubj	_	_
 35	na	an	DET	Art	Definite=Def|Number=Plur|PronType=Art	37	det	_	_
 36	400	400	NUM	Num	_	37	nummod	_	_
-37	m	m	NOUN	Abr	Abbr=Yes	33	obj	_	_
+37	m	m	NOUN	Abr	Abbr=Yes|Definite=Def	33	obj	_	_
 38	deiridh	deireadh	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	37	nmod	_	_
 39	i	i	ADP	Simp	_	41	case	_	_
 40	55	55	NUM	Num	_	41	nummod	_	_
@@ -8115,10 +8115,10 @@
 
 # sent_id = 316
 # text = Bhraitheas cigilt fhaoisimh im chnámha.
-1	Bhraitheas	braith	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Number=Sing|Person=1|Tense=Pres	0	root	_	_
+1	Bhraitheas	braith	VERB	VTI	Dialect=Munster|Form=Len|Mood=Ind|Number=Sing|Person=1|Tense=Past	0	root	_	_
 2	cigilt	cigilt	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	1	nsubj	_	_
 3	fhaoisimh	faoiseamh	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	2	nmod	_	_
-4	im	i_mo	ADP	Det	Number=Sing|Person=1|Poss=Yes	5	case	_	_
+4	im	i	ADP	Det	Number=Sing|Person=1|Poss=Yes	5	case	_	_
 5	chnámha	cnámh	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Plur	1	nmod	_	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -8563,7 +8563,7 @@
 26	in	i	ADP	Simp	_	27	case	_	_
 27	iúl	iúl	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	25	obl	_	_
 28	don	do	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
-29	Bhr	Br	NOUN	Abr	Abbr=Yes|Form=Len	25	obl	_	SpaceAfter=No
+29	Bhr	Br	NOUN	Abr	Abbr=Yes|Definite=Def|Form=Len	25	obl	_	SpaceAfter=No
 30	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 334
@@ -8644,8 +8644,8 @@
 15	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	16	nmod:poss	_	_
 16	chúirt	cúirt	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
 17	,	,	PUNCT	Punct	_	19	punct	_	_
-18	a	a	PART	Inf	PartType=Inf	19	nmod:poss	_	_
-19	chuid	cuid	NOUN	Noun	Case=Nom|Form=Len|Gender=Fem|Number=Sing	16	conj	_	_
+18	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	nmod:poss	_	_
+19	chuid	cuid	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	16	conj	_	_
 20	riarthóirí	riarthóir	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	19	nmod	_	_
 21	agus	agus	CCONJ	Coord	_	23	cc	_	_
 22	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	23	nmod:poss	_	_
@@ -9170,7 +9170,7 @@
 11	leigheas	leigheas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	10	obj	_	_
 12	iomlán	iomlán	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	11	amod	_	_
 13	ar	ar	ADP	Simp	_	14	case	_	_
-14	SEIF	SEIF	PROPN	Abr	Abbr=Yes	10	obl	_	_
+14	SEIF	SEIF	PROPN	Abr	Abbr=Yes|Definite=Def	10	obl	_	_
 15	riamh	riamh	ADV	Gn	_	10	advmod	_	SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	_	_
 
@@ -9196,7 +9196,7 @@
 # sent_id = 359
 # text = 'Caidé 'n scéala is deireanaí ón fhronta?
 1	'	'	PUNCT	Punct	_	2	punct	_	SpaceAfter=No
-2	Caidé	cad_é	PRON	Q	Dialect=Connaught	0	root	_	_
+2	Caidé	cad_é	PRON	Q	Dialect=Connaught|PronType=Int	0	root	_	_
 3	'n	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 4	scéala	scéala	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	2	nsubj	_	_
 5	is	is	PART	Sup	PartType=Sup	6	mark:prt	_	_
@@ -9392,8 +9392,8 @@
 45	cleite	cleite	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	44	compound	_	_
 46	'	'	PUNCT	Punct	_	48	punct	_	SpaceAfter=No
 47	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	48	det	_	_
-48	Craoibhín	craoibhín	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	38	nmod	_	_
-49	Aoibhinn	aoibhinn	ADJ	Adj	Case=Nom|Gender=Fem|Number=Sing	48	amod	_	SpaceAfter=No
+48	Craoibhín	craoibhín	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	38	nmod	_	_
+49	Aoibhinn	aoibhinn	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	48	amod	_	SpaceAfter=No
 50	'	'	PUNCT	Punct	_	48	punct	_	SpaceAfter=No
 51	)	)	PUNCT	Punct	_	38	punct	_	SpaceAfter=No
 52	:	:	PUNCT	:	_	2	punct	_	_
@@ -10076,8 +10076,8 @@
 # text = Ach tá athrú an-mhór tagtha ar an méid sin.
 1	Ach	ach	SCONJ	Subord	_	2	mark	_	_
 2	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-3	athrú	athrú	NOUN	Noun	VerbForm=Inf	2	nsubj	_	_
-4	an-mhór	an-mhór	ADJ	Adj	Degree=Pos	3	amod	_	_
+3	athrú	athrú	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
+4	an-mhór	an-mhór	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
 5	tagtha	tagtha	ADJ	Adj	VerbForm=Part	2	xcomp:pred	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
@@ -10271,7 +10271,7 @@
 3	Anois	anois	ADV	Gn	_	10	advmod	_	SpaceAfter=No
 4	,	,	PUNCT	Punct	_	3	punct	_	_
 5	a	a	PART	Voc	PartType=Voc	6	case:voc	_	_
-6	Pháidín	Páidín	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	10	vocative	_	SpaceAfter=No
+6	Pháidín	Páidín	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	vocative	_	SpaceAfter=No
 7	,	,	PUNCT	Punct	_	6	punct	_	SpaceAfter=No
 8	'	'	PUNCT	Punct	_	6	punct	_	_
 9	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	10	mark:prt	_	_
@@ -10621,7 +10621,7 @@
 12	láimhe	lámh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	10	obj	_	_
 13	ó	ó	ADP	Simp	_	14	case	_	_
 14	ghualainn	gualainn	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	obl	_	_
-15	Phóil	Pól	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	14	nmod	_	SpaceAfter=No
+15	Phóil	Pól	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	shiúil	siúil	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	advcl	_	_
 18	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	17	nsubj	_	_
@@ -10850,7 +10850,7 @@
 3	Oibríochtaí	oibríocht	NOUN	Noun	Case=Nom|Gender=Fem|Number=Plur	5	obl	_	_
 4	eachtracha	eachtrach	ADJ	Adj	Case=Nom|Gender=Fem|NounType=NotSlender|Number=Plur	3	amod	_	_
 5	Féadfaidh	féad	VERB	VTI	Mood=Ind|Tense=Fut	0	root	_	_
-6	BCE	BCE	PROPN	Abr	Abbr=Yes	5	nsubj	_	_
+6	BCE	BCE	PROPN	Abr	Abbr=Yes|Definite=Def	5	nsubj	_	_
 7	agus	agus	CCONJ	Coord	_	8	cc	_	_
 8	bainc	banc	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	6	conj	_	_
 9	cheannais	ceannas	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	8	compound	_	_
@@ -10988,7 +10988,7 @@
 14	dul	dul	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 15	thart	thart	ADV	Dir	_	14	advmod	_	_
 16	le	le	ADP	Simp	_	17	case	_	_
-17	Eilean	Eilean	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
+17	Eilean	Eilean	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	14	obl	_	NamedEntity=Yes
 18	a'	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	NamedEntity=Yes
 19	Bhealaich	bealach	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	17	nmod	_	NamedEntity=Yes
 20	chomh	chomh	ADV	Its	_	21	advmod	_	_
@@ -11080,10 +11080,10 @@
 19	hÉire	Éire	PROPN	Noun	Case=Nom|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	10	obl	_	_
 20	Bhriain	Brian	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
 21	is	agus	CCONJ	Coord	_	22	cc	_	_
-22	Chormaic	Cormac	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	20	conj	_	SpaceAfter=No
+22	Chormaic	Cormac	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	conj	_	SpaceAfter=No
 23	,	,	PUNCT	Punct	_	24	punct	_	_
 24	Éire	Éire	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	19	appos	_	_
-25	Choinn	Conn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	24	nmod	_	NamedEntity=Yes
+25	Choinn	Conn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
 26	Uí	uí	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
 27	Néill	Néill	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	?	?	PUNCT	?	_	6	punct	_	_
@@ -11404,7 +11404,7 @@
 4	Jurassic	Jurassic	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	2	nmod	_	NamedEntity=Yes
 5	Park	Park	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 6	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-7	bunchlocha	bunchloch	NOUN	Noun	Case=Nom|Gender=Fem|Number=Plur	6	nsubj	_	_
+7	bunchlocha	bunchloch	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	6	nsubj	_	_
 8	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
 9	scéil	scéal	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	7	compound	_	_
 10	seo	seo	DET	Det	PronType=Dem	9	det	_	_


### PR DESCRIPTION
I've continued developing the suite of scripts that I started more than a year ago (https://github.com/kscanne/grammatach) that aim to correctly predict all feature values based on the tags/features of neighboring words and dependency relations.   I'm using these to improve end-to-end POS tagging based on UDPipe, but they're also useful for QA for existing treebanks.

I think everything here will be non-controversial.  

This patch includes fixes for *some* of the words with underscores discussed in issue #92... only examples like "i_mo", "i_do", "le_mo", etc. which we all agreed should lemmatize to "i", "le", etc.  (following "ina", "lena", etc.).  This will likely cause merge conflicts with Lauren's PR #148.  I'd be happy to prepare a new one once we've settled on how to handle "caidé" and so on.

